### PR TITLE
Fix user loader to use session-based lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,13 +97,6 @@ def index():
     now = datetime.utcnow()
     return f"Horário de Brasília: {brasilia_filter(now)}"
 
-
-# Loader do usuário
-@login_manager.user_loader
-def load_user(user_id):
-    return Usuario.query.get(user_id) or Cliente.query.get(user_id) or Ministrante.query.get(user_id)
-
-
 # Execução da aplicação
 if __name__ == '__main__':
     socketio.run(app, debug=True)

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -21,14 +21,14 @@ def load_user(user_id):
     user_type = session.get('user_type')
 
     if user_type == 'ministrante':
-        return Ministrante.query.get(int(user_id))
+        return db.session.get(Ministrante, int(user_id))
     elif user_type in ['admin', 'participante']:
-        return Usuario.query.get(int(user_id))
+        return db.session.get(Usuario, int(user_id))
     elif user_type == 'cliente':
-        return Cliente.query.get(int(user_id))
+        return db.session.get(Cliente, int(user_id))
 
     # Fallback
-    return Usuario.query.get(int(user_id)) or Ministrante.query.get(int(user_id))
+    return db.session.get(Usuario, int(user_id)) or db.session.get(Ministrante, int(user_id))
 
 
 # =======================================
@@ -105,7 +105,7 @@ def reset_senha_cpf():
     if not user_id:
         flash('Nenhum usuário selecionado para redefinição!', 'danger')
         return redirect(url_for('routes.esqueci_senha_cpf'))
-    usuario = Usuario.query.get(user_id)
+    usuario = db.session.get(Usuario, user_id)
     if not usuario:
         flash('Usuário não encontrado no banco de dados!', 'danger')
         return redirect(url_for('routes.esqueci_senha_cpf'))


### PR DESCRIPTION
## Summary
- remove redundant login loader in `app.py`
- use `db.session.get()` in `auth_routes` loader and password reset

## Testing
- `python -m py_compile system/routes/auth_routes.py system/app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845bccfd3e88324ae3f1945d3e41820