### PR TITLE
Fix dashboard cliente route registration

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -16,6 +16,8 @@ def register_routes(app):
     # Importações e registros dos Blueprints de módulos organizados
     from .auth_routes import auth_routes
     from .dashboard_routes import dashboard_routes
+    # Importa rotas adicionais do cliente que utilizam o mesmo blueprint
+    from . import dashboard_cliente  # noqa: F401
     from .dashboard_participante import dashboard_participante_routes
     from .dashboard_professor import dashboard_professor_routes
     from .dashboard_ministrante import dashboard_ministrante_routes

--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -8,7 +8,8 @@ from models import (
     ConfiguracaoCliente, AgendamentoVisita, HorarioVisitacao
 )
 
-dashboard_routes = Blueprint('dashboard_routes', __name__)
+# Importa o blueprint central para registrar as rotas deste módulo
+from .dashboard_routes import dashboard_routes
 
 @dashboard_routes.route('/dashboard_cliente')
 @login_required

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, session
+from flask import Blueprint, render_template, redirect, url_for, flash, session, abort
 from flask_login import login_required, current_user
 
 dashboard_routes = Blueprint(
@@ -43,9 +43,3 @@ def dashboard_admin():
     return render_template("dashboard/dashboard_admin.html")
 
 
-@dashboard_routes.route("/dashboard_cliente")
-@login_required
-def dashboard_cliente():
-    if current_user.tipo != "cliente":
-        abort(403)
-    return render_template("dashboard/dashboard_cliente.html")


### PR DESCRIPTION
## Summary
- use central dashboard blueprint in `dashboard_cliente.py`
- import client dashboard routes in `register_routes`
- remove duplicate empty dashboard cliente route
- include missing abort import

## Testing
- `python -m py_compile routes/dashboard_cliente.py routes/dashboard_routes.py routes/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c4ac3f7c8324bea26a3cbba2c452