### PR TITLE
Fix cadastro_participante references

### DIFF
--- a/routes/gerar_link_routes.py
+++ b/routes/gerar_link_routes.py
@@ -63,7 +63,7 @@ def gerar_link():
         if slug_customizado:
             link_gerado = f"{base_url}/inscricao/{slug_customizado}"
         else:
-            link_gerado = f"{base_url}{url_for('routes.cadastro_participante', token=novo_token)}"
+            link_gerado = f"{base_url}{url_for('inscricao_routes.cadastro_participante', token=novo_token)}"
 
         return jsonify({'success': True, 'link': link_gerado})
 
@@ -89,7 +89,7 @@ def gerar_link():
             if link.slug_customizado:
                 url = f"{base_url}/inscricao/{link.slug_customizado}"
             else:
-                url = f"{base_url}{url_for('routes.cadastro_participante', token=link.token)}"
+                url = f"{base_url}{url_for('inscricao_routes.cadastro_participante', token=link.token)}"
                 
             links_list.append({
                 'id': link.id,

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -888,7 +888,7 @@ def inscricao_personalizada(slug_customizado):
         return "Link inválido ou sem evento associado", 404
 
     # Redireciona para a rota cadastro_participante com o token
-    return redirect(url_for('routes.cadastro_participante', token=link.token))
+    return redirect(url_for('inscricao_routes.cadastro_participante', token=link.token))
 
 
 @inscricao_routes.route('/admin/inscricao/<int:inscricao_id>/editar', methods=['GET', 'POST'])

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -234,7 +234,7 @@
                     <span>Nenhum lote disponível para inscrição no momento.</span>
                 </div>
                 {% else %}
-                <form method="POST" action="{{ url_for('routes.cadastro_participante', identifier=token) }}" id="registrationForm">
+                <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', identifier=token) }}" id="registrationForm">
                     <input type="hidden" id="evento_id" name="evento_id" value="{{ evento.id if evento else '' }}">
                     
                     <div class="form-grid">

--- a/templates/auth/cadastro_usuario.html
+++ b/templates/auth/cadastro_usuario.html
@@ -91,7 +91,7 @@
         {% endif %}
       {% endwith %}
 
-      <form method="POST" action="{{ url_for('routes.cadastro_participante', token=token) if token else url_for('routes.cadastro_participante') }}">
+      <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', token=token) if token else url_for('inscricao_routes.cadastro_participante') }}">
         <div class="form-grid">
           <div>
             <label for="nome" class="form-label fw-semibold">Nome Completo</label>


### PR DESCRIPTION
## Summary
- update link generator to use `inscricao_routes.cadastro_participante`
- update inscrição redirect to use new blueprint
- update template forms to point to `inscricao_routes.cadastro_participante`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772ba91c88324bb80ef8ce6323701