### PR TITLE
Fix sorteio blueprint URLs

### DIFF
--- a/routes/sorteio_routes.py
+++ b/routes/sorteio_routes.py
@@ -116,7 +116,7 @@ def criar_sorteio():
             db.session.add(sorteio)
             db.session.commit()
             flash('Sorteio criado com sucesso!', 'success')
-            return redirect(url_for('routes.gerenciar_sorteios'))
+            return redirect(url_for('sorteio_routes.gerenciar_sorteios'))
         except Exception as e:
             db.session.rollback()
             flash(f'Erro ao criar sorteio: {str(e)}', 'danger')

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -645,7 +645,7 @@
           </div>
           <h5 class="card-title fw-bold">Realizar Sorteio</h5>
           <p class="card-text text-muted ">Sorteie prêmios entre os participantes</p>
-          <a href="{{ url_for('routes.gerenciar_sorteios') }}" class="btn btn-danger mt-2 w-100">
+          <a href="{{ url_for('sorteio_routes.gerenciar_sorteios') }}" class="btn btn-danger mt-2 w-100">
             <i class="bi bi-gift me-2"></i> Gerenciar Sorteios
           </a>
         </div>

--- a/templates/sorteio/criar_sorteio.html
+++ b/templates/sorteio/criar_sorteio.html
@@ -10,7 +10,7 @@
             </h4>
         </div>
         <div class="card-body">
-            <form method="POST" action="{{ url_for('routes.criar_sorteio') }}">
+            <form method="POST" action="{{ url_for('sorteio_routes.criar_sorteio') }}">
                 <div class="row g-3">
                     <!-- Título do Sorteio -->
                     <div class="col-md-6">

--- a/templates/sorteio/gerenciar_sorteios.html
+++ b/templates/sorteio/gerenciar_sorteios.html
@@ -5,7 +5,7 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2><i class="bi bi-trophy me-2 text-danger"></i>Gerenciar Sorteios</h2>
-        <a href="{{ url_for('routes.criar_sorteio') }}" class="btn btn-danger">
+        <a href="{{ url_for('sorteio_routes.criar_sorteio') }}" class="btn btn-danger">
             <i class="bi bi-plus-circle me-2"></i>Novo Sorteio
         </a>
     </div>
@@ -13,7 +13,7 @@
     <!-- Filtros -->
     <div class="card shadow-sm border-0 mb-4">
         <div class="card-body">
-            <form method="GET" action="{{ url_for('routes.gerenciar_sorteios') }}" class="row g-3">
+            <form method="GET" action="{{ url_for('sorteio_routes.gerenciar_sorteios') }}" class="row g-3">
                 <div class="col-md-4">
                     <label for="evento_filter" class="form-label">Evento</label>
                     <select name="evento_id" id="evento_filter" class="form-select">


### PR DESCRIPTION
## Summary
- update sorteio routes to use blueprint name
- fix template links for sorteio routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772b4a3548324b0326c59017fcd10