### PR TITLE
Fix patrocinador url_for references

### DIFF
--- a/routes/patrocinador_routes.py
+++ b/routes/patrocinador_routes.py
@@ -77,7 +77,7 @@ def remover_patrocinador(patrocinador_id):
         # Busca o evento do patrocinador e verifica se pertence ao cliente
         if not patrocinador.evento or patrocinador.evento.cliente_id != current_user.id:
             flash("Você não tem permissão para remover esse patrocinador.", "danger")
-            return redirect(url_for('routes.listar_patrocinadores'))
+            return redirect(url_for('patrocinador_routes.listar_patrocinadores'))
 
     try:
         db.session.delete(patrocinador)
@@ -87,7 +87,7 @@ def remover_patrocinador(patrocinador_id):
         db.session.rollback()
         flash(f"Erro ao remover patrocinador: {e}", "danger")
 
-    return redirect(url_for('routes.listar_patrocinadores'))
+    return redirect(url_for('patrocinador_routes.listar_patrocinadores'))
 
 
 @patrocinador_routes.route('/patrocinadores', methods=['GET'])
@@ -146,7 +146,7 @@ def remover_foto_patrocinador(patrocinador_id):
     if current_user.tipo == 'cliente':
         if not pat.evento or pat.evento.cliente_id != current_user.id:
             flash("Você não tem permissão para remover este registro.", "danger")
-            return redirect(url_for('routes.gerenciar_patrocinadores'))
+            return redirect(url_for('patrocinador_routes.gerenciar_patrocinadores'))
 
     try:
         db.session.delete(pat)
@@ -156,7 +156,7 @@ def remover_foto_patrocinador(patrocinador_id):
         db.session.rollback()
         flash(f"Erro ao remover: {e}", "danger")
 
-    return redirect(url_for('routes.gerenciar_patrocinadores'))
+    return redirect(url_for('patrocinador_routes.gerenciar_patrocinadores'))
 
 @patrocinador_routes.route('/remover_fotos_selecionadas', methods=['POST'])
 def remover_fotos_selecionadas():
@@ -165,7 +165,7 @@ def remover_fotos_selecionadas():
 
     if not ids_selecionados:
         flash('Nenhuma imagem foi selecionada para remoção.', 'warning')
-        return redirect(url_for('routes.gerenciar_patrocinadores'))
+        return redirect(url_for('patrocinador_routes.gerenciar_patrocinadores'))
     
     # Converte cada id para inteiro
     ids_selecionados = [int(x) for x in ids_selecionados]
@@ -181,7 +181,7 @@ def remover_fotos_selecionadas():
     
     db.session.commit()
     flash('Fotos removidas com sucesso!', 'success')
-    return redirect(url_for('routes.gerenciar_patrocinadores'))
+    return redirect(url_for('patrocinador_routes.gerenciar_patrocinadores'))
     # Se não houver fotos selecionadas, redireciona para a página de gerenciamento
 
 

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1112,7 +1112,7 @@
               </div>
             </div>
             
-            <form method="POST" action="{{ url_for('routes.adicionar_patrocinadores_categorizados') }}" enctype="multipart/form-data">
+            <form method="POST" action="{{ url_for('patrocinador_routes.adicionar_patrocinadores_categorizados') }}" enctype="multipart/form-data">
               <!-- Selecionar evento -->
               <div class="bg-light p-4 rounded-3 mb-4">
                 <label for="evento_id" class="form-label fw-bold d-flex align-items-center mb-3">
@@ -1223,7 +1223,7 @@
 
               <!-- Botões de ação agrupados -->
               <div class="action-group d-flex flex-column flex-md-row justify-content-center gap-3">
-                <a href="{{ url_for('routes.gerenciar_patrocinadores') }}" class="btn btn-padrao btn-outline-primary btn-lg mb-2 mb-md-0">
+                <a href="{{ url_for('patrocinador_routes.gerenciar_patrocinadores') }}" class="btn btn-padrao btn-outline-primary btn-lg mb-2 mb-md-0">
                   <i class="bi bi-card-image"></i> Gerenciar Logos Existentes
                 </a>
                 <button type="submit" class="btn btn-padrao btn-success btn-lg">

--- a/templates/patrocinador/gerenciar_patrocinadores.html
+++ b/templates/patrocinador/gerenciar_patrocinadores.html
@@ -11,7 +11,7 @@
       Voltar
     </a>
     <!-- Form e botão "Remover Selecionadas" -->
-    <form action="{{ url_for('routes.remover_fotos_selecionadas') }}" method="POST"
+    <form action="{{ url_for('patrocinador_routes.remover_fotos_selecionadas') }}" method="POST"
           onsubmit="return confirm('Deseja realmente remover as imagens selecionadas?');">
       <button type="submit" class="btn btn-danger">
         Remover Selecionadas
@@ -56,7 +56,7 @@
         </td>
         <td>
           <!-- Botão individual de remoção (já existente) -->
-          <form action="{{ url_for('routes.remover_foto_patrocinador', patrocinador_id=pat.id) }}"
+          <form action="{{ url_for('patrocinador_routes.remover_foto_patrocinador', patrocinador_id=pat.id) }}"
                 method="POST"
                 onsubmit="return confirm('Deseja realmente remover esta logo?');">
             <button type="submit" class="btn btn-danger btn-sm">
@@ -71,7 +71,7 @@
 </div>
 
 <!-- Form oculto para remover em lote (bulk), usado pelos checkboxes -->
-<form id="bulkRemoveForm" action="{{ url_for('routes.remover_fotos_selecionadas') }}" method="POST">
+<form id="bulkRemoveForm" action="{{ url_for('patrocinador_routes.remover_fotos_selecionadas') }}" method="POST">
   <!-- Este form é usado pelos checkboxes via atributo form="bulkRemoveForm" -->
 </form>
 

--- a/templates/patrocinador/listar_patrocinadores.html
+++ b/templates/patrocinador/listar_patrocinadores.html
@@ -35,7 +35,7 @@
                style="max-width: 120px;"/>
         </td>
         <td>
-          <form action="{{ url_for('routes.remover_patrocinador', patrocinador_id=pat.id) }}" 
+          <form action="{{ url_for('patrocinador_routes.remover_patrocinador', patrocinador_id=pat.id) }}"
                 method="POST" 
                 onsubmit="return confirm('Deseja realmente remover este patrocinador?');"
                 class="d-inline">


### PR DESCRIPTION
## Summary
- update `patrocinador_routes.py` to use its own blueprint prefix in `url_for` calls
- update patrocinador templates with the new blueprint prefix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772b80e788324945a46ae5ff7165d