### PR TITLE
Fix blueprint names for formularios routes

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -60,7 +60,7 @@ def criar_formulario():
         db.session.add(novo_formulario)
         db.session.commit()
         flash('Formulário criado com sucesso!', 'success')
-        return redirect(url_for('routes.listar_formularios'))
+        return redirect(url_for('formularios_routes.listar_formularios'))
     
     return render_template("criar_formulario.html")
 
@@ -74,7 +74,7 @@ def editar_formulario(formulario_id):
         formulario.descricao = request.form.get('descricao')
         db.session.commit()
         flash('Formulário atualizado!', 'success')
-        return redirect(url_for('routes.listar_formularios'))
+        return redirect(url_for('formularios_routes.listar_formularios'))
 
     return render_template('editar_formulario.html', formulario=formulario)
 
@@ -85,7 +85,7 @@ def deletar_formulario(formulario_id):
     db.session.delete(formulario)
     db.session.commit()
     flash('Formulário deletado com sucesso!', 'success')
-    return redirect(url_for('routes.listar_formularios'))
+    return redirect(url_for('formularios_routes.listar_formularios'))
 
 @formularios_routes.route('/formularios/<int:formulario_id>/campos', methods=['GET', 'POST'])
 @login_required
@@ -114,7 +114,7 @@ def gerenciar_campos(formulario_id):
         db.session.commit()
         flash('Campo adicionado com sucesso!', 'success')
 
-        return redirect(url_for('routes.gerenciar_campos', formulario_id=formulario.id))
+        return redirect(url_for('formularios_routes.gerenciar_campos', formulario_id=formulario.id))
 
     return render_template('gerenciar_campos.html', formulario=formulario)
 
@@ -134,7 +134,7 @@ def editar_campo(campo_id):
         db.session.commit()
         flash('Campo atualizado com sucesso!', 'success')
 
-        return redirect(url_for('routes.gerenciar_campos', formulario_id=campo.formulario_id))
+        return redirect(url_for('formularios_routes.gerenciar_campos', formulario_id=campo.formulario_id))
 
     return render_template('editar_campo.html', campo=campo)
 
@@ -147,7 +147,7 @@ def deletar_campo(campo_id):
     db.session.commit()
     flash('Campo removido com sucesso!', 'success')
 
-    return redirect(url_for('routes.gerenciar_campos', formulario_id=formulario_id))
+    return redirect(url_for('formularios_routes.gerenciar_campos', formulario_id=formulario_id))
 
 @formularios_routes.route('/formularios/<int:formulario_id>/preencher', methods=['GET', 'POST'])
 @login_required
@@ -331,7 +331,7 @@ def excluir_formulario(formulario_id):
         db.session.rollback()
         flash(f"Erro ao excluir formulário: {str(e)}", "danger")
 
-    return redirect(url_for('routes.listar_formularios'))
+    return redirect(url_for('formularios_routes.listar_formularios'))
 
 @formularios_routes.route('/formularios/<int:formulario_id>/respostas_ministrante', methods=['GET'])
 @login_required
@@ -384,7 +384,7 @@ def dar_feedback_resposta(resposta_id):
 
         db.session.commit()
         flash("Feedback registrado com sucesso!", "success")
-        return redirect(url_for('routes.dar_feedback_resposta_formulario', resposta_id=resposta_id))
+        return redirect(url_for('formularios_routes.dar_feedback_resposta_formulario', resposta_id=resposta_id))
 
     return render_template(
         'dar_feedback_resposta.html',
@@ -440,7 +440,7 @@ def criar_template():
         db.session.commit()
         
         flash('Template criado com sucesso!', 'success')
-        return redirect(url_for('routes.gerenciar_campos_template', template_id=novo_template.id))
+        return redirect(url_for('formularios_routes.gerenciar_campos_template', template_id=novo_template.id))
     
     return render_template("certificado/criar_template.html")
 
@@ -452,7 +452,7 @@ def gerenciar_campos_template(template_id):
     # Check permissions
     if current_user.tipo != 'admin' and template.cliente_id != current_user.id and not template.is_default:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('routes.listar_templates'))
+        return redirect(url_for('formularios_routes.listar_templates'))
     
     if request.method == 'POST':
         nome = request.form.get('nome')
@@ -474,7 +474,7 @@ def gerenciar_campos_template(template_id):
         db.session.commit()
         
         flash('Campo adicionado com sucesso!', 'success')
-        return redirect(url_for('routes.gerenciar_campos_template', template_id=template.id))
+        return redirect(url_for('formularios_routes.gerenciar_campos_template', template_id=template.id))
     
     return render_template('gerenciar_campos_template.html', template=template)
 
@@ -509,7 +509,7 @@ def usar_template(template_id):
         
         db.session.commit()
         flash('Formulário criado com sucesso a partir do template!', 'success')
-        return redirect(url_for('routes.listar_formularios'))
+        return redirect(url_for('formularios_routes.listar_formularios'))
     
     return render_template('usar_template.html', template=template)
 
@@ -590,6 +590,6 @@ def definir_status_inline():
 
     # Redireciona para a mesma página (listar_respostas) ou usa request.referrer
     # Se estiver em /formularios/<id>/respostas_ministrante, podemos redirecionar
-    return redirect(request.referrer or url_for('routes.listar_respostas',
+    return redirect(request.referrer or url_for('formularios_routes.listar_respostas',
                                                 formulario_id=resposta.formulario_id))
 

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-plus me-2"></i>Criar Novo Formulário
         </h2>
-        <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para lista
         </a>
     </div>
@@ -28,7 +28,7 @@
                 </div>
                 
                 <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
-                    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-light me-md-2">
+                    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-light me-md-2">
                         Cancelar
                     </a>
                     <button type="submit" class="btn btn-primary">

--- a/templates/formulario/criar_template.html
+++ b/templates/formulario/criar_template.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-plus me-2"></i>Criar Novo Template
         </h2>
-        <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para Templates
         </a>
     </div>
@@ -74,7 +74,7 @@
                     
                     <div class="col-12">
                         <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                            <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-light me-md-2">
+                            <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-light me-md-2">
                                 Cancelar
                             </a>
                             <button type="submit" class="btn btn-primary">

--- a/templates/formulario/editar_campo.html
+++ b/templates/formulario/editar_campo.html
@@ -59,7 +59,7 @@
 
         <!-- Ações -->
         <div class="d-grid gap-2 d-md-flex mt-4">
-          <a href="{{ url_for('routes.gerenciar_campos', formulario_id=campo.formulario_id) }}" class="btn btn-outline-secondary">
+          <a href="{{ url_for('formularios_routes.gerenciar_campos', formulario_id=campo.formulario_id) }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar
           </a>
           <button type="submit" class="btn btn-primary ms-auto">

--- a/templates/formulario/editar_formulario.html
+++ b/templates/formulario/editar_formulario.html
@@ -15,6 +15,6 @@
         <button type="submit" class="btn btn-success">Salvar Alterações</button>
     </form>
 
-    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-secondary mt-3">Voltar</a>
+    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-secondary mt-3">Voltar</a>
 </div>
 {% endblock %}

--- a/templates/formulario/formularios.html
+++ b/templates/formulario/formularios.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-text me-2"></i>Formulários Criados
         </h2>
-        <a href="{{ url_for('routes.criar_formulario') }}" class="btn btn-success">
+        <a href="{{ url_for('formularios_routes.criar_formulario') }}" class="btn btn-success">
             <i class="bi bi-plus-circle me-1"></i> Criar Novo Formulário
         </a>
     </div>
@@ -29,13 +29,13 @@
                                 <td>{{ formulario.descricao or "Sem descrição" }}</td>
                                 <td>
                                     <div class="d-flex justify-content-center gap-2">
-                                        <a href="{{ url_for('routes.gerenciar_campos', formulario_id=formulario.id) }}" 
+                                        <a href="{{ url_for('formularios_routes.gerenciar_campos', formulario_id=formulario.id) }}" 
                                            class="btn btn-outline-primary btn-sm" 
                                            data-bs-toggle="tooltip" 
                                            title="Gerenciar Campos">
                                             <i class="bi bi-list-check"></i>
                                         </a>
-                                        <a href="{{ url_for('routes.editar_formulario', formulario_id=formulario.id) }}" 
+                                        <a href="{{ url_for('formularios_routes.editar_formulario', formulario_id=formulario.id) }}" 
                                            class="btn btn-outline-warning btn-sm"
                                            data-bs-toggle="tooltip" 
                                            title="Editar Formulário">
@@ -64,7 +64,7 @@
                                                 </div>
                                                 <div class="modal-footer">
                                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                                    <form action="{{ url_for('routes.excluir_formulario', formulario_id=formulario.id) }}" method="POST" class="d-inline">
+                                                    <form action="{{ url_for('formularios_routes.excluir_formulario', formulario_id=formulario.id) }}" method="POST" class="d-inline">
                                                         <button type="submit" class="btn btn-danger">
                                                             Excluir Formulário
                                                         </button>
@@ -83,7 +83,7 @@
                 <div class="text-center py-5">
                     <i class="bi bi-clipboard-x fs-1 text-muted mb-3"></i>
                     <p class="lead text-muted">Nenhum formulário criado ainda.</p>
-                    <a href="{{ url_for('routes.criar_formulario') }}" class="btn btn-primary mt-2">
+                    <a href="{{ url_for('formularios_routes.criar_formulario') }}" class="btn btn-primary mt-2">
                         Criar seu primeiro formulário
                     </a>
                 </div>

--- a/templates/formulario/formularios_participante.html
+++ b/templates/formulario/formularios_participante.html
@@ -24,7 +24,7 @@
                             <td class="text-end pe-3">
                                 <div class="btn-group" role="group">
                                     <!-- Botão de preencher -->
-                                    <a href="{{ url_for('routes.preencher_formulario', formulario_id=formulario.id) }}"
+                                    <a href="{{ url_for('formularios_routes.preencher_formulario', formulario_id=formulario.id) }}"
                                        class="btn btn-outline-primary btn-sm">
                                         <i class="bi bi-pencil-fill me-1"></i> Preencher
                                     </a>
@@ -38,7 +38,7 @@
 
                                     <!-- Se user_resposta existir, exibir botão de "Ver Feedback" -->
                                     {% if user_resposta %}
-                                    <a href="{{ url_for('routes.visualizar_resposta', resposta_id=user_resposta.id) }}"
+                                    <a href="{{ url_for('formularios_routes.visualizar_resposta', resposta_id=user_resposta.id) }}"
                                        class="btn btn-outline-info btn-sm ms-1">
                                        <i class="bi bi-eye-fill me-1"></i> Ver Feedback
                                     </a>

--- a/templates/formulario/gerenciar_campos.html
+++ b/templates/formulario/gerenciar_campos.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-list-nested me-2"></i>Gerenciar Campos
         </h2>
-        <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para Formulários
         </a>
     </div>
@@ -43,7 +43,7 @@
                                     </div>
                                 </div>
                                 <div class="btn-group btn-group-sm">
-                                    <a href="{{ url_for('routes.editar_campo', campo_id=campo.id) }}" class="btn btn-outline-warning">
+                                    <a href="{{ url_for('formularios_routes.editar_campo', campo_id=campo.id) }}" class="btn btn-outline-warning">
                                         <i class="bi bi-pencil"></i>
                                     </a>
                                     <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteFieldModal{{ campo.id }}">
@@ -67,7 +67,7 @@
                                     </div>
                                     <div class="modal-footer">
                                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                        <form action="{{ url_for('routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
+                                        <form action="{{ url_for('formularios_routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
                                             <button type="submit" class="btn btn-danger">Remover Campo</button>
                                         </form>
                                     </div>
@@ -85,7 +85,7 @@
                 </div>
                 {% if formulario.campos %}
                 <div class="card-footer bg-white text-center">
-                    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-primary">
+                    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-primary">
                         <i class="bi bi-check-circle me-1"></i> Finalizar e Salvar
                     </a>
                 </div>

--- a/templates/formulario/gerenciar_campos_template.html
+++ b/templates/formulario/gerenciar_campos_template.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-layout-text-window me-2"></i>Gerenciar Campos do Template
         </h2>
-        <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para Templates
         </a>
     </div>
@@ -103,7 +103,7 @@
                 </div>
                 {% if template.campos %}
                 <div class="card-footer bg-white text-center">
-                    <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-primary">
+                    <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-primary">
                         <i class="bi bi-check-circle me-1"></i> Finalizar e Salvar
                     </a>
                 </div>

--- a/templates/formulario/templates_formulario.html
+++ b/templates/formulario/templates_formulario.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-ruled me-2"></i>Templates de Formulários
         </h2>
-        <a href="{{ url_for('routes.criar_template') }}" class="btn btn-success">
+        <a href="{{ url_for('formularios_routes.criar_template') }}" class="btn btn-success">
             <i class="bi bi-plus-circle me-1"></i> Criar Novo Template
         </a>
     </div>
@@ -65,11 +65,11 @@
                 
                 <div class="card-footer bg-white">
                     <div class="d-flex gap-2">
-                        <a href="{{ url_for('routes.gerenciar_campos_template', template_id=template.id) }}" 
+                        <a href="{{ url_for('formularios_routes.gerenciar_campos_template', template_id=template.id) }}" 
                            class="btn btn-outline-primary flex-grow-1">
                             <i class="bi bi-pencil-square me-1"></i> Gerenciar Campos
                         </a>
-                        <a href="{{ url_for('routes.usar_template', template_id=template.id) }}" 
+                        <a href="{{ url_for('formularios_routes.usar_template', template_id=template.id) }}" 
                            class="btn btn-success flex-grow-1">
                             <i class="bi bi-check-circle me-1"></i> Usar Template
                         </a>
@@ -138,7 +138,7 @@
             <i class="bi bi-file-earmark-x text-muted fs-1 mb-3"></i>
             <h4 class="text-muted">Nenhum template disponível</h4>
             <p class="text-muted mb-4">Crie um novo template ou utilize os templates padrão do sistema.</p>
-            <a href="{{ url_for('routes.criar_template') }}" class="btn btn-primary">
+            <a href="{{ url_for('formularios_routes.criar_template') }}" class="btn btn-primary">
                 <i class="bi bi-plus-circle me-1"></i> Criar seu primeiro template
             </a>
         </div>


### PR DESCRIPTION
## Summary
- reference `formularios_routes` blueprint correctly in routes
- update form template links accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772bef2b0832490a1b1bcfdf164ad