### PR TITLE
Fix agendamento url_for references

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -434,11 +434,11 @@ def editar_horario_agendamento():
         
         if capacidade_total < agendamentos_alunos:
             flash(f'Não é possível reduzir a capacidade para {capacidade_total}. Já existem {agendamentos_alunos} alunos agendados.', 'danger')
-            return redirect(url_for('routes.listar_horarios_agendamento', evento_id=evento.id))
+            return redirect(url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id))
         
         if vagas_disponiveis > capacidade_total:
             flash('As vagas disponíveis não podem ser maiores que a capacidade total!', 'danger')
-            return redirect(url_for('routes.listar_horarios_agendamento', evento_id=evento.id))
+            return redirect(url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id))
         
         # Atualizar horário
         horario.capacidade_total = capacidade_total
@@ -453,7 +453,7 @@ def editar_horario_agendamento():
     else:
         flash('Preencha todos os campos!', 'danger')
     
-    return redirect(url_for('routes.listar_horarios_agendamento', evento_id=evento.id))
+    return redirect(url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id))
 
 
 @agendamento_routes.route('/excluir_horario_agendamento', methods=['POST'])
@@ -502,7 +502,7 @@ def excluir_horario_agendamento():
         db.session.rollback()
         flash(f'Erro ao excluir horário: {str(e)}', 'danger')
     
-    return redirect(url_for('routes.listar_horarios_agendamento', evento_id=evento_id))
+    return redirect(url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento_id))
 
 
 def gerar_pdf_relatorio_geral(eventos, estatisticas, data_inicio, data_fim, caminho_pdf):
@@ -820,7 +820,7 @@ def configurar_agendamentos(evento_id):
         try:
             db.session.commit()
             flash('Configurações de agendamento salvas com sucesso!', 'success')
-            return redirect(url_for('routes.gerar_horarios_agendamento', evento_id=evento_id))
+            return redirect(url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento_id))
         except Exception as e:
             db.session.rollback()
             flash(f'Erro ao salvar configurações: {str(e)}', 'danger')
@@ -911,7 +911,7 @@ def gerar_horarios_agendamento(evento_id):
         try:
             db.session.commit()
             flash(f'{horarios_criados} horários de visitação foram criados com sucesso!', 'success')
-            return redirect(url_for('routes.listar_horarios_agendamento', evento_id=evento_id))
+            return redirect(url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento_id))
         except Exception as e:
             db.session.rollback()
             flash(f'Erro ao gerar horários: {str(e)}', 'danger')
@@ -1258,7 +1258,7 @@ def configurar_horarios_agendamento():
                     flash(f"Horário adicionado com sucesso para o dia {data} das {horario_inicio} às {horario_fim}!", "success")
                     
                     # Redirecionar para a mesma página com o evento selecionado
-                    return redirect(url_for('routes.configurar_horarios_agendamento', evento_id=evento_id))
+                    return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
             
             elif acao == 'excluir':
                 # Obter ID do horário a ser excluído
@@ -1285,7 +1285,7 @@ def configurar_horarios_agendamento():
                         flash("Horário não encontrado.", "danger")
                     
                     # Redirecionar para a mesma página com o evento selecionado
-                    return redirect(url_for('routes.configurar_horarios_agendamento', evento_id=evento_id))
+                    return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
             
             elif acao == 'adicionar_periodo':
                 # Obter dados do formulário para adicionar vários horários em um período
@@ -1348,7 +1348,7 @@ def configurar_horarios_agendamento():
                         flash("Nenhum horário novo foi criado. Verifique se já existem horários para as datas selecionadas.", "warning")
                     
                     # Redirecionar para a mesma página com o evento selecionado
-                    return redirect(url_for('routes.configurar_horarios_agendamento', evento_id=evento_id))
+                    return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
                 
         except Exception as e:
             form_erro = f"Erro ao processar o formulário: {str(e)}"
@@ -1480,7 +1480,7 @@ def criar_evento_agendamento():
                     
                     db.session.commit()
                     flash(f"Evento '{nome}' criado com sucesso! Você pode agora configurar os horários.", "success")
-                    return redirect(url_for('routes.configurar_horarios_agendamento', evento_id=novo_evento.id))
+                    return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=novo_evento.id))
                 
                 except Exception as e:
                     db.session.rollback()
@@ -1610,7 +1610,7 @@ def download_modelo_importacao():
         
     except Exception as e:
         flash(f"Erro ao gerar o modelo: {str(e)}", "danger")
-        return redirect(url_for('routes.importar_agendamentos'))
+        return redirect(url_for('agendamento_routes.importar_agendamentos'))
 
 
 @agendamento_routes.route('/exportar-log-importacao')
@@ -1653,7 +1653,7 @@ def exportar_log_importacao():
         
     except Exception as e:
         flash(f"Erro ao gerar o log: {str(e)}", "danger")
-        return redirect(url_for('routes.importar_agendamentos'))
+        return redirect(url_for('agendamento_routes.importar_agendamentos'))
     
 @agendamento_routes.route('/api/toggle-agendamento-publico', methods=['POST'])
 @login_required
@@ -1957,7 +1957,7 @@ def criar_periodo_agendamento():
                     flash(f"Período de agendamento criado com sucesso! Horários configurados para {dias_texto} das {hora_inicio} às {hora_fim}.", "success")
                     
                     # Redirecionar para a página de configuração de horários
-                    return redirect(url_for('routes.configurar_horarios_agendamento', evento_id=evento_id))
+                    return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
                 
         except Exception as e:
             form_erro = f"Erro ao processar o formulário: {str(e)}"
@@ -2344,7 +2344,7 @@ def excluir_sala_visitacao(sala_id):
     agendamentos = Agendamento.query.filter_by(sala_id=sala_id).count()
     if agendamentos > 0:
         flash(f'Não é possível excluir esta sala pois existem {agendamentos} agendamentos associados a ela.', 'warning')
-        return redirect(url_for('routes.salas_visitacao', evento_id=sala.evento_id))
+        return redirect(url_for('agendamento_routes.salas_visitacao', evento_id=sala.evento_id))
     
     # Guardar o evento_id para usar no redirecionamento
     evento_id = sala.evento_id
@@ -2359,7 +2359,7 @@ def excluir_sala_visitacao(sala_id):
         flash(f'Erro ao excluir sala: {str(e)}', 'danger')
     
     # Redirecionar para a lista de salas do evento
-    return redirect(url_for('routes.salas_visitacao', evento_id=evento_id))
+    return redirect(url_for('agendamento_routes.salas_visitacao', evento_id=evento_id))
 
 
 @agendamento_routes.route('/agendamentos/exportar/pdf', methods=['GET'])
@@ -2549,7 +2549,7 @@ def editar_agendamento(agendamento_id):
     # Verifica permissões (apenas o próprio professor, administradores ou clientes podem editar)
     if current_user.tipo not in ['admin', 'cliente'] and current_user.id != agendamento.professor_id:
         flash('Você não tem permissão para editar este agendamento.', 'danger')
-        return redirect(url_for('routes.listar_agendamentos'))
+        return redirect(url_for('agendamento_routes.listar_agendamentos'))
     
     # Busca horários disponíveis para edição
     horarios_disponiveis = HorarioVisitacao.query.filter_by(disponivel=True).all()
@@ -2601,7 +2601,7 @@ def editar_agendamento(agendamento_id):
             
             db.session.commit()
             flash('Agendamento atualizado com sucesso!', 'success')
-            return redirect(url_for('routes.listar_agendamentos'))
+            return redirect(url_for('agendamento_routes.listar_agendamentos'))
             
         except Exception as e:
             db.session.rollback()
@@ -2884,14 +2884,14 @@ def processar_qrcode_agendamento():
             return jsonify({
                 'success': False,
                 'message': 'Check-in já realizado para este agendamento.',
-                'redirect': url_for('routes.confirmar_checkin_agendamento', token=token)
+                'redirect': url_for('agendamento_routes.confirmar_checkin_agendamento', token=token)
             }), 200
         
         # Redireciona para a página de confirmação de check-in
         return jsonify({
             'success': True,
             'message': 'Agendamento encontrado!',
-            'redirect': url_for('routes.confirmar_checkin_agendamento', token=token)
+            'redirect': url_for('agendamento_routes.confirmar_checkin_agendamento', token=token)
         }), 200
     
     except Exception as e:
@@ -2913,7 +2913,7 @@ def confirmar_checkin_agendamento(token):
     
     if not agendamento:
         flash('Agendamento não encontrado. Verifique o QR Code e tente novamente.', 'danger')
-        return redirect(url_for('routes.checkin_qr_agendamento'))
+        return redirect(url_for('agendamento_routes.checkin_qr_agendamento'))
     
     # Busca informações relacionadas
     evento = Evento.query.get(agendamento.horario.evento_id)
@@ -2964,7 +2964,7 @@ def checkin_qr_agendamento():
     if token:
         agendamento = AgendamentoVisita.query.filter_by(qr_code_token=token).first()
         if agendamento:
-            return redirect(url_for('routes.confirmar_checkin_agendamento', token=token))
+            return redirect(url_for('agendamento_routes.confirmar_checkin_agendamento', token=token))
         else:
             flash('Agendamento não encontrado. Verifique o token e tente novamente.', 'danger')
     
@@ -3040,7 +3040,7 @@ def agendar_visita(horario_id):
         # Validar vagas disponíveis
         if quantidade_alunos > horario.vagas_disponiveis:
             flash('Quantidade de alunos excede vagas disponíveis.', 'danger')
-            return redirect(url_for('routes.agendar_visita', horario_id=horario_id))
+            return redirect(url_for('agendamento_routes.agendar_visita', horario_id=horario_id))
 
         # Criar agendamento
         novo_agendamento = AgendamentoVisita(
@@ -3099,7 +3099,7 @@ def adicionar_alunos():
                 colunas_obrigatorias = ['nome', 'cpf', 'email', 'formacao']
                 if not all(col in df.columns for col in colunas_obrigatorias):
                     flash(f"Erro: O arquivo deve conter as colunas: {', '.join(colunas_obrigatorias)}", "danger")
-                    return redirect(url_for('routes.adicionar_alunos'))
+                    return redirect(url_for('agendamento_routes.adicionar_alunos'))
 
                 # Processamento em lote
                 alunos_adicionados = 0
@@ -3141,7 +3141,7 @@ def adicionar_alunos():
                 db.session.rollback()
                 flash(f"Erro ao processar arquivo: {str(e)}", "danger")
                 print(f"❌ Erro na importação: {e}")
-                return redirect(url_for('routes.adicionar_alunos'))
+                return redirect(url_for('agendamento_routes.adicionar_alunos'))
 
         # Processamento de entrada manual
         elif nome and cpf and email and formacao:
@@ -3153,7 +3153,7 @@ def adicionar_alunos():
 
                 if usuario_existente:
                     flash(f"Usuário com CPF {cpf} ou email {email} já existe.", "warning")
-                    return redirect(url_for('routes.adicionar_alunos'))
+                    return redirect(url_for('agendamento_routes.adicionar_alunos'))
 
                 novo_usuario = Usuario(
                     nome=nome,
@@ -3176,11 +3176,11 @@ def adicionar_alunos():
                 db.session.rollback()
                 flash(f"Erro ao adicionar aluno: {str(e)}", "danger")
                 print(f"❌ Erro na adição manual: {e}")
-                return redirect(url_for('routes.adicionar_alunos'))
+                return redirect(url_for('agendamento_routes.adicionar_alunos'))
 
         else:
             flash("Dados insuficientes para adicionar aluno.", "warning")
-            return redirect(url_for('routes.adicionar_alunos'))
+            return redirect(url_for('agendamento_routes.adicionar_alunos'))
 
     # GET: Renderiza o formulário
     estados = obter_estados()
@@ -3203,7 +3203,7 @@ def importar_alunos():
         
         if not arquivo or not arquivo.filename:
             flash('Nenhum arquivo selecionado.', 'warning')
-            return redirect(url_for('routes.importar_alunos'))
+            return redirect(url_for('agendamento_routes.importar_alunos'))
 
         try:
             # Determina o tipo de arquivo e usa a biblioteca correta
@@ -3213,7 +3213,7 @@ def importar_alunos():
                 df = pd.read_csv(arquivo, dtype={'cpf': str})
             else:
                 flash('Formato de arquivo não suportado. Use .xlsx, .xls ou .csv', 'danger')
-                return redirect(url_for('routes.importar_alunos'))
+                return redirect(url_for('agendamento_routes.importar_alunos'))
             
             # Verificar colunas obrigatórias
             colunas_obrigatorias = ['nome', 'cpf', 'email', 'formacao']
@@ -3221,7 +3221,7 @@ def importar_alunos():
             
             if colunas_faltantes:
                 flash(f"Erro: Colunas faltantes no arquivo: {', '.join(colunas_faltantes)}", "danger")
-                return redirect(url_for('routes.importar_alunos'))
+                return redirect(url_for('agendamento_routes.importar_alunos'))
 
             # Processamento em lote
             alunos_adicionados = 0
@@ -3311,7 +3311,7 @@ def importar_alunos():
             db.session.rollback()
             flash(f"Erro ao processar arquivo: {str(e)}", "danger")
             print(f"❌ Erro na importação: {e}")
-            return redirect(url_for('routes.importar_alunos'))
+            return redirect(url_for('agendamento_routes.importar_alunos'))
 
     # GET: Renderiza o formulário de importação
     return render_template('importar_alunos.html')
@@ -3439,17 +3439,17 @@ def cancelar_agendamento_professor(agendamento_id):
     # Verificar se o agendamento pertence ao professor
     if agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
-        return redirect(url_for('routes.meus_agendamentos'))
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
     
     # Verificar se o agendamento já foi cancelado
     if agendamento.status == 'cancelado':
         flash('Este agendamento já foi cancelado!', 'warning')
-        return redirect(url_for('routes.meus_agendamentos'))
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
     
     # Verificar se o agendamento já foi realizado
     if agendamento.status == 'realizado':
         flash('Este agendamento já foi realizado e não pode ser cancelado!', 'warning')
-        return redirect(url_for('routes.meus_agendamentos'))
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
     
     # Verificar prazo de cancelamento
     horario = agendamento.horario
@@ -3487,7 +3487,7 @@ def cancelar_agendamento_professor(agendamento_id):
         try:
             db.session.commit()
             flash('Agendamento cancelado com sucesso!', 'success')
-            return redirect(url_for('routes.meus_agendamentos'))
+            return redirect(url_for('agendamento_routes.meus_agendamentos'))
         except Exception as e:
             db.session.rollback()
             flash(f'Erro ao cancelar agendamento: {str(e)}', 'danger')
@@ -3538,7 +3538,7 @@ def marcar_presenca_aluno(aluno_id):
         db.session.rollback()
         flash(f'Erro ao marcar presença: {str(e)}', 'danger')
     
-    return redirect(url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id))
+    return redirect(url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id))
 
 
 @agendamento_routes.route('/qrcode_agendamento/<int:agendamento_id>', methods=['GET'])
@@ -3577,7 +3577,7 @@ def horarios_disponiveis_api():
             "title": f"Disponível ({horario.vagas_disponiveis} vagas)",
             "start": f"{horario.data}T{horario.horario_inicio}",
             "end": f"{horario.data}T{horario.horario_fim}",
-            "url": url_for('routes.agendar_visita', horario_id=horario.id)
+            "url": url_for('agendamento_routes.agendar_visita', horario_id=horario.id)
         })
 
     return jsonify(eventos)

--- a/templates/agendamento/configurar_agendamentos.html
+++ b/templates/agendamento/configurar_agendamentos.html
@@ -30,7 +30,7 @@
           <i class="bi bi-calendar-check"></i> Regras de Agendamento
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="prazo_cancelamento" class="form-label">Prazo para Cancelamento (horas)</label>

--- a/templates/agendamento/configurar_horarios_agendamento.html
+++ b/templates/agendamento/configurar_horarios_agendamento.html
@@ -20,7 +20,7 @@
     <div class="card-body">
       <div class="row align-items-center">
         <div class="col-md-8">
-          <form method="GET" action="{{ url_for('routes.configurar_horarios_agendamento') }}">
+          <form method="GET" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
             <div class="input-group">
               <select class="form-select" id="evento_id" name="evento_id" required>
                 <option value="">Selecione um evento</option>
@@ -83,7 +83,7 @@
                   <a href="{{ url_for('routes.editar_horario', horario_id=horario.id) if has_editar_horario else '#' }}" class="btn btn-warning">
                     <i class="bi bi-pencil"></i>
                   </a>
-                  <form method="POST" action="{{ url_for('routes.configurar_horarios_agendamento') }}" class="d-inline" onsubmit="return confirm('Tem certeza que deseja excluir este horário?');">
+                  <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="d-inline" onsubmit="return confirm('Tem certeza que deseja excluir este horário?');">
                     <input type="hidden" name="acao" value="excluir">
                     <input type="hidden" name="horario_id" value="{{ horario.id }}">
                     <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
@@ -115,7 +115,7 @@
           <h5 class="m-0 fw-bold"><i class="bi bi-plus-circle me-2"></i>Adicionar Horário</h5>
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.configurar_horarios_agendamento') }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
             <input type="hidden" name="acao" value="adicionar">
             <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
             
@@ -160,7 +160,7 @@
           <h5 class="m-0 fw-bold"><i class="bi bi-calendar-week me-2"></i>Configurar Período</h5>
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.configurar_horarios_agendamento') }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
             <input type="hidden" name="acao" value="adicionar_periodo">
             <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
             

--- a/templates/agendamento/criar_periodo_agendamento.html
+++ b/templates/agendamento/criar_periodo_agendamento.html
@@ -7,7 +7,7 @@
     <h1 class="h2 fw-bold text-primary mb-0">
       <i class="bi bi-calendar-range me-2"></i>Criar Período de Agendamento
     </h1>
-    <a href="{{ url_for('routes.configurar_horarios_agendamento') }}" class="btn btn-outline-primary">
+    <a href="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="btn btn-outline-primary">
       <i class="bi bi-arrow-left me-2"></i>Voltar à Configuração de Horários
     </a>
   </div>
@@ -153,7 +153,7 @@
         
         <div class="row mt-4">
           <div class="col-12 d-flex justify-content-between">
-            <a href="{{ url_for('routes.configurar_horarios_agendamento') }}" class="btn btn-secondary">Cancelar</a>
+            <a href="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="btn btn-secondary">Cancelar</a>
             <button type="submit" class="btn btn-success">
               <i class="bi bi-calendar-plus me-2"></i>Criar Período e Horários
             </button>

--- a/templates/agendamento/dashboard_agendamentos.html
+++ b/templates/agendamento/dashboard_agendamentos.html
@@ -124,7 +124,7 @@
                           {% if agendamentos_hoje %}
                             <div class="list-group">
                               {% for agendamento in agendamentos_hoje %}
-                                <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
+                                <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
                                   <div class="d-flex w-100 justify-content-between">
                                     <h5 class="mb-1">{{ agendamento.escola_nome }}</h5>
                                     <small>{{ agendamento.horario.horario_inicio.strftime('%H:%M') }}</small>
@@ -159,7 +159,7 @@
                           {% if proximos_agendamentos %}
                             <div class="list-group">
                               {% for agendamento in proximos_agendamentos %}
-                                <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
+                                <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
                                   <div class="d-flex w-100 justify-content-between">
                                     <h5 class="mb-1">{{ agendamento.escola_nome }}</h5>
                                     <small>{{ agendamento.horario.data.strftime('%d/%m/%Y') }}</small>
@@ -190,7 +190,7 @@
                 </div>
                 <div class="card-body">
                   <div class="list-group mb-4">
-                    <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
+                    <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
                       <div class="d-flex align-items-center">
                         <i class="bi bi-qrcode fs-4 me-3 text-primary"></i>
                         <div>
@@ -219,13 +219,13 @@
                         <div class="list-group-item">
                           <h6>{{ evento.nome }}</h6>
                           <div class="btn-group btn-group-sm w-100 mt-2">
-                            <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-primary">
+                            <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-primary">
                               <i class="bi bi-gear"></i> Configurar
                             </a>
-                            <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-outline-info">
+                            <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-outline-info">
                               <i class="bi bi-clock"></i> Horários
                             </a>
-                            <a href="{{ url_for('routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-success">
+                            <a href="{{ url_for('agendamento_routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-success">
                               <i class="bi bi-list-check"></i> Agendamentos
                             </a>
                           </div>
@@ -403,7 +403,7 @@
                       <i class="bi bi-calendar-plus me-2"></i> Criar Novo Agendamento
                     </a>
                     
-                    <a href="{{ url_for('routes.configurar_horarios_agendamento') }}" class="btn btn-info btn-lg">
+                    <a href="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="btn btn-info btn-lg">
                       <i class="bi bi-clock me-2"></i> Configurar Horários
                     </a>
                     
@@ -422,11 +422,11 @@
                 </div>
                 <div class="card-body">
                   <div class="d-grid gap-3">
-                    <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="btn btn-dark btn-lg">
+                    <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="btn btn-dark btn-lg">
                       <i class="bi bi-qr-code-scan me-2"></i> Check-in com QR Code
                     </a>
                     
-                    <a href="{{ url_for('routes.importar_agendamentos') }}" class="btn btn-primary btn-lg">
+                    <a href="{{ url_for('agendamento_routes.importar_agendamentos') }}" class="btn btn-primary btn-lg">
                       <i class="bi bi-upload me-2"></i> Importar Agendamentos
                     </a>
 

--- a/templates/agendamento/detalhes_agendamentos.html
+++ b/templates/agendamento/detalhes_agendamentos.html
@@ -65,6 +65,6 @@
     </div>
     {% endif %}
 
-    <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary mt-3">Voltar</a>
+    <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary mt-3">Voltar</a>
 </div>
 {% endblock %}

--- a/templates/agendamento/editar_agendamento.html
+++ b/templates/agendamento/editar_agendamento.html
@@ -81,7 +81,7 @@
             </div>
             
             <div class="d-flex justify-content-end gap-2">
-              <a href="{{ url_for('routes.listar_agendamentos') }}" class="btn btn-secondary">Cancelar</a>
+              <a href="{{ url_for('agendamento_routes.listar_agendamentos') }}" class="btn btn-secondary">Cancelar</a>
               <button type="submit" class="btn btn-primary">Salvar Alterações</button>
             </div>
           </form>

--- a/templates/agendamento/editar_sala_visitacao.html
+++ b/templates/agendamento/editar_sala_visitacao.html
@@ -33,7 +33,7 @@
             </div>
             
             <div class="d-flex justify-content-between">
-              <a href="{{ url_for('routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-secondary">
+              <a href="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-secondary">
                 <i class="bi bi-arrow-left"></i> Cancelar
               </a>
               <button type="submit" class="btn btn-success">

--- a/templates/agendamento/eventos_agendamento.html
+++ b/templates/agendamento/eventos_agendamento.html
@@ -71,17 +71,17 @@
                                                     <td>
                                                         <div class="btn-group">
                                                             {% if evento.configuracoes_agendamento %}
-                                                                <a href="{{ url_for('routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
+                                                                <a href="{{ url_for('agendamento_routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
                                                                     <i class="fas fa-list"></i> Agendamentos
                                                                 </a>
-                                                                <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
+                                                                <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
                                                                     <i class="fas fa-clock"></i> Horários
                                                                 </a>
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
                                                                     <i class="fas fa-cog"></i> Editar
                                                                 </a>
                                                             {% else %}
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
                                                                     <i class="fas fa-plus-circle"></i> Configurar Agendamento
                                                                 </a>
                                                             {% endif %}
@@ -118,14 +118,14 @@
                                                     <td>
                                                         <div class="btn-group">
                                                             {% if evento.configuracoes_agendamento %}
-                                                                <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
+                                                                <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
                                                                     <i class="fas fa-clock"></i> Horários
                                                                 </a>
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
                                                                     <i class="fas fa-cog"></i> Editar
                                                                 </a>
                                                             {% else %}
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
                                                                     <i class="fas fa-plus-circle"></i> Configurar Agendamento
                                                                 </a>
                                                             {% endif %}
@@ -170,7 +170,7 @@
                                                     <td>
                                                         <div class="btn-group">
                                                             {% if evento.agendamentos_count %}
-                                                                <a href="{{ url_for('routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
+                                                                <a href="{{ url_for('agendamento_routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
                                                                     <i class="fas fa-list"></i> Ver Agendamentos
                                                                 </a>
                                                                 <a href="{{ url_for('routes.gerar_relatorio_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
@@ -206,7 +206,7 @@
                 </div>
                 <div class="card-body">
                     <div class="list-group mb-3">
-                        <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
+                        <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
                             <div class="d-flex align-items-center">
                                 <i class="fas fa-qrcode fa-2x me-3 text-primary"></i>
                                 <div>

--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -39,7 +39,7 @@
           <i class="bi bi-calendar-plus"></i> Gerar Novos Horários
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.gerar_horarios_agendamento', evento_id=evento.id) }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento.id) }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="data_inicial" class="form-label">Data Inicial</label>
@@ -67,7 +67,7 @@
               <button type="submit" class="btn btn-success">
                 <i class="bi bi-calendar-plus"></i> Gerar Horários
               </button>
-              <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
+              <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
                 <i class="bi bi-clock-history"></i> Ver Horários Existentes
               </a>
               <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">

--- a/templates/agendamento/importar_agendamentos.html
+++ b/templates/agendamento/importar_agendamentos.html
@@ -25,7 +25,7 @@
           </div>
           {% endif %}
 
-          <form method="POST" action="{{ url_for('routes.importar_agendamentos') }}" enctype="multipart/form-data">
+          <form method="POST" action="{{ url_for('agendamento_routes.importar_agendamentos') }}" enctype="multipart/form-data">
             <!-- Evento -->
             <div class="mb-3">
               <label for="evento_id" class="form-label">Evento <span class="text-danger">*</span></label>

--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -14,7 +14,7 @@
       <h5 class="mb-0">Filtros</h5>
     </div>
     <div class="card-body">
-      <form method="GET" action="{{ url_for('routes.listar_agendamentos') }}">
+      <form method="GET" action="{{ url_for('agendamento_routes.listar_agendamentos') }}">
         <div class="row g-3">
           <div class="col-md-4">
             <label for="data_inicio" class="form-label">Data Inicial</label>
@@ -77,7 +77,7 @@
             <button type="submit" class="btn btn-primary">
               <i class="bi bi-funnel-fill me-1"></i>Filtrar
             </button>
-            <a href="{{ url_for('routes.listar_agendamentos') }}" class="btn btn-outline-secondary">Limpar</a>
+            <a href="{{ url_for('agendamento_routes.listar_agendamentos') }}" class="btn btn-outline-secondary">Limpar</a>
           </div>
         </div>
       </form>
@@ -282,7 +282,7 @@
       <nav aria-label="Navegação de páginas">
         <ul class="pagination justify-content-center mb-0">
           <li class="page-item {{ 'disabled' if pagination.page == 1 else '' }}">
-            <a class="page-link" href="{{ url_for('routes.listar_agendamentos', page=pagination.page-1, **request.args) if pagination.page > 1 else '#' }}">
+            <a class="page-link" href="{{ url_for('agendamento_routes.listar_agendamentos', page=pagination.page-1, **request.args) if pagination.page > 1 else '#' }}">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
@@ -290,7 +290,7 @@
           {% for p in range(1, pagination.pages + 1) %}
             {% if p >= pagination.page - 2 and p <= pagination.page + 2 %}
               <li class="page-item {{ 'active' if p == pagination.page else '' }}">
-                <a class="page-link" href="{{ url_for('routes.listar_agendamentos', page=p, **request.args) }}">
+                <a class="page-link" href="{{ url_for('agendamento_routes.listar_agendamentos', page=p, **request.args) }}">
                   {{ p }}
                 </a>
               </li>
@@ -298,7 +298,7 @@
           {% endfor %}
           
           <li class="page-item {{ 'disabled' if pagination.page == pagination.pages else '' }}">
-            <a class="page-link" href="{{ url_for('routes.listar_agendamentos', page=pagination.page+1, **request.args) if pagination.page < pagination.pages else '#' }}">
+            <a class="page-link" href="{{ url_for('agendamento_routes.listar_agendamentos', page=pagination.page+1, **request.args) if pagination.page < pagination.pages else '#' }}">
               <span aria-hidden="true">&raquo;</span>
             </a>
           </li>

--- a/templates/agendamento/listar_horarios_agendamento.html
+++ b/templates/agendamento/listar_horarios_agendamento.html
@@ -21,13 +21,13 @@
       </div>
       
       <div class="d-flex justify-content-end mb-4">
-        <a href="{{ url_for('routes.gerar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-success me-2">
+        <a href="{{ url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-success me-2">
           <i class="bi bi-calendar-plus"></i> Gerar Novos Horários
         </a>
-        <a href="{{ url_for('routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-info me-2">
+        <a href="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-info me-2">
           <i class="bi bi-door-open"></i> Gerenciar Salas
         </a>
-        <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-warning">
+        <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-warning">
           <i class="bi bi-gear"></i> Configurações
         </a>
       </div>

--- a/templates/agendamento/salas_visitacao.html
+++ b/templates/agendamento/salas_visitacao.html
@@ -13,7 +13,7 @@
           <i class="bi bi-plus-circle"></i> Adicionar Nova Sala
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.salas_visitacao', evento_id=evento.id) }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}">
             <div class="row">
               <div class="col-md-4 mb-3">
                 <label for="nome" class="form-label">Nome da Sala *</label>
@@ -87,7 +87,7 @@
       </div>
       
       <div class="mt-4">
-        <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
+        <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
           <i class="bi bi-clock-history"></i> Gerenciar Horários
         </a>
         <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">

--- a/templates/checkin/confirmar_checkin.html
+++ b/templates/checkin/confirmar_checkin.html
@@ -85,7 +85,7 @@
         </div>
         
         <div class="d-flex justify-content-between mb-4">
-          <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="btn btn-secondary">
+          <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="btn btn-secondary">
             <i class="bi bi-arrow-left"></i> Voltar
           </a>
           

--- a/templates/dashboard/dashboard_professor.html
+++ b/templates/dashboard/dashboard_professor.html
@@ -29,7 +29,7 @@
               <i class="bi bi-calendar-plus me-3 fs-5 text-success"></i>
               <span>Criar Agendamento</span>
             </a>
-            <a href="{{ url_for('routes.meus_agendamentos') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
+            <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
               <i class="bi bi-calendar-week me-3 fs-5 text-success"></i>
               <span>Meus Agendamentos</span>
             </a>
@@ -119,7 +119,7 @@
           title: '{{ agendamento.escola_nome }} ({{ agendamento.turma }})',
           start: '{{ agendamento.data_inicio }}',
           end: '{{ agendamento.data_fim }}',
-          url: '{{ url_for("routes.detalhes_agendamento", agendamento_id=agendamento.id) }}'
+          url: '{{ url_for("agendamento_routes.detalhes_agendamento", agendamento_id=agendamento.id) }}'
         }{% if not loop.last %},{% endif %}
         {% endfor %}
       ],

--- a/templates/emails/confirmacao_agendamento.html
+++ b/templates/emails/confirmacao_agendamento.html
@@ -75,7 +75,7 @@
         <p>No dia da visita, apresente o QR Code ou o comprovante impresso para agilizar o check-in.</p>
         
         <center>
-            <a href="{{ url_for('routes.meus_agendamentos', _external=True) }}" class="btn">Acessar Meus Agendamentos</a>
+            <a href="{{ url_for('agendamento_routes.meus_agendamentos', _external=True) }}" class="btn">Acessar Meus Agendamentos</a>
         </center>
         
         <p>Se precisar cancelar ou modificar seu agendamento, faça isso com pelo menos {{ evento.configuracoes_agendamento[0].prazo_cancelamento if evento.configuracoes_agendamento else 24 }} horas de antecedência para evitar bloqueios temporários.</p>
@@ -284,7 +284,7 @@
         <p>Se por algum motivo você não puder comparecer, por favor cancele o agendamento o quanto antes para liberar a vaga para outros interessados.</p>
         
         <center>
-            <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
+            <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
         </center>
         
         <p>Estamos ansiosos para recebê-los amanhã!</p>
@@ -374,7 +374,7 @@
         <p>Você pode visualizar todos os detalhes deste agendamento no sistema.</p>
         
         <center>
-            <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
+            <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
         </center>
         
         <div class="footer">

--- a/templates/professor/adicionar_alunos.html
+++ b/templates/professor/adicionar_alunos.html
@@ -142,7 +142,7 @@
             <i class="fas fa-qrcode"></i> Ver QR Code
         </a>
         
-        <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>

--- a/templates/professor/cancelar_agendamento.html
+++ b/templates/professor/cancelar_agendamento.html
@@ -60,7 +60,7 @@
                     <button type="submit" class="btn btn-danger">
                         <i class="fas fa-times"></i> Confirmar Cancelamento
                     </button>
-                    <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary">
+                    <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
                         <i class="fas fa-chevron-left"></i> Voltar
                     </a>
                 </div>

--- a/templates/professor/meus_agendamentos.html
+++ b/templates/professor/meus_agendamentos.html
@@ -15,7 +15,7 @@
                     <i class="fas fa-filter me-2"></i>Filtrar
                 </div>
                 <div class="card-body">
-                    <form method="GET" action="{{ url_for('routes.meus_agendamentos') }}" class="row g-2 align-items-center">
+                    <form method="GET" action="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="row g-2 align-items-center">
                         <div class="col-md-4">
                             <select name="status" class="form-select">
                                 <option value="">Todos os status</option>
@@ -31,7 +31,7 @@
                         </div>
                         {% if status_filtro %}
                         <div class="col-auto">
-                            <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-outline-secondary">
+                            <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-outline-secondary">
                                 <i class="fas fa-times me-1"></i>Limpar
                             </a>
                         </div>
@@ -83,7 +83,7 @@
                                             </td>
                                             <td>
                                                 <div class="d-flex flex-wrap justify-content-center gap-1">
-                                                    <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" 
+                                                    <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id) }}"
                                                        class="btn btn-sm btn-outline-info" title="Detalhes">
                                                         <i class="fas fa-info-circle me-1"></i>Detalhes
                                                     </a>

--- a/templates/professor/qrcode_agendamento.html
+++ b/templates/professor/qrcode_agendamento.html
@@ -48,7 +48,7 @@
         <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
-        <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>
@@ -60,7 +60,7 @@
     {% endif %}
     
     <div class="mt-4">
-        <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-primary">
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-primary">
             <i class="fas fa-calendar-alt"></i> Meus Agendamentos
         </a>
         <a href="{{ url_for('dashboard_participante_routes.dashboard_participante') }}" class="btn btn-secondary">


### PR DESCRIPTION
## Summary
- update `agendamento_routes` to use its own blueprint name for redirects
- fix associated template links to use `agendamento_routes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772c7d78083249db1e4823de63c56