### PR TITLE
Fix blueprint prefixes in templates

### DIFF
--- a/templates/agendamento/configurar_agendamentos.html
+++ b/templates/agendamento/configurar_agendamentos.html
@@ -30,7 +30,7 @@
           <i class="bi bi-calendar-check"></i> Regras de Agendamento
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="prazo_cancelamento" class="form-label">Prazo para Cancelamento (horas)</label>
@@ -141,7 +141,7 @@
               <button type="submit" class="btn btn-success">
                 <i class="bi bi-save"></i> Salvar Configurações
               </button>
-              <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">
+              <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-secondary">
                 <i class="bi bi-x"></i> Cancelar
               </a>
             </div>

--- a/templates/agendamento/configurar_horarios_agendamento.html
+++ b/templates/agendamento/configurar_horarios_agendamento.html
@@ -20,7 +20,7 @@
     <div class="card-body">
       <div class="row align-items-center">
         <div class="col-md-8">
-          <form method="GET" action="{{ url_for('routes.configurar_horarios_agendamento') }}">
+          <form method="GET" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
             <div class="input-group">
               <select class="form-select" id="evento_id" name="evento_id" required>
                 <option value="">Selecione um evento</option>
@@ -35,7 +35,7 @@
           </form>
         </div>
         <div class="col-md-4 text-end">
-          <a href="{{ url_for('routes.criar_evento') }}" class="btn btn-success">
+          <a href="{{ url_for('evento_routes.criar_evento') }}" class="btn btn-success">
             <i class="bi bi-plus-circle me-2"></i>Criar Novo Evento
           </a>
         </div>
@@ -83,7 +83,7 @@
                   <a href="{{ url_for('routes.editar_horario', horario_id=horario.id) if has_editar_horario else '#' }}" class="btn btn-warning">
                     <i class="bi bi-pencil"></i>
                   </a>
-                  <form method="POST" action="{{ url_for('routes.configurar_horarios_agendamento') }}" class="d-inline" onsubmit="return confirm('Tem certeza que deseja excluir este horário?');">
+                  <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="d-inline" onsubmit="return confirm('Tem certeza que deseja excluir este horário?');">
                     <input type="hidden" name="acao" value="excluir">
                     <input type="hidden" name="horario_id" value="{{ horario.id }}">
                     <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
@@ -115,7 +115,7 @@
           <h5 class="m-0 fw-bold"><i class="bi bi-plus-circle me-2"></i>Adicionar Horário</h5>
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.configurar_horarios_agendamento') }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
             <input type="hidden" name="acao" value="adicionar">
             <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
             
@@ -160,7 +160,7 @@
           <h5 class="m-0 fw-bold"><i class="bi bi-calendar-week me-2"></i>Configurar Período</h5>
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.configurar_horarios_agendamento') }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
             <input type="hidden" name="acao" value="adicionar_periodo">
             <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
             

--- a/templates/agendamento/configurar_regras_inscricao.html
+++ b/templates/agendamento/configurar_regras_inscricao.html
@@ -89,7 +89,7 @@
               {% else %}
                 <div class="alert alert-info">
                   <i class="bi bi-info-circle me-2"></i>Nenhum tipo de inscrição configurado para este evento.
-                  <a href="{{ url_for('routes.configurar_evento') }}" class="alert-link">Clique aqui</a> para configurar os tipos de inscrição.
+                  <a href="{{ url_for('evento_routes.configurar_evento') }}" class="alert-link">Clique aqui</a> para configurar os tipos de inscrição.
                 </div>
               {% endif %}
             </div>
@@ -118,7 +118,7 @@
 <script>
 function carregarEvento(eventoId) {
   if (eventoId) {
-    window.location.href = "{{ url_for('routes.configurar_regras_inscricao') }}?evento_id=" + eventoId;
+    window.location.href = "{{ url_for('inscricao_routes.configurar_regras_inscricao') }}?evento_id=" + eventoId;
   } else {
     document.getElementById('regras-container').classList.add('d-none');
     document.getElementById('sem-evento-msg').classList.remove('d-none');

--- a/templates/agendamento/criar_agendamento.html
+++ b/templates/agendamento/criar_agendamento.html
@@ -20,7 +20,7 @@
       </div>
       {% endif %}
 
-      <form method="POST" action="{{ url_for('routes.criar_agendamento') }}">
+      <form method="POST" action="{{ url_for('agendamento_routes.criar_agendamento') }}">
         <div class="row">
           <!-- Coluna 1: Informações do Evento -->
           <div class="col-md-6">

--- a/templates/agendamento/criar_evento_agendamento.html
+++ b/templates/agendamento/criar_evento_agendamento.html
@@ -20,7 +20,7 @@
       </div>
       {% endif %}
 
-      <form method="POST" action="{{ url_for('routes.configurar_evento') }}" enctype="multipart/form-data">
+      <form method="POST" action="{{ url_for('evento_routes.configurar_evento') }}" enctype="multipart/form-data">
         <div class="row">
           <!-- Coluna 1: Informações Básicas -->
           <div class="col-md-6">

--- a/templates/agendamento/criar_periodo_agendamento.html
+++ b/templates/agendamento/criar_periodo_agendamento.html
@@ -7,7 +7,7 @@
     <h1 class="h2 fw-bold text-primary mb-0">
       <i class="bi bi-calendar-range me-2"></i>Criar Período de Agendamento
     </h1>
-    <a href="{{ url_for('routes.configurar_horarios_agendamento') }}" class="btn btn-outline-primary">
+    <a href="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="btn btn-outline-primary">
       <i class="bi bi-arrow-left me-2"></i>Voltar à Configuração de Horários
     </a>
   </div>
@@ -23,7 +23,7 @@
       </div>
       {% endif %}
 
-      <form method="POST" action="{{ url_for('routes.criar_periodo_agendamento') }}">
+      <form method="POST" action="{{ url_for('agendamento_routes.criar_periodo_agendamento') }}">
         <div class="row">
           <!-- Coluna 1: Informações do Evento e Período -->
           <div class="col-md-6">
@@ -153,7 +153,7 @@
         
         <div class="row mt-4">
           <div class="col-12 d-flex justify-content-between">
-            <a href="{{ url_for('routes.configurar_horarios_agendamento') }}" class="btn btn-secondary">Cancelar</a>
+            <a href="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="btn btn-secondary">Cancelar</a>
             <button type="submit" class="btn btn-success">
               <i class="bi bi-calendar-plus me-2"></i>Criar Período e Horários
             </button>

--- a/templates/agendamento/dashboard_agendamentos.html
+++ b/templates/agendamento/dashboard_agendamentos.html
@@ -124,7 +124,7 @@
                           {% if agendamentos_hoje %}
                             <div class="list-group">
                               {% for agendamento in agendamentos_hoje %}
-                                <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
+                                <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
                                   <div class="d-flex w-100 justify-content-between">
                                     <h5 class="mb-1">{{ agendamento.escola_nome }}</h5>
                                     <small>{{ agendamento.horario.horario_inicio.strftime('%H:%M') }}</small>
@@ -159,7 +159,7 @@
                           {% if proximos_agendamentos %}
                             <div class="list-group">
                               {% for agendamento in proximos_agendamentos %}
-                                <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
+                                <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action">
                                   <div class="d-flex w-100 justify-content-between">
                                     <h5 class="mb-1">{{ agendamento.escola_nome }}</h5>
                                     <small>{{ agendamento.horario.data.strftime('%d/%m/%Y') }}</small>
@@ -190,7 +190,7 @@
                 </div>
                 <div class="card-body">
                   <div class="list-group mb-4">
-                    <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
+                    <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
                       <div class="d-flex align-items-center">
                         <i class="bi bi-qrcode fs-4 me-3 text-primary"></i>
                         <div>
@@ -200,7 +200,7 @@
                       </div>
                     </a>
                     
-                    <a href="{{ url_for('routes.eventos_agendamento') }}" class="list-group-item list-group-item-action">
+                    <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="list-group-item list-group-item-action">
                       <div class="d-flex align-items-center">
                         <i class="bi bi-calendar-plus fs-4 me-3 text-success"></i>
                         <div>
@@ -219,13 +219,13 @@
                         <div class="list-group-item">
                           <h6>{{ evento.nome }}</h6>
                           <div class="btn-group btn-group-sm w-100 mt-2">
-                            <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-primary">
+                            <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-primary">
                               <i class="bi bi-gear"></i> Configurar
                             </a>
-                            <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-outline-info">
+                            <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-outline-info">
                               <i class="bi bi-clock"></i> Horários
                             </a>
-                            <a href="{{ url_for('routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-success">
+                            <a href="{{ url_for('agendamento_routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-outline-success">
                               <i class="bi bi-list-check"></i> Agendamentos
                             </a>
                           </div>
@@ -235,7 +235,7 @@
                   {% endif %}
                 </div>
                 <div class="card-footer">
-                  <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-primary w-100">
+                  <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-primary w-100">
                     <i class="bi bi-gear"></i> Gerenciar Sistema de Agendamento
                   </a>
                 </div>
@@ -289,7 +289,7 @@
                     </div>
                   {% endif %}
                   
-                  <a href="{{ url_for('routes.relatorio_geral_agendamentos') }}" class="btn btn-outline-primary w-100 mt-2">
+                  <a href="{{ url_for('agendamento_routes.relatorio_geral_agendamentos') }}" class="btn btn-outline-primary w-100 mt-2">
                     <i class="bi bi-file-earmark-spreadsheet me-2"></i>Exportar Relatório
                   </a>
                 </div>
@@ -351,7 +351,7 @@
                             <button class="btn btn-info btn-detalhes-agendamento" data-agendamento-id="{{ agendamento.id }}">
                               <i class="bi bi-eye"></i>
                             </button>
-                            <a href="{{ url_for('routes.editar_agendamento', agendamento_id=agendamento.id) }}" 
+                            <a href="{{ url_for('agendamento_routes.editar_agendamento', agendamento_id=agendamento.id) }}" 
                                class="btn btn-warning">
                               <i class="bi bi-pencil"></i>
                             </a>
@@ -381,7 +381,7 @@
                 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalRelatorioAgendamentos">
                   <i class="bi bi-file-earmark-text me-1"></i> Gerar Relatório
                 </button>
-                <a href="{{ url_for('routes.criar_agendamento') }}" class="btn btn-success">
+                <a href="{{ url_for('agendamento_routes.criar_agendamento') }}" class="btn btn-success">
                   <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
                 </a>
               </div>
@@ -399,15 +399,15 @@
                 </div>
                 <div class="card-body">
                   <div class="d-grid gap-3">
-                    <a href="{{ url_for('routes.criar_agendamento') }}" class="btn btn-primary btn-lg">
+                    <a href="{{ url_for('agendamento_routes.criar_agendamento') }}" class="btn btn-primary btn-lg">
                       <i class="bi bi-calendar-plus me-2"></i> Criar Novo Agendamento
                     </a>
                     
-                    <a href="{{ url_for('routes.configurar_horarios_agendamento') }}" class="btn btn-info btn-lg">
+                    <a href="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="btn btn-info btn-lg">
                       <i class="bi bi-clock me-2"></i> Configurar Horários
                     </a>
                     
-                    <a href="{{ url_for('routes.criar_evento_agendamento') }}" class="btn btn-success btn-lg">
+                    <a href="{{ url_for('agendamento_routes.criar_evento_agendamento') }}" class="btn btn-success btn-lg">
                       <i class="bi bi-calendar-event me-2"></i> Criar Evento para Agendamento
                     </a>
                   </div>
@@ -422,15 +422,15 @@
                 </div>
                 <div class="card-body">
                   <div class="d-grid gap-3">
-                    <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="btn btn-dark btn-lg">
+                    <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="btn btn-dark btn-lg">
                       <i class="bi bi-qr-code-scan me-2"></i> Check-in com QR Code
                     </a>
                     
-                    <a href="{{ url_for('routes.importar_agendamentos') }}" class="btn btn-primary btn-lg">
+                    <a href="{{ url_for('agendamento_routes.importar_agendamentos') }}" class="btn btn-primary btn-lg">
                       <i class="bi bi-upload me-2"></i> Importar Agendamentos
                     </a>
 
-                    <a href="{{ url_for('routes.professor_eventos_disponiveis') }}" class="btn btn-primary">
+                    <a href="{{ url_for('agendamento_routes.professor_eventos_disponiveis') }}" class="btn btn-primary">
                       <i class="bi bi-calendar-event me-2"></i> Ver Eventos Disponíveis
                   </a>
                     
@@ -466,7 +466,7 @@
                       <button type="button" 
                               id="btnToggleAgendamentoPublico"
                               class="btn btn-{{ 'success' if config_agendamento and config_agendamento.agendamento_publico else 'danger' }}"
-                              data-toggle-url="{{ url_for('routes.toggle_agendamento_publico') }}"
+                              data-toggle-url="{{ url_for('agendamento_routes.toggle_agendamento_publico') }}"
                       >
                         {{ 'Ativo' if config_agendamento and config_agendamento.agendamento_publico else 'Desativado' }}
                       </button>
@@ -481,7 +481,7 @@
                       <button type="button"
                               id="btnToggleAprovacaoManual"
                               class="btn btn-{{ 'success' if config_agendamento and config_agendamento.aprovacao_manual else 'danger' }}"
-                              data-toggle-url="{{ url_for('routes.toggle_aprovacao_manual') }}"
+                              data-toggle-url="{{ url_for('agendamento_routes.toggle_aprovacao_manual') }}"
                       >
                         {{ 'Ativo' if config_agendamento and config_agendamento.aprovacao_manual else 'Desativado' }}
                       </button>
@@ -496,7 +496,7 @@
                       <button type="button" 
                               id="btnToggleLimiteCapacidade"
                               class="btn btn-{{ 'success' if config_agendamento and config_agendamento.aplicar_limite_capacidade else 'danger' }}"
-                              data-toggle-url="{{ url_for('routes.toggle_limite_capacidade') }}"
+                              data-toggle-url="{{ url_for('agendamento_routes.toggle_limite_capacidade') }}"
                       >
                         {{ 'Ativo' if config_agendamento and config_agendamento.aplicar_limite_capacidade else 'Desativado' }}
                       </button>
@@ -506,7 +506,7 @@
                   <div class="card bg-light mb-4">
                     <div class="card-body">
                       <h6 class="mb-3">Configurações Adicionais</h6>
-                      <form action="{{ url_for('routes.salvar_config_agendamento') }}" method="POST">
+                      <form action="{{ url_for('agendamento_routes.salvar_config_agendamento') }}" method="POST">
                         <div class="mb-3">
                           <label for="capacidadeMaxima" class="form-label">Capacidade Máxima por Horário</label>
                           <input type="number" class="form-control" id="capacidadeMaxima" name="capacidade_maxima" value="{{ config_agendamento.capacidade_maxima if config_agendamento else 30 }}" min="1">
@@ -577,7 +577,7 @@
                     </table>
                   </div>
                   
-                  <a href="{{ url_for('routes.criar_periodo_agendamento') }}" class="btn btn-primary w-100 mb-3">
+                  <a href="{{ url_for('agendamento_routes.criar_periodo_agendamento') }}" class="btn btn-primary w-100 mb-3">
                     <i class="bi bi-calendar-plus me-2"></i> Adicionar Novo Período
                   </a>
                   
@@ -602,21 +602,21 @@
                   </div>
                   
                   <div class="d-grid gap-3 mt-3">
-                    <form action="{{ url_for('routes.excluir_todos_agendamentos') }}" method="post"
+                    <form action="{{ url_for('agendamento_routes.excluir_todos_agendamentos') }}" method="post"
                           onsubmit="return confirm('ATENÇÃO: Esta ação excluirá TODOS os agendamentos e não pode ser desfeita! Tem certeza que deseja continuar?');">
                       <button type="submit" class="btn btn-danger w-100">
                         <i class="bi bi-trash-fill me-2"></i> Excluir Todos os Agendamentos
                       </button>
                     </form>
                     
-                    <form action="{{ url_for('routes.resetar_configuracoes_agendamento') }}" method="post"
+                    <form action="{{ url_for('agendamento_routes.resetar_configuracoes_agendamento') }}" method="post"
                           onsubmit="return confirm('Tem certeza que deseja restaurar as configurações padrão?');">
                       <button type="submit" class="btn btn-warning w-100">
                         <i class="bi bi-arrow-repeat me-2"></i> Restaurar Configurações Padrão
                       </button>
                     </form>
                     
-                    <a href="{{ url_for('routes.exportar_agendamentos') }}" class="btn btn-info w-100">
+                    <a href="{{ url_for('agendamento_routes.exportar_agendamentos') }}" class="btn btn-info w-100">
                       <i class="bi bi-download me-2"></i> Exportar Agendamentos
                     </a>
                   </div>

--- a/templates/agendamento/detalhes_agendamentos.html
+++ b/templates/agendamento/detalhes_agendamentos.html
@@ -65,6 +65,6 @@
     </div>
     {% endif %}
 
-    <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary mt-3">Voltar</a>
+    <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary mt-3">Voltar</a>
 </div>
 {% endblock %}

--- a/templates/agendamento/editar_agendamento.html
+++ b/templates/agendamento/editar_agendamento.html
@@ -81,7 +81,7 @@
             </div>
             
             <div class="d-flex justify-content-end gap-2">
-              <a href="{{ url_for('routes.listar_agendamentos') }}" class="btn btn-secondary">Cancelar</a>
+              <a href="{{ url_for('agendamento_routes.listar_agendamentos') }}" class="btn btn-secondary">Cancelar</a>
               <button type="submit" class="btn btn-primary">Salvar Alterações</button>
             </div>
           </form>

--- a/templates/agendamento/editar_sala_visitacao.html
+++ b/templates/agendamento/editar_sala_visitacao.html
@@ -33,7 +33,7 @@
             </div>
             
             <div class="d-flex justify-content-between">
-              <a href="{{ url_for('routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-secondary">
+              <a href="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-secondary">
                 <i class="bi bi-arrow-left"></i> Cancelar
               </a>
               <button type="submit" class="btn btn-success">

--- a/templates/agendamento/eventos_agendamento.html
+++ b/templates/agendamento/eventos_agendamento.html
@@ -71,17 +71,17 @@
                                                     <td>
                                                         <div class="btn-group">
                                                             {% if evento.configuracoes_agendamento %}
-                                                                <a href="{{ url_for('routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
+                                                                <a href="{{ url_for('agendamento_routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
                                                                     <i class="fas fa-list"></i> Agendamentos
                                                                 </a>
-                                                                <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
+                                                                <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
                                                                     <i class="fas fa-clock"></i> Horários
                                                                 </a>
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
                                                                     <i class="fas fa-cog"></i> Editar
                                                                 </a>
                                                             {% else %}
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
                                                                     <i class="fas fa-plus-circle"></i> Configurar Agendamento
                                                                 </a>
                                                             {% endif %}
@@ -118,14 +118,14 @@
                                                     <td>
                                                         <div class="btn-group">
                                                             {% if evento.configuracoes_agendamento %}
-                                                                <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
+                                                                <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-sm btn-info">
                                                                     <i class="fas fa-clock"></i> Horários
                                                                 </a>
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-warning">
                                                                     <i class="fas fa-cog"></i> Editar
                                                                 </a>
                                                             {% else %}
-                                                                <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
+                                                                <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
                                                                     <i class="fas fa-plus-circle"></i> Configurar Agendamento
                                                                 </a>
                                                             {% endif %}
@@ -170,10 +170,10 @@
                                                     <td>
                                                         <div class="btn-group">
                                                             {% if evento.agendamentos_count %}
-                                                                <a href="{{ url_for('routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
+                                                                <a href="{{ url_for('agendamento_routes.listar_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-success">
                                                                     <i class="fas fa-list"></i> Ver Agendamentos
                                                                 </a>
-                                                                <a href="{{ url_for('routes.gerar_relatorio_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
+                                                                <a href="{{ url_for('agendamento_routes.gerar_relatorio_agendamentos', evento_id=evento.id) }}" class="btn btn-sm btn-primary">
                                                                     <i class="fas fa-file-pdf"></i> Relatório
                                                                 </a>
                                                             {% else %}
@@ -206,7 +206,7 @@
                 </div>
                 <div class="card-body">
                     <div class="list-group mb-3">
-                        <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
+                        <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="list-group-item list-group-item-action">
                             <div class="d-flex align-items-center">
                                 <i class="fas fa-qrcode fa-2x me-3 text-primary"></i>
                                 <div>
@@ -216,7 +216,7 @@
                             </div>
                         </a>
                         
-                        <a href="{{ url_for('routes.relatorio_geral_agendamentos') }}" class="list-group-item list-group-item-action">
+                        <a href="{{ url_for('agendamento_routes.relatorio_geral_agendamentos') }}" class="list-group-item list-group-item-action">
                             <div class="d-flex align-items-center">
                                 <i class="fas fa-chart-bar fa-2x me-3 text-success"></i>
                                 <div>

--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -39,7 +39,7 @@
           <i class="bi bi-calendar-plus"></i> Gerar Novos Horários
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.gerar_horarios_agendamento', evento_id=evento.id) }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento.id) }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="data_inicial" class="form-label">Data Inicial</label>
@@ -67,10 +67,10 @@
               <button type="submit" class="btn btn-success">
                 <i class="bi bi-calendar-plus"></i> Gerar Horários
               </button>
-              <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
+              <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
                 <i class="bi bi-clock-history"></i> Ver Horários Existentes
               </a>
-              <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">
+              <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-secondary">
                 <i class="bi bi-arrow-left"></i> Voltar
               </a>
             </div>

--- a/templates/agendamento/importar_agendamentos.html
+++ b/templates/agendamento/importar_agendamentos.html
@@ -25,7 +25,7 @@
           </div>
           {% endif %}
 
-          <form method="POST" action="{{ url_for('routes.importar_agendamentos') }}" enctype="multipart/form-data">
+          <form method="POST" action="{{ url_for('agendamento_routes.importar_agendamentos') }}" enctype="multipart/form-data">
             <!-- Evento -->
             <div class="mb-3">
               <label for="evento_id" class="form-label">Evento <span class="text-danger">*</span></label>
@@ -96,7 +96,7 @@
           <div class="alert alert-warning">
             <i class="bi bi-exclamation-triangle me-2"></i>Importante: Certifique-se de que os horários informados estejam configurados no evento selecionado.
           </div>
-          <a href="{{ url_for('routes.download_modelo_importacao') }}" class="btn btn-outline-primary mt-2">
+          <a href="{{ url_for('agendamento_routes.download_modelo_importacao') }}" class="btn btn-outline-primary mt-2">
             <i class="bi bi-download me-2"></i>Baixar Modelo de Planilha
           </a>
         </div>
@@ -161,7 +161,7 @@
           </div>
           
           <div class="d-grid gap-2 mt-3">
-            <a href="{{ url_for('routes.exportar_log_importacao') }}" class="btn btn-outline-secondary">
+            <a href="{{ url_for('agendamento_routes.exportar_log_importacao') }}" class="btn btn-outline-secondary">
               <i class="bi bi-download me-2"></i>Baixar Log Completo
             </a>
             <a href="{{ url_for('dashboard_routes.dashboard_agendamentos') }}" class="btn btn-primary">

--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -14,7 +14,7 @@
       <h5 class="mb-0">Filtros</h5>
     </div>
     <div class="card-body">
-      <form method="GET" action="{{ url_for('routes.listar_agendamentos') }}">
+      <form method="GET" action="{{ url_for('agendamento_routes.listar_agendamentos') }}">
         <div class="row g-3">
           <div class="col-md-4">
             <label for="data_inicio" class="form-label">Data Inicial</label>
@@ -77,7 +77,7 @@
             <button type="submit" class="btn btn-primary">
               <i class="bi bi-funnel-fill me-1"></i>Filtrar
             </button>
-            <a href="{{ url_for('routes.listar_agendamentos') }}" class="btn btn-outline-secondary">Limpar</a>
+            <a href="{{ url_for('agendamento_routes.listar_agendamentos') }}" class="btn btn-outline-secondary">Limpar</a>
           </div>
         </div>
       </form>
@@ -89,14 +89,14 @@
     <div class="card-header bg-white d-flex justify-content-between align-items-center">
       <h5 class="mb-0">Lista de Agendamentos</h5>
       <div>
-        <a href="{{ url_for('routes.exportar_agendamentos_pdf') }}" class="btn btn-sm btn-outline-primary">
+        <a href="{{ url_for('agendamento_routes.exportar_agendamentos_pdf') }}" class="btn btn-sm btn-outline-primary">
           <i class="bi bi-file-pdf me-1"></i> Exportar PDF
         </a>
-        <a href="{{ url_for('routes.exportar_agendamentos_csv') }}" class="btn btn-sm btn-outline-success">
+        <a href="{{ url_for('agendamento_routes.exportar_agendamentos_csv') }}" class="btn btn-sm btn-outline-success">
           <i class="bi bi-file-excel me-1"></i> Exportar CSV
         </a>
         {% if current_user.tipo in ['admin', 'cliente', 'ministrante'] %}
-        <a href="{{ url_for('routes.criar_agendamento') }}" class="btn btn-sm btn-primary ms-2">
+        <a href="{{ url_for('agendamento_routes.criar_agendamento') }}" class="btn btn-sm btn-primary ms-2">
           <i class="bi bi-plus-circle me-1"></i> Novo Agendamento
         </a>
         {% endif %}
@@ -137,13 +137,13 @@
                   </td>
                   <td class="text-center">
                     <div class="btn-group btn-group-sm">
-                      <a href="{{ url_for('routes.visualizar_agendamento', agendamento_id=agendamento.id) }}" 
+                      <a href="{{ url_for('agendamento_routes.visualizar_agendamento', agendamento_id=agendamento.id) }}" 
                          class="btn btn-outline-info" data-bs-toggle="tooltip" title="Visualizar">
                         <i class="bi bi-eye"></i>
                       </a>
                       
                       {% if current_user.tipo in ['admin', 'cliente', 'ministrante'] or current_user.id == agendamento.usuario_id %}
-                        <a href="{{ url_for('routes.editar_agendamento', agendamento_id=agendamento.id) }}" 
+                        <a href="{{ url_for('agendamento_routes.editar_agendamento', agendamento_id=agendamento.id) }}" 
                            class="btn btn-outline-warning" data-bs-toggle="tooltip" title="Editar">
                           <i class="bi bi-pencil"></i>
                         </a>
@@ -189,7 +189,7 @@
                             <h5 class="modal-title">Cancelar Agendamento</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                           </div>
-                          <form action="{{ url_for('routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
+                          <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
                             <div class="modal-body">
                               <input type="hidden" name="status" value="cancelado">
                               <p>Tem certeza que deseja cancelar este agendamento?</p>
@@ -215,7 +215,7 @@
                             <h5 class="modal-title">Confirmar Agendamento</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                           </div>
-                          <form action="{{ url_for('routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
+                          <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
                             <div class="modal-body">
                               <input type="hidden" name="status" value="confirmado">
                               <p>Deseja confirmar este agendamento?</p>
@@ -241,7 +241,7 @@
                             <h5 class="modal-title">Marcar como Realizado</h5>
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                           </div>
-                          <form action="{{ url_for('routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
+                          <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
                             <div class="modal-body">
                               <input type="hidden" name="status" value="realizado">
                               <p>Confirma que este agendamento foi realizado?</p>
@@ -282,7 +282,7 @@
       <nav aria-label="Navegação de páginas">
         <ul class="pagination justify-content-center mb-0">
           <li class="page-item {{ 'disabled' if pagination.page == 1 else '' }}">
-            <a class="page-link" href="{{ url_for('routes.listar_agendamentos', page=pagination.page-1, **request.args) if pagination.page > 1 else '#' }}">
+            <a class="page-link" href="{{ url_for('agendamento_routes.listar_agendamentos', page=pagination.page-1, **request.args) if pagination.page > 1 else '#' }}">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
@@ -290,7 +290,7 @@
           {% for p in range(1, pagination.pages + 1) %}
             {% if p >= pagination.page - 2 and p <= pagination.page + 2 %}
               <li class="page-item {{ 'active' if p == pagination.page else '' }}">
-                <a class="page-link" href="{{ url_for('routes.listar_agendamentos', page=p, **request.args) }}">
+                <a class="page-link" href="{{ url_for('agendamento_routes.listar_agendamentos', page=p, **request.args) }}">
                   {{ p }}
                 </a>
               </li>
@@ -298,7 +298,7 @@
           {% endfor %}
           
           <li class="page-item {{ 'disabled' if pagination.page == pagination.pages else '' }}">
-            <a class="page-link" href="{{ url_for('routes.listar_agendamentos', page=pagination.page+1, **request.args) if pagination.page < pagination.pages else '#' }}">
+            <a class="page-link" href="{{ url_for('agendamento_routes.listar_agendamentos', page=pagination.page+1, **request.args) if pagination.page < pagination.pages else '#' }}">
               <span aria-hidden="true">&raquo;</span>
             </a>
           </li>

--- a/templates/agendamento/listar_horarios_agendamento.html
+++ b/templates/agendamento/listar_horarios_agendamento.html
@@ -21,13 +21,13 @@
       </div>
       
       <div class="d-flex justify-content-end mb-4">
-        <a href="{{ url_for('routes.gerar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-success me-2">
+        <a href="{{ url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-success me-2">
           <i class="bi bi-calendar-plus"></i> Gerar Novos Horários
         </a>
-        <a href="{{ url_for('routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-info me-2">
+        <a href="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}" class="btn btn-info me-2">
           <i class="bi bi-door-open"></i> Gerenciar Salas
         </a>
-        <a href="{{ url_for('routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-warning">
+        <a href="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}" class="btn btn-warning">
           <i class="bi bi-gear"></i> Configurações
         </a>
       </div>
@@ -109,7 +109,7 @@
       </div>
       
       <div class="mt-4">
-        <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-secondary">
           <i class="bi bi-arrow-left"></i> Voltar
         </a>
       </div>
@@ -125,7 +125,7 @@
         <h5 class="modal-title" id="editarHorarioModalLabel">Editar Horário</h5>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <form id="editarHorarioForm" method="POST" action="{{ url_for('routes.editar_horario_agendamento') }}">
+      <form id="editarHorarioForm" method="POST" action="{{ url_for('agendamento_routes.editar_horario_agendamento') }}">
         <div class="modal-body">
           <input type="hidden" id="horario_id" name="horario_id">
           
@@ -179,7 +179,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <form id="excluirHorarioForm" method="POST" action="{{ url_for('routes.excluir_horario_agendamento') }}">
+        <form id="excluirHorarioForm" method="POST" action="{{ url_for('agendamento_routes.excluir_horario_agendamento') }}">
           <input type="hidden" id="excluir_horario_id" name="horario_id">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
           <button type="submit" class="btn btn-danger">Confirmar Exclusão</button>

--- a/templates/agendamento/relatorio_geral_agendamentos.html
+++ b/templates/agendamento/relatorio_geral_agendamentos.html
@@ -12,7 +12,7 @@
             <i class="fas fa-filter"></i> Filtros
         </div>
         <div class="card-body">
-            <form method="GET" action="{{ url_for('routes.relatorio_geral_agendamentos') }}">
+            <form method="GET" action="{{ url_for('agendamento_routes.relatorio_geral_agendamentos') }}">
                 <div class="row">
                     <div class="col-md-4 mb-3">
                         <label for="data_inicio" class="form-label">Data Inicial:</label>
@@ -29,7 +29,7 @@
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-search"></i> Filtrar
                             </button>
-                            <a href="{{ url_for('routes.relatorio_geral_agendamentos') }}" class="btn btn-outline-secondary">
+                            <a href="{{ url_for('agendamento_routes.relatorio_geral_agendamentos') }}" class="btn btn-outline-secondary">
                                 <i class="fas fa-times"></i> Limpar
                             </a>
                             <button type="submit" name="gerar_pdf" value="1" class="btn btn-danger">
@@ -236,10 +236,10 @@
     </div>
     
     <div class="mt-4">
-        <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
-        <button type="button" class="btn btn-danger" onclick="window.location.href='{{ url_for('routes.relatorio_geral_agendamentos', data_inicio=filtros.data_inicio.strftime('%Y-%m-%d') if filtros.data_inicio else '', data_fim=filtros.data_fim.strftime('%Y-%m-%d') if filtros.data_fim else '', gerar_pdf=1) }}'">
+        <button type="button" class="btn btn-danger" onclick="window.location.href='{{ url_for('agendamento_routes.relatorio_geral_agendamentos', data_inicio=filtros.data_inicio.strftime('%Y-%m-%d') if filtros.data_inicio else '', data_fim=filtros.data_fim.strftime('%Y-%m-%d') if filtros.data_fim else '', gerar_pdf=1) }}'">
             <i class="fas fa-file-pdf"></i> Gerar PDF
         </button>
     </div>

--- a/templates/agendamento/salas_visitacao.html
+++ b/templates/agendamento/salas_visitacao.html
@@ -13,7 +13,7 @@
           <i class="bi bi-plus-circle"></i> Adicionar Nova Sala
         </div>
         <div class="card-body">
-          <form method="POST" action="{{ url_for('routes.salas_visitacao', evento_id=evento.id) }}">
+          <form method="POST" action="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}">
             <div class="row">
               <div class="col-md-4 mb-3">
                 <label for="nome" class="form-label">Nome da Sala *</label>
@@ -87,10 +87,10 @@
       </div>
       
       <div class="mt-4">
-        <a href="{{ url_for('routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
+        <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-info">
           <i class="bi bi-clock-history"></i> Gerenciar Horários
         </a>
-        <a href="{{ url_for('routes.eventos_agendamento') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-secondary">
           <i class="bi bi-arrow-left"></i> Voltar
         </a>
       </div>
@@ -133,7 +133,7 @@
       var salaNome = button.getAttribute('data-sala-nome');
       
       document.getElementById('nomeSala').textContent = salaNome;
-      document.getElementById('excluirSalaForm').action = "{{ url_for('routes.excluir_sala_visitacao', sala_id=0) }}".replace('0', salaId);
+      document.getElementById('excluirSalaForm').action = "{{ url_for('agendamento_routes.excluir_sala_visitacao', sala_id=0) }}".replace('0', salaId);
     });
   });
 </script>

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -234,7 +234,7 @@
                     <span>Nenhum lote disponível para inscrição no momento.</span>
                 </div>
                 {% else %}
-                <form method="POST" action="{{ url_for('routes.cadastro_participante', identifier=token) }}" id="registrationForm">
+                <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', identifier=token) }}" id="registrationForm">
                     <input type="hidden" id="evento_id" name="evento_id" value="{{ evento.id if evento else '' }}">
                     
                     <div class="form-grid">
@@ -396,7 +396,7 @@
                             </button>
                             
                             <div class="login-prompt">
-                                Já possui uma conta? <a href="{{ url_for('routes.login') }}">Faça login aqui</a>
+                                Já possui uma conta? <a href="{{ url_for('auth_routes.login') }}">Faça login aqui</a>
                             </div>
                         </div>
                     </div>

--- a/templates/auth/cadastro_usuario.html
+++ b/templates/auth/cadastro_usuario.html
@@ -91,7 +91,7 @@
         {% endif %}
       {% endwith %}
 
-      <form method="POST" action="{{ url_for('routes.cadastro_participante', token=token) if token else url_for('routes.cadastro_participante') }}">
+      <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', token=token) if token else url_for('inscricao_routes.cadastro_participante') }}">
         <div class="form-grid">
           <div>
             <label for="nome" class="form-label fw-semibold">Nome Completo</label>
@@ -137,7 +137,7 @@
 
         <div class="text-center mt-4">
           <p class="text-muted mb-0">Já possui conta?
-            <a href="{{ url_for('routes.login') }}" class="text-primary fw-semibold">Acesse aqui</a>
+            <a href="{{ url_for('auth_routes.login') }}" class="text-primary fw-semibold">Acesse aqui</a>
           </p>
         </div>
       </form>

--- a/templates/certificado/templates_certificado.html
+++ b/templates/certificado/templates_certificado.html
@@ -36,7 +36,7 @@
               </td>
               <td>
                 {% if not template.ativo %}
-                <form action="{{ url_for('routes.set_template_ativo', template_id=template.id) }}" method="post" class="d-inline">
+                <form action="{{ url_for('certificado_routes.set_template_ativo', template_id=template.id) }}" method="post" class="d-inline">
                   <button class="btn btn-sm btn-outline-primary">Definir como ativo</button>
                 </form>
                 {% endif %}
@@ -54,7 +54,7 @@
                     <h5 class="modal-title">Editar Template: {{ template.titulo }}</h5>
                     <button class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
                   </div>
-                  <form method="POST" action="{{ url_for('routes.editar_template_certificado', template_id=template.id) }}">
+                  <form method="POST" action="{{ url_for('certificado_routes.editar_template_certificado', template_id=template.id) }}">
                     <div class="modal-body">
                       <div class="form-group mb-3">
                         <label>Título do Template</label>
@@ -92,7 +92,7 @@
           <h5 class="modal-title">Novo Template de Certificado</h5>
           <button class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
         </div>
-        <form method="POST" action="{{ url_for('routes.templates_certificado') }}">
+        <form method="POST" action="{{ url_for('certificado_routes.templates_certificado') }}">
           <div class="modal-body">
             <div class="form-group mb-3">
               <label>Título do Template</label>

--- a/templates/certificado/upload_personalizacao_cert.html
+++ b/templates/certificado/upload_personalizacao_cert.html
@@ -22,7 +22,7 @@
           </h5>
         </div>
         <div class="card-body p-4">
-          <form action="{{ url_for('routes.salvar_personalizacao_certificado') }}" method="POST" enctype="multipart/form-data">
+          <form action="{{ url_for('certificado_routes.salvar_personalizacao_certificado') }}" method="POST" enctype="multipart/form-data">
 
             <div class="mb-4">
               <label class="form-label fw-semibold mb-2">
@@ -104,13 +104,13 @@
                   <td>
                     <div class="d-flex flex-wrap gap-2">
                       {% if not template.ativo %}
-                      <form action="{{ url_for('routes.set_template_ativo', template_id=template.id) }}" method="post">
+                      <form action="{{ url_for('certificado_routes.set_template_ativo', template_id=template.id) }}" method="post">
                         <button class="btn btn-outline-primary btn-sm">
                           <i class="bi bi-check-circle me-1"></i><span class="d-none d-sm-inline">Ativar</span>
                         </button>
                       </form>
                       {% else %}
-                      <form action="{{ url_for('routes.desativar_template_certificado', template_id=template.id) }}" method="post">
+                      <form action="{{ url_for('certificado_routes.desativar_template_certificado', template_id=template.id) }}" method="post">
                         <button class="btn btn-outline-secondary btn-sm">
                           <i class="bi bi-x-circle me-1"></i><span class="d-none d-sm-inline">Desativar</span>
                         </button>
@@ -151,7 +151,7 @@
           </h5>
           <button class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        <form action="{{ url_for('routes.editar_template_certificado', template_id=template.id) }}" method="POST">
+        <form action="{{ url_for('certificado_routes.editar_template_certificado', template_id=template.id) }}" method="POST">
           <div class="modal-body p-4">
             <div class="mb-3">
               <label class="form-label fw-semibold">Título do Template</label>
@@ -186,7 +186,7 @@
           </h5>
           <button class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        <form method="POST" action="{{ url_for('routes.templates_certificado') }}">
+        <form method="POST" action="{{ url_for('certificado_routes.templates_certificado') }}">
           <div class="modal-body p-4">
             <div class="mb-4">
               <label class="form-label fw-semibold">Título do Template</label>

--- a/templates/certificado/usar_template.html
+++ b/templates/certificado/usar_template.html
@@ -34,7 +34,7 @@
         </div>
 
         <button type="submit" class="btn btn-success">Criar Formulário</button>
-        <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-secondary">Cancelar</a>
+        <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-secondary">Cancelar</a>
     </form>
 </div>
 {% endblock %}

--- a/templates/checkin/checkin.html
+++ b/templates/checkin/checkin.html
@@ -240,7 +240,7 @@
         </div>
 
         <!-- Formulário de Check-in com opções de múltipla escolha -->
-        <form method="POST" action="{{ url_for('routes.checkin', oficina_id=oficina.id) }}">
+        <form method="POST" action="{{ url_for('checkin_routes.checkin', oficina_id=oficina.id) }}">
             <p class="form-title">Selecione a palavra-chave correta para confirmar sua presença:</p>
             
             <div class="options-container">

--- a/templates/checkin/confirmar_checkin.html
+++ b/templates/checkin/confirmar_checkin.html
@@ -33,7 +33,7 @@
         </div>
       </div>
       
-      <form method="POST" action="{{ url_for('routes.confirmar_checkin', agendamento_id=agendamento.id) }}">
+      <form method="POST" action="{{ url_for('checkin_routes.confirmar_checkin', agendamento_id=agendamento.id) }}">
         <div class="card mb-4">
           <div class="card-header bg-success text-white">
             <i class="bi bi-person-check"></i> Lista de Presença
@@ -85,7 +85,7 @@
         </div>
         
         <div class="d-flex justify-content-between mb-4">
-          <a href="{{ url_for('routes.checkin_qr_agendamento') }}" class="btn btn-secondary">
+          <a href="{{ url_for('agendamento_routes.checkin_qr_agendamento') }}" class="btn btn-secondary">
             <i class="bi bi-arrow-left"></i> Voltar
           </a>
           

--- a/templates/checkin/scan_qr.html
+++ b/templates/checkin/scan_qr.html
@@ -168,7 +168,7 @@
         const resultElement = document.getElementById('qr-result');
     
         try {
-            const response = await fetch("{{ url_for('routes.leitor_checkin_json') }}", {
+            const response = await fetch("{{ url_for('checkin_routes.leitor_checkin_json') }}", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ token })
@@ -240,7 +240,7 @@
     
     async function carregarCheckinsAnteriores() {
         try {
-            const resp = await fetch("{{ url_for('routes.lista_checkins_json') }}");
+            const resp = await fetch("{{ url_for('checkin_routes.lista_checkins_json') }}");
             const data = await resp.json();
             if (data.status === 'success' && Array.isArray(data.checkins)) {
                 data.checkins.forEach(chk => {

--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -147,13 +147,13 @@
                                 </button>
                               
                                 <!-- Botão Ativar/Inativar -->
-                                <a href="{{ url_for('routes.toggle_cliente', cliente_id=cliente.id) }}" 
+                                <a href="{{ url_for('config_cliente_routes.toggle_cliente', cliente_id=cliente.id) }}" 
                                    class="btn btn-sm btn-outline-{{ 'secondary' if cliente.ativo else 'success' }}">
                                   {{ "Restringir" if cliente.ativo else "Ativar" }}
                                 </a>
                               
                                 <!-- Botão Excluir -->
-                                <form method="POST" action="{{ url_for('routes.excluir_cliente', cliente_id=cliente.id) }}"
+                                <form method="POST" action="{{ url_for('cliente_routes.excluir_cliente', cliente_id=cliente.id) }}"
                                       onsubmit="return confirm('Tem certeza que deseja excluir este cliente e TODAS as informações vinculadas a ele?');">
                                   <button type="submit" class="btn btn-sm btn-outline-danger">
                                     <i class="bi bi-trash"></i>
@@ -228,7 +228,7 @@
 <!-- Modal -->
 <div class="modal fade" id="modalTaxa" tabindex="-1">
   <div class="modal-dialog"><div class="modal-content">
-   <form method="POST" action="{{ url_for('routes.atualizar_taxa') }}">
+   <form method="POST" action="{{ url_for('mercadopago_routes.atualizar_taxa') }}">
      <div class="modal-header"><h5 class="modal-title">Taxa percentual</h5>
        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
      </div>
@@ -256,7 +256,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <!-- Use um placeholder (cliente_id=0) para que o action seja atualizado via JS -->
-      <form action="{{ url_for('routes.editar_cliente', cliente_id=0) }}" method="POST" id="formEditarCliente">
+      <form action="{{ url_for('cliente_routes.editar_cliente', cliente_id=0) }}" method="POST" id="formEditarCliente">
         <div class="modal-header">
           <h5 class="modal-title" id="modalEditarClienteLabel">Editar Cliente</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
@@ -294,7 +294,7 @@
 
 <script>
   // Define a URL base em uma variável JavaScript
-  var editarClienteBaseUrl = "{{ url_for('routes.editar_cliente', cliente_id=0) }}".replace('/0', '');
+  var editarClienteBaseUrl = "{{ url_for('cliente_routes.editar_cliente', cliente_id=0) }}".replace('/0', '');
 
   var modalEditarCliente = document.getElementById('modalEditarCliente');
   modalEditarCliente.addEventListener('show.bs.modal', function (event) {

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -293,7 +293,7 @@
             <p class="card-text text-muted">Gerencie as inscrições dos participantes</p>
           </div>
           <div class="card-footer bg-white border-0 pt-0">
-            <a href="{{ url_for('routes.gerenciar_inscricoes') }}" class="btn btn-warning w-100">
+            <a href="{{ url_for('inscricao_routes.gerenciar_inscricoes') }}" class="btn btn-warning w-100">
               <i class="bi bi-clipboard-check me-2"></i> Gerenciar Inscrições
             </a>
           </div>
@@ -311,7 +311,7 @@
             <p class="card-text text-muted">Gerencie os palestrantes e facilitadores</p>
           </div>
           <div class="card-footer bg-white border-0 pt-0">
-            <a href="{{ url_for('routes.gerenciar_ministrantes') }}" class="btn btn-success w-100">
+            <a href="{{ url_for('ministrante_routes.gerenciar_ministrantes') }}" class="btn btn-success w-100">
               <i class="bi bi-person-badge me-2"></i> Gerenciar Ministrantes
             </a>
           </div>
@@ -351,29 +351,29 @@
             <div class="d-lg-none mb-3">
               <select class="form-select" id="contentManagementMobile" onchange="window.location.href=this.value">
                 <option value="">Selecione uma opção...</option>
-                <option value="{{ url_for('routes.listar_formularios') }}">Formulários</option>
-                <option value="{{ url_for('routes.listar_respostas') }}">Respostas</option>
-                <option value="{{ url_for('routes.listar_templates') }}">Templates</option>
+                <option value="{{ url_for('formularios_routes.listar_formularios') }}">Formulários</option>
+                <option value="{{ url_for('formularios_routes.listar_respostas') }}">Respostas</option>
+                <option value="{{ url_for('formularios_routes.listar_templates') }}">Templates</option>
               </select>
             </div>
             
             <!-- Botões para telas grandes -->
             <div class="d-none d-lg-flex justify-content-between gap-3">
-              <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-outline-primary flex-fill content-card">
+              <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-outline-primary flex-fill content-card">
                 <div class="text-center py-2">
                   <i class="bi bi-ui-checks fs-2 d-block mb-2"></i>
                   <span>Formulários</span>
                 </div>
               </a>
               
-              <a href="{{ url_for('routes.listar_respostas') }}" class="btn btn-outline-primary flex-fill content-card">
+              <a href="{{ url_for('formularios_routes.listar_respostas') }}" class="btn btn-outline-primary flex-fill content-card">
                 <div class="text-center py-2">
                   <i class="bi bi-chat-square-text fs-2 d-block mb-2"></i>
                   <span>Respostas</span>
                 </div>
               </a>
               
-              <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-outline-primary flex-fill content-card">
+              <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-outline-primary flex-fill content-card">
                 <div class="text-center py-2">
                   <i class="bi bi-file-earmark-ruled fs-2 d-block mb-2"></i>
                   <span>Templates</span>
@@ -427,7 +427,7 @@
                         <td class="d-none d-md-table-cell">{{ oficina.descricao|truncate(50) }}</td>
                         <td>
                           <div class="btn-group d-flex justify-content-center">
-                            <a href="{{ url_for('routes.editar_oficina', oficina_id=oficina.id) }}" 
+                            <a href="{{ url_for('oficina_routes.editar_oficina', oficina_id=oficina.id) }}" 
                                class="btn btn-sm btn-outline-warning" 
                                data-bs-toggle="tooltip" 
                                title="Editar atividade">
@@ -439,19 +439,19 @@
                                     title="Participantes">
                               <i class="bi bi-people-fill"></i>
                             </button>
-                            <a href="{{ url_for('routes.lista_checkins', oficina_id=oficina.id) }}" 
+                            <a href="{{ url_for('checkin_routes.lista_checkins', oficina_id=oficina.id) }}" 
                                class="btn btn-sm btn-outline-primary"
                                data-bs-toggle="tooltip" 
                                title="Checkins">
                               <i class="bi bi-card-checklist"></i>
                             </a>
-                            <a href="{{ url_for('routes.feedback_oficina', oficina_id=oficina.id) }}" 
+                            <a href="{{ url_for('feedback_routes.feedback_oficina', oficina_id=oficina.id) }}" 
                                class="btn btn-sm btn-outline-success"
                                data-bs-toggle="tooltip" 
                                title="Feedback">
                               <i class="bi bi-chat-square-text"></i>
                             </a>
-                            <form action="{{ url_for('routes.excluir_oficina', oficina_id=oficina.id) }}" method="POST" class="d-inline">
+                            <form action="{{ url_for('oficina_routes.excluir_oficina', oficina_id=oficina.id) }}" method="POST" class="d-inline">
                               <button type="submit" class="btn btn-sm btn-outline-danger"
                                       onclick="return confirm('Tem certeza que deseja excluir esta oficina?');"
                                       data-bs-toggle="tooltip" 
@@ -546,12 +546,12 @@
     
           <!-- Botões -->
           <div class="d-grid gap-2 d-md-flex">
-            <a href="{{ url_for('routes.criar_evento') }}"
+            <a href="{{ url_for('evento_routes.criar_evento') }}"
                class="btn btn-primary w-100 w-md-auto">
               <i class="bi bi-calendar-event me-2"></i> Novo
             </a>
     
-            <a href="{{ url_for('routes.configurar_evento', habilitar_pagamento=True) }}"
+            <a href="{{ url_for('evento_routes.configurar_evento', habilitar_pagamento=True) }}"
                class="btn btn-padrao btn-secondary w-100 w-md-auto">
                <i class="bi bi-gear me-2"></i> Editar
             </a>
@@ -569,7 +569,7 @@
           </div>
           <h5 class="card-title fw-bold">Criar Atividade</h5>
           <p class="card-text text-muted">Adicione palestras, oficinas e outras atividades</p>
-          <a href="{{ url_for('routes.criar_oficina') }}" class="btn btn-success mt-2 w-100">
+          <a href="{{ url_for('oficina_routes.criar_oficina') }}" class="btn btn-success mt-2 w-100">
             <i class="bi bi-journal-plus me-2"></i> Nova Atividade
           </a>
         </div>
@@ -584,7 +584,7 @@
           </div>
           <h5 class="card-title fw-bold">Adicionar Ministrante</h5>
           <p class="card-text text-muted">Cadastre palestrantes e facilitadores</p>
-          <a href="{{ url_for('routes.cadastro_ministrante') }}" class="btn btn-info mt-2 w-100 text-white">
+          <a href="{{ url_for('ministrante_routes.cadastro_ministrante') }}" class="btn btn-info mt-2 w-100 text-white">
             <i class="bi bi-person-plus me-2"></i> Novo Ministrante
           </a>
         </div>
@@ -599,7 +599,7 @@
           </div>
           <h5 class="card-title fw-bold">Link de Inscrição</h5>
           <p class="card-text text-muted">Gere links personalizados para compartilhar</p>
-          <a href="{{ url_for('routes.gerar_link_ui') }}"
+          <a href="{{ url_for('oficina_routes.gerar_link_ui') }}"
              class="btn btn-warning mt-2 w-100">
             <i class="bi bi-link-45deg me-2"></i> Gerar Link
           </a>
@@ -630,7 +630,7 @@
           </div>
           <h5 class="card-title fw-bold">Certificados</h5>
           <p class="card-text text-muted ">Personalize a aparência dos certificados</p>
-          <a href="{{ url_for('routes.upload_personalizacao_certificado') }}" class="btn btn-success mt-2 w-100">
+          <a href="{{ url_for('certificado_routes.upload_personalizacao_certificado') }}" class="btn btn-success mt-2 w-100">
             <i class="bi bi-image me-2"></i> Personalizar
           </a>
         </div>
@@ -645,7 +645,7 @@
           </div>
           <h5 class="card-title fw-bold">Realizar Sorteio</h5>
           <p class="card-text text-muted ">Sorteie prêmios entre os participantes</p>
-          <a href="{{ url_for('routes.gerenciar_sorteios') }}" class="btn btn-danger mt-2 w-100">
+          <a href="{{ url_for('sorteio_routes.gerenciar_sorteios') }}" class="btn btn-danger mt-2 w-100">
             <i class="bi bi-gift me-2"></i> Gerenciar Sorteios
           </a>
         </div>
@@ -669,7 +669,7 @@
         </div>
         <div class="card-body">
           <p class="text-muted mb-3">Configure limites de inscrições, restrições e outras regras para os participantes</p>
-          <a href="{{ url_for('routes.configurar_regras_inscricao') }}" class="btn btn-warning w-100">
+          <a href="{{ url_for('inscricao_routes.configurar_regras_inscricao') }}" class="btn btn-warning w-100">
             <i class="bi bi-gear-fill me-2"></i> Configurar Regras
           </a>
         </div>
@@ -753,7 +753,7 @@
                   <button type="button" 
                           id="btnToggleCheckin"
                           class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.permitir_checkin_global else 'danger' }}"
-                          data-toggle-url="{{ url_for('routes.toggle_checkin_global_cliente') }}">
+                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_checkin_global_cliente') }}">
                     <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.permitir_checkin_global else 'x-circle-fill' }}"></i>
                     {{ 'Ativo' if config_cliente and config_cliente.permitir_checkin_global else 'Desativado' }}
                   </button>
@@ -771,7 +771,7 @@
                   <button type="button" 
                           id="btnToggleQrCredenciamento"
                           class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_qrcode_evento_credenciamento else 'danger' }}"
-                          data-toggle-url="{{ url_for('routes.toggle_qrcode_evento_credenciamento') }}">
+                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_qrcode_evento_credenciamento') }}">
                     <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_qrcode_evento_credenciamento else 'x-circle-fill' }}"></i>
                     {{ 'Ativo' if config_cliente and config_cliente.habilitar_qrcode_evento_credenciamento else 'Desativado' }}
                   </button>
@@ -789,7 +789,7 @@
                   <button type="button"
                           id="btnToggleFeedback"
                           class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_feedback else 'danger' }}"
-                          data-toggle-url="{{ url_for('routes.toggle_feedback_cliente') }}">
+                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_feedback_cliente') }}">
                     <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_feedback else 'x-circle-fill' }}"></i>
                     {{ 'Ativo' if config_cliente and config_cliente.habilitar_feedback else 'Desativado' }}
                   </button>
@@ -807,7 +807,7 @@
                   <button type="button" 
                           id="btnToggleCertificado"
                           class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_certificado_individual else 'danger' }}"
-                          data-toggle-url="{{ url_for('routes.toggle_certificado_cliente') }}">
+                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_certificado_cliente') }}">
                     <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_certificado_individual else 'x-circle-fill' }}"></i>
                     {{ 'Ativo' if config_cliente and config_cliente.habilitar_certificado_individual else 'Desativado' }}
                   </button>
@@ -835,12 +835,12 @@
                   <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                 </div>
                 <div class="d-grid gap-2">
-                  <a href="{{ url_for('routes.gerar_modelo', tipo='usuarios') }}"
+                  <a href="{{ url_for('relatorio_routes.gerar_modelo', tipo='usuarios') }}"
                     class="btn btn-padrao btn-file btn-outline-success">
                     <i class="bi bi-file-earmark-excel"></i>
                     <span>Modelo de Usuários</span>
                   </a>
-                  <a href="{{ url_for('routes.gerar_modelo', tipo='oficinas') }}"
+                  <a href="{{ url_for('relatorio_routes.gerar_modelo', tipo='oficinas') }}"
                     class="btn btn-padrao btn-file btn-outline-success">
                     <i class="bi bi-file-earmark-excel"></i>
                     <span>Modelo de Atividades</span>
@@ -866,7 +866,7 @@
                   </div>
                 </div>
 
-                <form action="{{ url_for('routes.excluir_todas_oficinas') }}" method="post"
+                <form action="{{ url_for('oficina_routes.excluir_todas_oficinas') }}" method="post"
                       onsubmit="return confirm('ATENÇÃO: Esta ação excluirá TODAS as oficinas e não pode ser desfeita! Tem certeza que deseja continuar?');">
                   <button type="submit" class="btn btn-padrao btn-danger w-100">
                     <i class="bi bi-trash-fill"></i> Excluir Todas as Atividades
@@ -902,7 +902,7 @@
                 <span class="badge bg-primary rounded-circle p-2 me-2">1</span>
                 Adicionar Novo Campo
               </h6>
-              <form method="POST" action="{{ url_for('routes.adicionar_campo_personalizado') }}" class="mb-0">
+              <form method="POST" action="{{ url_for('campo_routes.adicionar_campo_personalizado') }}" class="mb-0">
                 <div class="row g-3">
                   <div class="col-md-5">
                     <label for="nome_campo" class="form-label fw-medium">Nome do Campo</label>
@@ -984,7 +984,7 @@
                           {% endif %}
                         </td>
                         <td class="text-center">
-                          <form method="POST" action="{{ url_for('routes.remover_campo_personalizado', campo_id=campo.id) }}" 
+                          <form method="POST" action="{{ url_for('campo_routes.remover_campo_personalizado', campo_id=campo.id) }}" 
                                 onsubmit="return confirm('Tem certeza que deseja remover este campo?');">
                             <button class="btn btn-padrao btn-table btn-sm btn-danger" type="submit">
                               <i class="bi bi-trash-fill"></i> Remover
@@ -1035,7 +1035,7 @@
                   </div>
                   
                   <div class="d-grid">
-                    <a href="{{ url_for('routes.gerar_modelo', tipo='oficinas') }}" 
+                    <a href="{{ url_for('relatorio_routes.gerar_modelo', tipo='oficinas') }}" 
                       class="btn btn-padrao btn-file btn-success">
                       <i class="bi bi-file-earmark-excel"></i>
                       <span>Baixar Modelo Excel</span>
@@ -1073,7 +1073,7 @@
                 </div>
               
                 <!-- Formulário de Upload -->
-                <form action="{{ url_for('routes.importar_oficinas') }}" method="POST" enctype="multipart/form-data">
+                <form action="{{ url_for('agendamento_routes.importar_oficinas') }}" method="POST" enctype="multipart/form-data">
                   <div class="file-drop-area bg-white p-4 rounded-3 border-2 border-primary border-dashed text-center">
                     <div class="mb-3 text-primary">
                       <i class="bi bi-cloud-upload fs-1"></i>
@@ -1112,7 +1112,7 @@
               </div>
             </div>
             
-            <form method="POST" action="{{ url_for('routes.adicionar_patrocinadores_categorizados') }}" enctype="multipart/form-data">
+            <form method="POST" action="{{ url_for('patrocinador_routes.adicionar_patrocinadores_categorizados') }}" enctype="multipart/form-data">
               <!-- Selecionar evento -->
               <div class="bg-light p-4 rounded-3 mb-4">
                 <label for="evento_id" class="form-label fw-bold d-flex align-items-center mb-3">
@@ -1223,7 +1223,7 @@
 
               <!-- Botões de ação agrupados -->
               <div class="action-group d-flex flex-column flex-md-row justify-content-center gap-3">
-                <a href="{{ url_for('routes.gerenciar_patrocinadores') }}" class="btn btn-padrao btn-outline-primary btn-lg mb-2 mb-md-0">
+                <a href="{{ url_for('patrocinador_routes.gerenciar_patrocinadores') }}" class="btn btn-padrao btn-outline-primary btn-lg mb-2 mb-md-0">
                   <i class="bi bi-card-image"></i> Gerenciar Logos Existentes
                 </a>
                 <button type="submit" class="btn btn-padrao btn-success btn-lg">
@@ -1401,7 +1401,7 @@
               data-bs-target="#modalCertificadoIndividual{{ oficina.id }}">
         <i class="bi bi-award me-2"></i>Certificado Individual
       </button>
-      <a href="{{ url_for('routes.feedback_oficina', oficina_id=oficina.id) }}"
+      <a href="{{ url_for('feedback_routes.feedback_oficina', oficina_id=oficina.id) }}"
          class="btn btn-outline-info">
         <i class="bi bi-chat-text me-2"></i>Feedback
       </a>

--- a/templates/dashboard/dashboard_ministrante.html
+++ b/templates/dashboard/dashboard_ministrante.html
@@ -3,13 +3,13 @@
 <div class="container mt-4">
   <h2>Dashboard do Ministrante: {{ ministrante.nome }}</h2>
   <div class="mb-4">
-    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-primary w-100 fw-bold">
+    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-primary w-100 fw-bold">
         <i class="bi bi-ui-checks"></i> Gerenciar Formulários
     </a>
 </div>
 
 <div class="mb-4">
-  <a href="{{ url_for('routes.listar_respostas', formulario_id=1) }}" class="btn btn-primary w-100 fw-bold">
+  <a href="{{ url_for('formularios_routes.listar_respostas', formulario_id=1) }}" class="btn btn-primary w-100 fw-bold">
       📄 Gerenciar Respostas dos Formulários
   </a>
 </div>
@@ -32,15 +32,15 @@
             <p><strong>Quantidade de inscritos:</strong> {{ oficina.inscritos|length }}</p>
 
             <!-- Botões de ação -->
-            <a href="{{ url_for('routes.upload_material', oficina_id=oficina.id) }}" class="btn btn-sm btn-secondary">
+            <a href="{{ url_for('ministrante_routes.upload_material', oficina_id=oficina.id) }}" class="btn btn-sm btn-secondary">
                 Anexar Material
               </a>
-            <a href="{{ url_for('routes.enviar_relatorio', oficina_id=oficina.id) }}" class="btn btn-sm btn-warning">
+            <a href="{{ url_for('ministrante_routes.enviar_relatorio', oficina_id=oficina.id) }}" class="btn btn-sm btn-warning">
               Enviar Relatório
             </a>
 
             {% if habilitar_feedback %}
-            <a href="{{ url_for('routes.feedback_ministrante', oficina_id=oficina.id) }}" class="btn btn-sm btn-info">
+            <a href="{{ url_for('feedback_routes.feedback_ministrante', oficina_id=oficina.id) }}" class="btn btn-sm btn-info">
                 Enviar Feedback
             </a>
             {% endif %}

--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -370,7 +370,7 @@
   {% if config_cliente and config_cliente.habilitar_submissao_trabalhos %}
   <div class="container-fluid px-4 mt-5">
     <div class="d-flex justify-content-end mb-4">
-      <a href="{{ url_for('routes.nova_submissao') }}" class="btn btn-success btn-lg">
+      <a href="{{ url_for('trabalho_routes.nova_submissao') }}" class="btn btn-success btn-lg">
         <i class="bi bi-upload me-2"></i> Submeter Trabalho
       </a>
     </div>
@@ -387,7 +387,7 @@
   {% if formularios_disponiveis %}
     <div class="formularios-card">
       <strong>Formulários Disponíveis</strong>
-      <a href="{{ url_for('routes.listar_formularios_participante') }}" class="btn btn-primary">
+      <a href="{{ url_for('formularios_routes.listar_formularios_participante') }}" class="btn btn-primary">
         <i class="fas fa-clipboard-list"></i> Acessar Formulários
       </a>
     </div>
@@ -480,26 +480,26 @@
                         <div class="d-flex flex-column gap-2">
                             <!-- Check-in (só aparece se permitir_checkin_global == True) -->
                             {% if permitir_checkin_global %}
-                            <a href="{{ url_for('routes.checkin', oficina_id=oficina.id) }}" class="btn btn-warning w-100">
+                            <a href="{{ url_for('checkin_routes.checkin', oficina_id=oficina.id) }}" class="btn btn-warning w-100">
                               <i class="fas fa-clipboard-check"></i> Realizar Check-in
                             </a>
                             {% endif %}
                         
                             <!-- Botão para cancelar inscrição -->
-                            <form action="{{ url_for('routes.remover_inscricao', oficina_id=oficina.id) }}" method="post">
+                            <form action="{{ url_for('inscricao_routes.remover_inscricao', oficina_id=oficina.id) }}" method="post">
                                 <button type="submit" class="btn btn-danger w-100">
                                   <i class="fas fa-times-circle"></i> Cancelar Inscrição
                                 </button>
                             </form>
 
                             <!-- Comprovante de Inscrição -->
-                            <a href="{{ url_for('routes.baixar_comprovante', oficina_id=oficina.id) }}" class="btn btn-primary w-100">
+                            <a href="{{ url_for('comprovante_routes.baixar_comprovante', oficina_id=oficina.id) }}" class="btn btn-primary w-100">
                                 <i class="fas fa-file-download"></i> Baixar Comprovante
                             </a>
 
                             <!-- Certificado Individual (só aparece se habilitar_certificado_individual == True) -->
                             {% if habilitar_certificado_individual %}
-                            <a href="{{ url_for('routes.gerar_certificado_individual', oficina_id=oficina.id) }}"
+                            <a href="{{ url_for('comprovante_routes.gerar_certificado_individual', oficina_id=oficina.id) }}"
                               class="btn btn-success w-100">
                               <i class="fas fa-graduation-cap"></i> Baixar Certificado
                             </a>
@@ -507,7 +507,7 @@
                           
                             <!-- Feedback (só aparece se habilitar_feedback == True) -->
                             {% if habilitar_feedback %}
-                            <a href="{{ url_for('routes.feedback', oficina_id=oficina.id) }}" class="btn btn-info w-100">
+                            <a href="{{ url_for('feedback_routes.feedback', oficina_id=oficina.id) }}" class="btn btn-info w-100">
                                 <i class="fas fa-comment-dots"></i> Enviar Feedback
                             </a>
                             {% endif %}

--- a/templates/dashboard/dashboard_professor.html
+++ b/templates/dashboard/dashboard_professor.html
@@ -25,16 +25,16 @@
         </div>
         <div class="card-body">
           <div class="list-group list-group-flush border-0">
-            <a href="{{ url_for('routes.criar_agendamento') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
+            <a href="{{ url_for('agendamento_routes.criar_agendamento') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
               <i class="bi bi-calendar-plus me-3 fs-5 text-success"></i>
               <span>Criar Agendamento</span>
             </a>
-            <a href="{{ url_for('routes.meus_agendamentos') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
+            <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
               <i class="bi bi-calendar-week me-3 fs-5 text-success"></i>
               <span>Meus Agendamentos</span>
             </a>
             {% for agendamento in agendamentos %}
-              <form action="{{ url_for('routes.cancelar_agendamento_professor', agendamento_id=agendamento.id) }}" method="POST" style="display:inline;">
+              <form action="{{ url_for('agendamento_routes.cancelar_agendamento_professor', agendamento_id=agendamento.id) }}" method="POST" style="display:inline;">
                 <button class="btn btn-danger btn-sm" type="submit">
                   Cancelar Agendamento (#{{ agendamento.id }})
                 </button>
@@ -56,12 +56,12 @@
         </div>
         <div class="card-body">
           <div class="list-group list-group-flush border-0">
-            <a href="{{ url_for('routes.listar_eventos_disponiveis') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
+            <a href="{{ url_for('agendamento_routes.listar_eventos_disponiveis') }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
               <i class="bi bi-calendar-event me-3 fs-5 text-info"></i>
               <span>Eventos Disponíveis</span>
             </a>
             {% for evento in eventos %}
-              <a href="{{ url_for('routes.detalhes_evento', evento_id=evento.id) }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
+              <a href="{{ url_for('evento_routes.detalhes_evento', evento_id=evento.id) }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
                 <i class="bi bi-stars me-3 fs-5 text-info"></i>
                 <span>{{ evento.nome }}</span>
               </a>
@@ -82,7 +82,7 @@
         <div class="card-body">
           <div class="list-group list-group-flush border-0">
             {% for agendamento in agendamentos %}
-              <a href="{{ url_for('routes.qrcode_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
+              <a href="{{ url_for('agendamento_routes.qrcode_agendamento', agendamento_id=agendamento.id) }}" class="list-group-item list-group-item-action border-0 py-3 px-0 d-flex align-items-center">
                 <i class="bi bi-qr-code-scan me-3 fs-5 text-warning"></i>
                 <span>Ver QR Code - Agendamento #{{ agendamento.id }}</span>
               </a>

--- a/templates/dashboard/dashboard_superadmin.html
+++ b/templates/dashboard/dashboard_superadmin.html
@@ -31,7 +31,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    <a href="{{ url_for('routes.toggle_cliente', cliente_id=cliente.id) }}" class="btn btn-sm {% if cliente.ativo %}btn-danger{% else %}btn-success{% endif %}">
+                    <a href="{{ url_for('config_cliente_routes.toggle_cliente', cliente_id=cliente.id) }}" class="btn btn-sm {% if cliente.ativo %}btn-danger{% else %}btn-success{% endif %}">
                         {% if cliente.ativo %}Desativar{% else %}Ativar{% endif %}
                     </a>
                 </td>

--- a/templates/emails/confirmacao_agendamento.html
+++ b/templates/emails/confirmacao_agendamento.html
@@ -75,7 +75,7 @@
         <p>No dia da visita, apresente o QR Code ou o comprovante impresso para agilizar o check-in.</p>
         
         <center>
-            <a href="{{ url_for('routes.meus_agendamentos', _external=True) }}" class="btn">Acessar Meus Agendamentos</a>
+            <a href="{{ url_for('agendamento_routes.meus_agendamentos', _external=True) }}" class="btn">Acessar Meus Agendamentos</a>
         </center>
         
         <p>Se precisar cancelar ou modificar seu agendamento, faça isso com pelo menos {{ evento.configuracoes_agendamento[0].prazo_cancelamento if evento.configuracoes_agendamento else 24 }} horas de antecedência para evitar bloqueios temporários.</p>
@@ -284,7 +284,7 @@
         <p>Se por algum motivo você não puder comparecer, por favor cancele o agendamento o quanto antes para liberar a vaga para outros interessados.</p>
         
         <center>
-            <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
+            <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
         </center>
         
         <p>Estamos ansiosos para recebê-los amanhã!</p>
@@ -374,7 +374,7 @@
         <p>Você pode visualizar todos os detalhes deste agendamento no sistema.</p>
         
         <center>
-            <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
+            <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id, _external=True) }}" class="btn">Ver Detalhes do Agendamento</a>
         </center>
         
         <div class="footer">

--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -1218,9 +1218,9 @@ function updateProgressBar(step) {
 <script>
   function carregarEvento(eventoId) {
     if (eventoId) {
-      window.location.href = "{{ url_for('routes.configurar_evento') }}?evento_id=" + eventoId;
+      window.location.href = "{{ url_for('evento_routes.configurar_evento') }}?evento_id=" + eventoId;
     } else {
-      window.location.href = "{{ url_for('routes.configurar_evento') }}";
+      window.location.href = "{{ url_for('evento_routes.configurar_evento') }}";
     }
   }
 

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-plus me-2"></i>Criar Novo Formulário
         </h2>
-        <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para lista
         </a>
     </div>
@@ -28,7 +28,7 @@
                 </div>
                 
                 <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
-                    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-light me-md-2">
+                    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-light me-md-2">
                         Cancelar
                     </a>
                     <button type="submit" class="btn btn-primary">

--- a/templates/formulario/criar_template.html
+++ b/templates/formulario/criar_template.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-plus me-2"></i>Criar Novo Template
         </h2>
-        <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para Templates
         </a>
     </div>
@@ -74,7 +74,7 @@
                     
                     <div class="col-12">
                         <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                            <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-light me-md-2">
+                            <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-light me-md-2">
                                 Cancelar
                             </a>
                             <button type="submit" class="btn btn-primary">

--- a/templates/formulario/editar_campo.html
+++ b/templates/formulario/editar_campo.html
@@ -59,7 +59,7 @@
 
         <!-- Ações -->
         <div class="d-grid gap-2 d-md-flex mt-4">
-          <a href="{{ url_for('routes.gerenciar_campos', formulario_id=campo.formulario_id) }}" class="btn btn-outline-secondary">
+          <a href="{{ url_for('formularios_routes.gerenciar_campos', formulario_id=campo.formulario_id) }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar
           </a>
           <button type="submit" class="btn btn-primary ms-auto">

--- a/templates/formulario/editar_formulario.html
+++ b/templates/formulario/editar_formulario.html
@@ -15,6 +15,6 @@
         <button type="submit" class="btn btn-success">Salvar Alterações</button>
     </form>
 
-    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-secondary mt-3">Voltar</a>
+    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-secondary mt-3">Voltar</a>
 </div>
 {% endblock %}

--- a/templates/formulario/formularios.html
+++ b/templates/formulario/formularios.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-text me-2"></i>Formulários Criados
         </h2>
-        <a href="{{ url_for('routes.criar_formulario') }}" class="btn btn-success">
+        <a href="{{ url_for('formularios_routes.criar_formulario') }}" class="btn btn-success">
             <i class="bi bi-plus-circle me-1"></i> Criar Novo Formulário
         </a>
     </div>
@@ -29,13 +29,13 @@
                                 <td>{{ formulario.descricao or "Sem descrição" }}</td>
                                 <td>
                                     <div class="d-flex justify-content-center gap-2">
-                                        <a href="{{ url_for('routes.gerenciar_campos', formulario_id=formulario.id) }}" 
+                                        <a href="{{ url_for('formularios_routes.gerenciar_campos', formulario_id=formulario.id) }}" 
                                            class="btn btn-outline-primary btn-sm" 
                                            data-bs-toggle="tooltip" 
                                            title="Gerenciar Campos">
                                             <i class="bi bi-list-check"></i>
                                         </a>
-                                        <a href="{{ url_for('routes.editar_formulario', formulario_id=formulario.id) }}" 
+                                        <a href="{{ url_for('formularios_routes.editar_formulario', formulario_id=formulario.id) }}" 
                                            class="btn btn-outline-warning btn-sm"
                                            data-bs-toggle="tooltip" 
                                            title="Editar Formulário">
@@ -64,7 +64,7 @@
                                                 </div>
                                                 <div class="modal-footer">
                                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                                    <form action="{{ url_for('routes.excluir_formulario', formulario_id=formulario.id) }}" method="POST" class="d-inline">
+                                                    <form action="{{ url_for('formularios_routes.excluir_formulario', formulario_id=formulario.id) }}" method="POST" class="d-inline">
                                                         <button type="submit" class="btn btn-danger">
                                                             Excluir Formulário
                                                         </button>
@@ -83,7 +83,7 @@
                 <div class="text-center py-5">
                     <i class="bi bi-clipboard-x fs-1 text-muted mb-3"></i>
                     <p class="lead text-muted">Nenhum formulário criado ainda.</p>
-                    <a href="{{ url_for('routes.criar_formulario') }}" class="btn btn-primary mt-2">
+                    <a href="{{ url_for('formularios_routes.criar_formulario') }}" class="btn btn-primary mt-2">
                         Criar seu primeiro formulário
                     </a>
                 </div>

--- a/templates/formulario/formularios_participante.html
+++ b/templates/formulario/formularios_participante.html
@@ -24,7 +24,7 @@
                             <td class="text-end pe-3">
                                 <div class="btn-group" role="group">
                                     <!-- Botão de preencher -->
-                                    <a href="{{ url_for('routes.preencher_formulario', formulario_id=formulario.id) }}"
+                                    <a href="{{ url_for('formularios_routes.preencher_formulario', formulario_id=formulario.id) }}"
                                        class="btn btn-outline-primary btn-sm">
                                         <i class="bi bi-pencil-fill me-1"></i> Preencher
                                     </a>
@@ -38,7 +38,7 @@
 
                                     <!-- Se user_resposta existir, exibir botão de "Ver Feedback" -->
                                     {% if user_resposta %}
-                                    <a href="{{ url_for('routes.visualizar_resposta', resposta_id=user_resposta.id) }}"
+                                    <a href="{{ url_for('formularios_routes.visualizar_resposta', resposta_id=user_resposta.id) }}"
                                        class="btn btn-outline-info btn-sm ms-1">
                                        <i class="bi bi-eye-fill me-1"></i> Ver Feedback
                                     </a>

--- a/templates/formulario/gerenciar_campos.html
+++ b/templates/formulario/gerenciar_campos.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-list-nested me-2"></i>Gerenciar Campos
         </h2>
-        <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para Formulários
         </a>
     </div>
@@ -43,7 +43,7 @@
                                     </div>
                                 </div>
                                 <div class="btn-group btn-group-sm">
-                                    <a href="{{ url_for('routes.editar_campo', campo_id=campo.id) }}" class="btn btn-outline-warning">
+                                    <a href="{{ url_for('formularios_routes.editar_campo', campo_id=campo.id) }}" class="btn btn-outline-warning">
                                         <i class="bi bi-pencil"></i>
                                     </a>
                                     <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteFieldModal{{ campo.id }}">
@@ -67,7 +67,7 @@
                                     </div>
                                     <div class="modal-footer">
                                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                        <form action="{{ url_for('routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
+                                        <form action="{{ url_for('formularios_routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
                                             <button type="submit" class="btn btn-danger">Remover Campo</button>
                                         </form>
                                     </div>
@@ -85,7 +85,7 @@
                 </div>
                 {% if formulario.campos %}
                 <div class="card-footer bg-white text-center">
-                    <a href="{{ url_for('routes.listar_formularios') }}" class="btn btn-primary">
+                    <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-primary">
                         <i class="bi bi-check-circle me-1"></i> Finalizar e Salvar
                     </a>
                 </div>

--- a/templates/formulario/gerenciar_campos_template.html
+++ b/templates/formulario/gerenciar_campos_template.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-layout-text-window me-2"></i>Gerenciar Campos do Template
         </h2>
-        <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Voltar para Templates
         </a>
     </div>
@@ -103,7 +103,7 @@
                 </div>
                 {% if template.campos %}
                 <div class="card-footer bg-white text-center">
-                    <a href="{{ url_for('routes.listar_templates') }}" class="btn btn-primary">
+                    <a href="{{ url_for('formularios_routes.listar_templates') }}" class="btn btn-primary">
                         <i class="bi bi-check-circle me-1"></i> Finalizar e Salvar
                     </a>
                 </div>

--- a/templates/formulario/templates_formulario.html
+++ b/templates/formulario/templates_formulario.html
@@ -5,7 +5,7 @@
         <h2 class="mb-0">
             <i class="bi bi-file-earmark-ruled me-2"></i>Templates de Formulários
         </h2>
-        <a href="{{ url_for('routes.criar_template') }}" class="btn btn-success">
+        <a href="{{ url_for('formularios_routes.criar_template') }}" class="btn btn-success">
             <i class="bi bi-plus-circle me-1"></i> Criar Novo Template
         </a>
     </div>
@@ -65,11 +65,11 @@
                 
                 <div class="card-footer bg-white">
                     <div class="d-flex gap-2">
-                        <a href="{{ url_for('routes.gerenciar_campos_template', template_id=template.id) }}" 
+                        <a href="{{ url_for('formularios_routes.gerenciar_campos_template', template_id=template.id) }}" 
                            class="btn btn-outline-primary flex-grow-1">
                             <i class="bi bi-pencil-square me-1"></i> Gerenciar Campos
                         </a>
-                        <a href="{{ url_for('routes.usar_template', template_id=template.id) }}" 
+                        <a href="{{ url_for('formularios_routes.usar_template', template_id=template.id) }}" 
                            class="btn btn-success flex-grow-1">
                             <i class="bi bi-check-circle me-1"></i> Usar Template
                         </a>
@@ -138,7 +138,7 @@
             <i class="bi bi-file-earmark-x text-muted fs-1 mb-3"></i>
             <h4 class="text-muted">Nenhum template disponível</h4>
             <p class="text-muted mb-4">Crie um novo template ou utilize os templates padrão do sistema.</p>
-            <a href="{{ url_for('routes.criar_template') }}" class="btn btn-primary">
+            <a href="{{ url_for('formularios_routes.criar_template') }}" class="btn btn-primary">
                 <i class="bi bi-plus-circle me-1"></i> Criar seu primeiro template
             </a>
         </div>

--- a/templates/inscricao/gerenciar_inscricoes.html
+++ b/templates/inscricao/gerenciar_inscricoes.html
@@ -144,7 +144,7 @@
                 </td>
                 <td>
                   <div class="d-flex gap-2 justify-content-center">
-                    <a href="{{ url_for('routes.editar_participante',
+                    <a href="{{ url_for('inscricao_routes.editar_participante',
                                         usuario_id=insc.usuario.id,
                                         oficina_id=insc.oficina.id) }}"
                        class="btn btn-sm btn-outline-primary">
@@ -162,7 +162,7 @@
                     </button>
                   {% else %}
                     <form method="POST"
-                          action="{{ url_for('routes.checkin_manual',
+                          action="{{ url_for('checkin_routes.checkin_manual',
                                              usuario_id=insc.usuario.id,
                                              oficina_id=insc.oficina.id) }}">
                       <button type="submit" class="btn btn-sm btn-success"
@@ -173,7 +173,7 @@
                   {% endif %}
                   
 
-                    <form action="{{ url_for('routes.cancelar_inscricao', inscricao_id=insc.id) }}"
+                    <form action="{{ url_for('inscricao_routes.cancelar_inscricao', inscricao_id=insc.id) }}"
                           method="POST" style="display:inline;"
                           onsubmit="return confirm('Cancelar esta inscrição?')">
                       <button type="submit" class="btn btn-sm btn-danger">
@@ -220,7 +220,7 @@
 
         <div class="modal-body p-4">
           <form id="formMoverInscricoes"
-                action="{{ url_for('routes.inscricoes_lote') }}"
+                action="{{ url_for('inscricao_routes.inscricoes_lote') }}"
                 method="POST">
 
             <!-- Ação: mover x copiar -->

--- a/templates/links/gerar.html
+++ b/templates/links/gerar.html
@@ -92,8 +92,8 @@
 {% block scripts %}
 {{ super() }}
 <script>
-const API        = "{{ url_for('routes.gerar_link') }}";
-const API_DELETE = "{{ url_for('routes.excluir_link') }}";
+const API        = "{{ url_for('gerar_link_routes.gerar_link') }}";
+const API_DELETE = "{{ url_for('gerar_link_routes.excluir_link') }}";
 
 /* ===== Bootstrap Toast helper ===== */
 function toast(msg, type='info') {

--- a/templates/ministrante/editar_ministrante.html
+++ b/templates/ministrante/editar_ministrante.html
@@ -19,7 +19,7 @@
         {% endif %}
       {% endwith %}
 
-      <form method="POST" enctype="multipart/form-data" action="{{ url_for('routes.editar_ministrante', ministrante_id=ministrante.id) }}">
+      <form method="POST" enctype="multipart/form-data" action="{{ url_for('ministrante_routes.editar_ministrante', ministrante_id=ministrante.id) }}">
         {% if current_user.tipo == 'admin' %}
         <div class="mb-3">
           <label for="cliente_id" class="form-label">Cliente:</label>
@@ -98,7 +98,7 @@
         </div>
 
         <button type="submit" class="btn btn-success w-100">Salvar Alterações</button>
-        <a href="{{ url_for('routes.gerenciar_ministrantes') }}" class="btn btn-danger w-100 mt-3">Cancelar</a>
+        <a href="{{ url_for('ministrante_routes.gerenciar_ministrantes') }}" class="btn btn-danger w-100 mt-3">Cancelar</a>
       </form>
     </div>
   </div>

--- a/templates/ministrante/gerenciar_ministrantes.html
+++ b/templates/ministrante/gerenciar_ministrantes.html
@@ -7,7 +7,7 @@
     <h2 class="mb-0">
       <i class="bi bi-people-fill me-2"></i>Gerenciar Ministrantes
     </h2>
-    <a href="{{ url_for('routes.cadastro_ministrante') }}" class="btn btn-success">
+    <a href="{{ url_for('ministrante_routes.cadastro_ministrante') }}" class="btn btn-success">
       <i class="bi bi-person-plus me-1"></i> Cadastrar Novo Ministrante
     </a>
   </div>
@@ -90,7 +90,7 @@
               </td>
               <td>
                 <div class="d-flex justify-content-center gap-2">
-                  <a href="{{ url_for('routes.editar_ministrante', ministrante_id=ministrante.id) }}" 
+                  <a href="{{ url_for('ministrante_routes.editar_ministrante', ministrante_id=ministrante.id) }}" 
                      class="btn btn-outline-primary btn-sm" 
                      data-bs-toggle="tooltip" 
                      title="Editar Ministrante">
@@ -128,7 +128,7 @@
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                        <form action="{{ url_for('routes.excluir_ministrante', ministrante_id=ministrante.id) }}" method="POST" class="d-inline">
+                        <form action="{{ url_for('ministrante_routes.excluir_ministrante', ministrante_id=ministrante.id) }}" method="POST" class="d-inline">
                           <button type="submit" class="btn btn-danger">
                             <i class="bi bi-trash me-1"></i> Excluir Ministrante
                           </button>
@@ -148,7 +148,7 @@
         <i class="bi bi-people text-muted fs-1 mb-3"></i>
         <h4 class="text-muted">Nenhum ministrante cadastrado</h4>
         <p class="text-muted mb-4">Cadastre seu primeiro ministrante para começar.</p>
-        <a href="{{ url_for('routes.cadastro_ministrante') }}" class="btn btn-primary">
+        <a href="{{ url_for('ministrante_routes.cadastro_ministrante') }}" class="btn btn-primary">
           <i class="bi bi-person-plus me-1"></i> Cadastrar Ministrante
         </a>
       </div>

--- a/templates/oficina/criar_oficina.html
+++ b/templates/oficina/criar_oficina.html
@@ -44,7 +44,7 @@
   <!-- Main form card -->
   <div class="card border-0 shadow">
     <div class="card-body p-4 bg-light rounded-3">
-      <form action="{{ url_for('routes.criar_oficina') }}" method="POST" id="form-oficina">
+      <form action="{{ url_for('oficina_routes.criar_oficina') }}" method="POST" id="form-oficina">
         
         <!-- Etapa 1: Informações Básicas -->
         <div class="step" id="step-1">
@@ -801,7 +801,7 @@
 
       cidadeSelect.innerHTML = "<option value=''>Carregando...</option>";
 
-      fetch("{{ url_for('routes.get_cidades', estado_sigla='') }}" + estado)
+      fetch("{{ url_for('api_cidades.get_cidades', estado_sigla='') }}" + estado)
         .then(response => response.json())
         .then(data => {
           cidadeSelect.innerHTML = "<option value=''>Selecione uma cidade</option>";

--- a/templates/oficina/editar_oficina.html
+++ b/templates/oficina/editar_oficina.html
@@ -325,7 +325,7 @@
 
     cidadeSelect.innerHTML = "<option value=''>Carregando...</option>";
 
-    fetch("{{ url_for('routes.get_cidades', estado_sigla='') }}" + estado)
+    fetch("{{ url_for('api_cidades.get_cidades', estado_sigla='') }}" + estado)
       .then(response => response.json())
       .then(data => {
         cidadeSelect.innerHTML = "<option value=''>Selecione uma cidade</option>";
@@ -347,7 +347,7 @@
     var cidadeAtual = "{{ oficina.cidade }}";
 
     if (estadoAtual) {
-      fetch("{{ url_for('routes.get_cidades', estado_sigla='') }}" + estadoAtual)
+      fetch("{{ url_for('api_cidades.get_cidades', estado_sigla='') }}" + estadoAtual)
         .then(response => response.json())
         .then(data => {
           var cidadeSelect = document.getElementById("cidade");

--- a/templates/patrocinador/gerenciar_patrocinadores.html
+++ b/templates/patrocinador/gerenciar_patrocinadores.html
@@ -11,7 +11,7 @@
       Voltar
     </a>
     <!-- Form e botão "Remover Selecionadas" -->
-    <form action="{{ url_for('routes.remover_fotos_selecionadas') }}" method="POST"
+    <form action="{{ url_for('patrocinador_routes.remover_fotos_selecionadas') }}" method="POST"
           onsubmit="return confirm('Deseja realmente remover as imagens selecionadas?');">
       <button type="submit" class="btn btn-danger">
         Remover Selecionadas
@@ -56,7 +56,7 @@
         </td>
         <td>
           <!-- Botão individual de remoção (já existente) -->
-          <form action="{{ url_for('routes.remover_foto_patrocinador', patrocinador_id=pat.id) }}"
+          <form action="{{ url_for('patrocinador_routes.remover_foto_patrocinador', patrocinador_id=pat.id) }}"
                 method="POST"
                 onsubmit="return confirm('Deseja realmente remover esta logo?');">
             <button type="submit" class="btn btn-danger btn-sm">
@@ -71,7 +71,7 @@
 </div>
 
 <!-- Form oculto para remover em lote (bulk), usado pelos checkboxes -->
-<form id="bulkRemoveForm" action="{{ url_for('routes.remover_fotos_selecionadas') }}" method="POST">
+<form id="bulkRemoveForm" action="{{ url_for('patrocinador_routes.remover_fotos_selecionadas') }}" method="POST">
   <!-- Este form é usado pelos checkboxes via atributo form="bulkRemoveForm" -->
 </form>
 

--- a/templates/patrocinador/listar_patrocinadores.html
+++ b/templates/patrocinador/listar_patrocinadores.html
@@ -35,7 +35,7 @@
                style="max-width: 120px;"/>
         </td>
         <td>
-          <form action="{{ url_for('routes.remover_patrocinador', patrocinador_id=pat.id) }}" 
+          <form action="{{ url_for('patrocinador_routes.remover_patrocinador', patrocinador_id=pat.id) }}" 
                 method="POST" 
                 onsubmit="return confirm('Deseja realmente remover este patrocinador?');"
                 class="d-inline">

--- a/templates/professor/adicionar_alunos.html
+++ b/templates/professor/adicionar_alunos.html
@@ -142,7 +142,7 @@
             <i class="fas fa-qrcode"></i> Ver QR Code
         </a>
         
-        <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>

--- a/templates/professor/cancelar_agendamento.html
+++ b/templates/professor/cancelar_agendamento.html
@@ -55,12 +55,12 @@
         <div class="card-body">
             <p>Tem certeza que deseja cancelar este agendamento? Esta ação não pode ser desfeita.</p>
             
-            <form method="POST" action="{{ url_for('routes.cancelar_agendamento_professor', agendamento_id=agendamento.id) }}">
+            <form method="POST" action="{{ url_for('agendamento_routes.cancelar_agendamento_professor', agendamento_id=agendamento.id) }}">
                 <div class="mt-4 d-flex gap-2">
                     <button type="submit" class="btn btn-danger">
                         <i class="fas fa-times"></i> Confirmar Cancelamento
                     </button>
-                    <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary">
+                    <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
                         <i class="fas fa-chevron-left"></i> Voltar
                     </a>
                 </div>

--- a/templates/professor/detalhes_agendamento.html
+++ b/templates/professor/detalhes_agendamento.html
@@ -34,7 +34,7 @@
       <hr>
       <!-- Botão de Cancelar, chamando a rota cancelar_agendamento -->
       {% if agendamento.status != 'cancelado' and agendamento.status != 'realizado' %}
-        <form method="POST" action="{{ url_for('routes.cancelar_agendamento', agendamento_id=agendamento.id) }}">
+        <form method="POST" action="{{ url_for('agendamento_routes.cancelar_agendamento', agendamento_id=agendamento.id) }}">
           <button class="btn btn-danger">
             <i class="bi bi-x-octagon"></i> Cancelar Agendamento
           </button>
@@ -71,7 +71,7 @@
   <div class="mt-4">
     <h5>QR Code para Check-in</h5>
     <p>Caso seu sistema gere QR Code para check-in, você pode exibi-lo abaixo:</p>
-    <img src="{{ url_for('routes.qrcode_agendamento', agendamento_id=agendamento.id) }}" 
+    <img src="{{ url_for('agendamento_routes.qrcode_agendamento', agendamento_id=agendamento.id) }}" 
          alt="QR Code do Agendamento" style="max-width: 200px;">
   </div>
 </div>

--- a/templates/professor/detalhes_evento.html
+++ b/templates/professor/detalhes_evento.html
@@ -100,7 +100,7 @@
                 <i class="fas fa-calendar-check"></i> Agendar Visita
             </a>
         {% endif %}
-        <a href="{{ url_for('routes.listar_eventos_disponiveis') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.listar_eventos_disponiveis') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>

--- a/templates/professor/meus_agendamentos.html
+++ b/templates/professor/meus_agendamentos.html
@@ -15,7 +15,7 @@
                     <i class="fas fa-filter me-2"></i>Filtrar
                 </div>
                 <div class="card-body">
-                    <form method="GET" action="{{ url_for('routes.meus_agendamentos') }}" class="row g-2 align-items-center">
+                    <form method="GET" action="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="row g-2 align-items-center">
                         <div class="col-md-4">
                             <select name="status" class="form-select">
                                 <option value="">Todos os status</option>
@@ -31,7 +31,7 @@
                         </div>
                         {% if status_filtro %}
                         <div class="col-auto">
-                            <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-outline-secondary">
+                            <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-outline-secondary">
                                 <i class="fas fa-times me-1"></i>Limpar
                             </a>
                         </div>
@@ -83,7 +83,7 @@
                                             </td>
                                             <td>
                                                 <div class="d-flex flex-wrap justify-content-center gap-1">
-                                                    <a href="{{ url_for('routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" 
+                                                    <a href="{{ url_for('agendamento_routes.detalhes_agendamento', agendamento_id=agendamento.id) }}" 
                                                        class="btn btn-sm btn-outline-info" title="Detalhes">
                                                         <i class="fas fa-info-circle me-1"></i>Detalhes
                                                     </a>
@@ -94,7 +94,7 @@
                                                             <i class="fas fa-user-plus me-1"></i>Adicionar
                                                         </a>
                                                         
-                                                        <a href="{{ url_for('routes.cancelar_agendamento_professor', agendamento_id=agendamento.id) }}" 
+                                                        <a href="{{ url_for('agendamento_routes.cancelar_agendamento_professor', agendamento_id=agendamento.id) }}" 
                                                            class="btn btn-sm btn-outline-danger" title="Cancelar">
                                                             <i class="fas fa-times me-1"></i>Cancelar
                                                         </a>

--- a/templates/professor/qrcode_agendamento.html
+++ b/templates/professor/qrcode_agendamento.html
@@ -48,7 +48,7 @@
         <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
-        <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-secondary">
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>
@@ -60,7 +60,7 @@
     {% endif %}
     
     <div class="mt-4">
-        <a href="{{ url_for('routes.meus_agendamentos') }}" class="btn btn-primary">
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-primary">
             <i class="fas fa-calendar-alt"></i> Meus Agendamentos
         </a>
         <a href="{{ url_for('dashboard_participante_routes.dashboard_participante') }}" class="btn btn-secondary">

--- a/templates/sorteio/criar_sorteio.html
+++ b/templates/sorteio/criar_sorteio.html
@@ -10,7 +10,7 @@
             </h4>
         </div>
         <div class="card-body">
-            <form method="POST" action="{{ url_for('routes.criar_sorteio') }}">
+            <form method="POST" action="{{ url_for('sorteio_routes.criar_sorteio') }}">
                 <div class="row g-3">
                     <!-- Título do Sorteio -->
                     <div class="col-md-6">

--- a/templates/sorteio/gerenciar_sorteios.html
+++ b/templates/sorteio/gerenciar_sorteios.html
@@ -5,7 +5,7 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2><i class="bi bi-trophy me-2 text-danger"></i>Gerenciar Sorteios</h2>
-        <a href="{{ url_for('routes.criar_sorteio') }}" class="btn btn-danger">
+        <a href="{{ url_for('sorteio_routes.criar_sorteio') }}" class="btn btn-danger">
             <i class="bi bi-plus-circle me-2"></i>Novo Sorteio
         </a>
     </div>
@@ -13,7 +13,7 @@
     <!-- Filtros -->
     <div class="card shadow-sm border-0 mb-4">
         <div class="card-body">
-            <form method="GET" action="{{ url_for('routes.gerenciar_sorteios') }}" class="row g-3">
+            <form method="GET" action="{{ url_for('sorteio_routes.gerenciar_sorteios') }}" class="row g-3">
                 <div class="col-md-4">
                     <label for="evento_filter" class="form-label">Evento</label>
                     <select name="evento_id" id="evento_filter" class="form-select">

--- a/templates/trabalho/avaliar_trabalhos.html
+++ b/templates/trabalho/avaliar_trabalhos.html
@@ -20,7 +20,7 @@
         <td>{{ trabalho.usuario.nome }}</td>
         <td>{{ trabalho.status }}</td>
         <td>
-          <a href="{{ url_for('routes.avaliar_trabalho', trabalho_id=trabalho.id) }}" class="btn btn-primary btn-sm">Avaliar</a>
+          <a href="{{ url_for('trabalho_routes.avaliar_trabalho', trabalho_id=trabalho.id) }}" class="btn btn-primary btn-sm">Avaliar</a>
         </td>
       </tr>
       {% endfor %}

--- a/templates/trabalho/definir_status_resposta.html
+++ b/templates/trabalho/definir_status_resposta.html
@@ -41,7 +41,7 @@
     </div>
 
     <button type="submit" class="btn btn-primary">Salvar</button>
-    <a href="{{ url_for('routes.listar_respostas_ministrante', formulario_id=resposta.formulario_id) }}"
+    <a href="{{ url_for('formularios_routes.listar_respostas_ministrante', formulario_id=resposta.formulario_id) }}"
        class="btn btn-secondary">
       Cancelar
     </a>

--- a/templates/trabalho/listar_respostas.html
+++ b/templates/trabalho/listar_respostas.html
@@ -13,7 +13,7 @@
                     <li><a class="dropdown-item" href="{{ url_for('routes.gerar_pdf_respostas', formulario_id=formulario.id) }}">
                         <i class="bi bi-file-pdf"></i> PDF
                     </a></li>
-                    <li><a class="dropdown-item" href="{{ url_for('routes.exportar_csv', formulario_id=formulario.id) }}">
+                    <li><a class="dropdown-item" href="{{ url_for('formularios_routes.exportar_csv', formulario_id=formulario.id) }}">
                         <i class="bi bi-file-excel"></i> CSV
                     </a></li>
                 </ul>
@@ -79,7 +79,7 @@
                     
                     <!-- Hidden status form (revealed by button click) -->
                     <div class="status-form mt-3" id="status-form-{{ resposta.id }}" style="display: none;">
-                        <form method="POST" action="{{ url_for('routes.definir_status_inline') }}" class="d-flex gap-2">
+                        <form method="POST" action="{{ url_for('formularios_routes.definir_status_inline') }}" class="d-flex gap-2">
                             <input type="hidden" name="resposta_id" value="{{ resposta.id }}">
                             <select name="status_avaliacao" class="form-select form-select-sm">
                                 <option value="Não Avaliada" {% if resposta.status_avaliacao == 'Não Avaliada' %} selected {% endif %}>Não Avaliada</option>

--- a/templates/trabalho/visualizar_resposta.html
+++ b/templates/trabalho/visualizar_resposta.html
@@ -67,7 +67,7 @@
                       <h6 class="text-muted mb-3">Sua resposta:</h6>
                       <div class="ps-3">
                         {% if rcampo.campo.tipo == 'file' %}
-                          <a href="{{ url_for('routes.get_resposta_file', filename=rcampo.valor|replace('uploads/respostas/', '')) }}" class="btn btn-sm btn-outline-primary">
+                          <a href="{{ url_for('formularios_routes.get_resposta_file', filename=rcampo.valor|replace('uploads/respostas/', '')) }}" class="btn btn-sm btn-outline-primary">
                             <i class="bi bi-file-earmark me-2"></i>Visualizar Anexo
                           </a>
                         {% else %}


### PR DESCRIPTION
## Summary
- adjust `url_for` blueprint prefixes throughout templates
- keep prefix as `routes.` if the route belongs to the main blueprint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772bffa288324a811d9b94670dc03