### PR TITLE
Fix missing gerar_etiquetas route

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -15,6 +15,7 @@ def register_routes(app):
     from .dashboard_routes import dashboard_routes
     # Importa rotas adicionais do cliente que utilizam o mesmo blueprint
     from . import dashboard_cliente  # noqa: F401
+    from . import pdf_routes  # noqa: F401
     from .dashboard_participante import dashboard_participante_routes
     from .dashboard_professor import dashboard_professor_routes
     from .dashboard_ministrante import dashboard_ministrante_routes

--- a/routes/pdf_routes.py
+++ b/routes/pdf_routes.py
@@ -1,0 +1,10 @@
+from flask_login import login_required
+from services.pdf_service import gerar_etiquetas
+from . import routes
+
+
+@routes.route('/gerar_etiquetas/<int:cliente_id>')
+@login_required
+def gerar_etiquetas_route(cliente_id):
+    """Endpoint para gerar etiquetas em PDF para um cliente."""
+    return gerar_etiquetas(cliente_id)


### PR DESCRIPTION
## Summary
- add a `pdf_routes` module that registers the `gerar_etiquetas` endpoint
- import `pdf_routes` in `routes/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483f072f788324bb02c16ebea64b9b