### PR TITLE
Fix route endpoint for frequency list

### DIFF
--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1391,7 +1391,7 @@
       <a href="{{ url_for('relatorio_pdf_routes.gerar_inscritos_pdf_route', oficina_id=oficina.id) }}" class="btn btn-outline-primary">
         <i class="bi bi-file-earmark-text me-2"></i>Lista de Inscritos
       </a>
-      <a href="{{ url_for('relatorio_pdf_routes.gerar_lista_frequencia_route', oficina_id=oficina.id) }}" class="btn btn-outline-secondary">
+      <a href="{{ url_for('routes.gerar_lista_frequencia_route', oficina_id=oficina.id) }}" class="btn btn-outline-secondary">
         <i class="bi bi-file-earmark-spreadsheet me-2"></i>Lista de Frequência
       </a>
       <a href="{{ url_for('routes.gerar_certificados_route', oficina_id=oficina.id) }}" class="btn btn-outline-success">


### PR DESCRIPTION
## Summary
- fix the URL endpoint for generating the frequency list in the customer dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848b9eda62c832491f3b74e822f5a45