### PR TITLE
Fix form response export endpoints

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -27,6 +27,7 @@ from models import (
     Oficina,
     Ministrante,
 )
+from services.pdf_service import gerar_pdf_respostas
 
 formularios_routes = Blueprint(
     'formularios_routes',
@@ -306,6 +307,18 @@ def exportar_csv(formulario_id):
         mimetype="text/csv",
         headers={"Content-Disposition": f"attachment; filename={csv_filename}"}
     )
+
+
+@formularios_routes.route('/formularios/<int:formulario_id>/gerar_pdf_respostas')
+@login_required
+def gerar_pdf_respostas_route(formulario_id):
+    """Gera um PDF contendo todas as respostas do formulário."""
+    resultado = gerar_pdf_respostas(formulario_id)
+    if isinstance(resultado, tuple):
+        _, mensagem = resultado
+        flash(mensagem, 'warning')
+        return redirect(request.referrer or url_for('formularios_routes.listar_respostas'))
+    return resultado
 
 
 @formularios_routes.route('/respostas/<path:filename>')

--- a/templates/trabalho/definir_status_resposta.html
+++ b/templates/trabalho/definir_status_resposta.html
@@ -42,7 +42,7 @@
 
     <button type="submit" class="btn btn-primary">Salvar</button>
 
-    <a href="{{ url_for('trabalho_routes.listar_respostas_ministrante', formulario_id=resposta.formulario_id) }}"
+    <a href="{{ url_for('formularios_routes.listar_respostas_ministrante', formulario_id=resposta.formulario_id) }}"
 
        class="btn btn-secondary">
       Cancelar

--- a/templates/trabalho/listar_respostas.html
+++ b/templates/trabalho/listar_respostas.html
@@ -10,11 +10,11 @@
                     <i class="bi bi-download"></i> Exportar
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="exportDropdown">
-                    <li><a class="dropdown-item" href="{{ url_for('trabalho_routes.gerar_pdf_respostas', formulario_id=formulario.id) }}">
+                    <li><a class="dropdown-item" href="{{ url_for('formularios_routes.gerar_pdf_respostas', formulario_id=formulario.id) }}">
                         <i class="bi bi-file-pdf"></i> PDF
                     </a></li>
 
-                    <li><a class="dropdown-item" href="{{ url_for('trabalho_routes.exportar_csv', formulario_id=formulario.id) }}">
+                    <li><a class="dropdown-item" href="{{ url_for('formularios_routes.exportar_csv', formulario_id=formulario.id) }}">
 
                         <i class="bi bi-file-excel"></i> CSV
                     </a></li>
@@ -74,7 +74,7 @@
                                 <i class="bi bi-pencil-square"></i> Alterar Status
                             </button>
                         </div>
-                        <a href="{{ url_for('trabalho_routes.dar_feedback_resposta_formulario', resposta_id=resposta.id) }}" class="btn btn-sm btn-primary">
+                        <a href="{{ url_for('formularios_routes.dar_feedback_resposta_formulario', resposta_id=resposta.id) }}" class="btn btn-sm btn-primary">
                             <i class="bi bi-eye"></i> Ver / Feedback
                         </a>
                     </div>
@@ -82,7 +82,7 @@
                     <!-- Hidden status form (revealed by button click) -->
                     <div class="status-form mt-3" id="status-form-{{ resposta.id }}" style="display: none;">
 
-                        <form method="POST" action="{{ url_for('trabalho_routes.definir_status_inline') }}" class="d-flex gap-2">
+                        <form method="POST" action="{{ url_for('formularios_routes.definir_status_inline') }}" class="d-flex gap-2">
 
                             <input type="hidden" name="resposta_id" value="{{ resposta.id }}">
                             <select name="status_avaliacao" class="form-select form-select-sm">

--- a/templates/trabalho/visualizar_resposta.html
+++ b/templates/trabalho/visualizar_resposta.html
@@ -68,7 +68,7 @@
                       <div class="ps-3">
                         {% if rcampo.campo.tipo == 'file' %}
 
-                          <a href="{{ url_for('trabalho_routes.get_resposta_file', filename=rcampo.valor|replace('uploads/respostas/', '')) }}" class="btn btn-sm btn-outline-primary">
+                          <a href="{{ url_for('formularios_routes.get_resposta_file', filename=rcampo.valor|replace('uploads/respostas/', '')) }}" class="btn btn-sm btn-outline-primary">
 
                             <i class="bi bi-file-earmark me-2"></i>Visualizar Anexo
                           </a>


### PR DESCRIPTION
## Summary
- reference correct blueprint when exporting form responses
- allow PDF export of form answers via new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c706ffcc83248c6cc8eb6a5128ce