### PR TITLE
Fix PDF export link

### DIFF
--- a/templates/trabalho/listar_respostas.html
+++ b/templates/trabalho/listar_respostas.html
@@ -10,7 +10,7 @@
                     <i class="bi bi-download"></i> Exportar
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="exportDropdown">
-                    <li><a class="dropdown-item" href="{{ url_for('formularios_routes.gerar_pdf_respostas', formulario_id=formulario.id) }}">
+                    <li><a class="dropdown-item" href="{{ url_for('formularios_routes.gerar_pdf_respostas_route', formulario_id=formulario.id) }}">
                         <i class="bi bi-file-pdf"></i> PDF
                     </a></li>
 


### PR DESCRIPTION
## Summary
- fix incorrect endpoint for PDF export link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c9c728bc8324b268ecdfe8d760af