### PR TITLE
Fix template path references in routes

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -214,7 +214,7 @@ def lista_checkins(oficina_id):
     ministrantes = [m.nome for m in oficina.ministrantes_associados] if oficina.ministrantes_associados else []
 
     return render_template(
-        'lista_checkins.html',
+        'checkin/lista_checkins.html',
         oficina=oficina,
         usuarios_checkin=usuarios_checkin,
         ministrantes=ministrantes

--- a/routes/feedback_routes.py
+++ b/routes/feedback_routes.py
@@ -123,7 +123,7 @@ def feedback_oficina(oficina_id):
     feedbacks = query.order_by(Feedback.created_at.desc()).all()
 
     
-    return render_template('feedback_oficina.html', oficina=oficina, feedbacks=feedbacks,
+    return render_template('oficina/feedback_oficina.html', oficina=oficina, feedbacks=feedbacks,
                            total_count=total_count, total_avg=total_avg,
                            count_ministrantes=count_ministrantes, avg_ministrantes=avg_ministrantes,
                            count_usuarios=count_usuarios, avg_usuarios=avg_usuarios,  is_admin=current_user.tipo == 'admin', clientes=clientes, cliente_filter=cliente_filter)

--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -287,7 +287,7 @@ def editar_oficina(oficina_id):
             db.session.rollback()
             flash(f'Erro ao editar oficina: {str(e)}', 'danger')
             return render_template(
-                'editar_oficina.html',
+                'oficina/editar_oficina.html',
                 oficina=oficina,
                 estados=estados,
                 ministrantes=ministrantes,
@@ -296,7 +296,7 @@ def editar_oficina(oficina_id):
             )
 
     return render_template(
-        'editar_oficina.html',
+        'oficina/editar_oficina.html',
         oficina=oficina,
         estados=estados,
         ministrantes=ministrantes,


### PR DESCRIPTION
## Summary
- fix template paths for editing offices, listing check-ins and feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cc11fd608324b8bdd76a88a8668d