### PR TITLE
Fix missing templates and request import

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -14,7 +14,7 @@ from models import (
     Usuario, RegraInscricaoEvento, LoteTipoInscricao, Inscricao
 )
 
-evento_routes = Blueprint('evento_routes', __name__)
+evento_routes = Blueprint('evento_routes', __name__, template_folder="../templates")
 
 
 @evento_routes.route('/')
@@ -134,7 +134,7 @@ def listar_eventos():
             evento_dict = {
                 'id': evento.id,
                 'nome': evento.nome,
-                # adicione outros campos necessários para o template eventos.html
+                # adicione outros campos necessários para o template eventos_disponiveis.html
                 'data_inicio': evento.data_inicio.strftime('%d/%m/%Y') if evento.data_inicio else 'Data a definir',
                 'localizacao': evento.localizacao or 'Local a definir',
                 'preco_base': 0
@@ -145,11 +145,11 @@ def listar_eventos():
             
             eventos_processed.append(evento_dict)
         
-        return render_template('eventos.html', eventos=eventos_processed)
+        return render_template('evento/eventos_disponiveis.html', eventos=eventos_processed)
     
     except Exception as e:
         print(f"Erro em listar_eventos: {str(e)}")
-        return render_template('eventos.html', eventos=[])
+        return render_template('evento/eventos_disponiveis.html', eventos=[])
 
 @evento_routes.route('/configurar_evento', methods=['GET', 'POST'])
 @login_required
@@ -521,7 +521,7 @@ def configurar_evento():
             traceback.print_exc()
 
     return render_template(
-    "configurar_evento.html",
+    "evento/configurar_evento.html",
     eventos=eventos,
     evento=evento,
     habilita_pagamento=current_user.habilita_pagamento   #  <-- acrescente isto
@@ -730,7 +730,7 @@ def criar_evento():
             flash(f'Erro ao criar evento: {str(e)}', 'danger')
 
     # Retorna ao template, passando o 'evento' mesmo que seja None
-    return render_template('criar_evento.html', evento=evento)
+    return render_template('evento/criar_evento.html', evento=evento)
 
 @evento_routes.route('/evento/<identifier>')
 def pagina_evento(identifier):

--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -11,7 +11,7 @@ from models import (
 )
 from flask import Blueprint
 
-oficina_routes = Blueprint('oficina_routes', __name__)
+oficina_routes = Blueprint('oficina_routes', __name__, template_folder="../templates/oficina")
 
 @oficina_routes.route('/criar_oficina', methods=['GET', 'POST'])
 @login_required
@@ -287,7 +287,7 @@ def editar_oficina(oficina_id):
             db.session.rollback()
             flash(f'Erro ao editar oficina: {str(e)}', 'danger')
             return render_template(
-                'oficina/editar_oficina.html',
+                'editar_oficina.html',
                 oficina=oficina,
                 estados=estados,
                 ministrantes=ministrantes,
@@ -296,7 +296,7 @@ def editar_oficina(oficina_id):
             )
 
     return render_template(
-        'oficina/editar_oficina.html',
+        'editar_oficina.html',
         oficina=oficina,
         estados=estados,
         ministrantes=ministrantes,
@@ -440,7 +440,7 @@ def eventos_com_oficinas():
 @login_required
 def oficinas_disponiveis():
     oficinas = Oficina.query.filter_by(cliente_id=current_user.cliente_id).all()
-    return render_template('oficina/oficinas.html', oficinas=oficinas)
+    return render_template('oficinas.html', oficinas=oficinas)
 
 # routes/links_ui.py  (ou no mesmo arquivo se preferir)
 @oficina_routes.route("/links/gerar", methods=["GET"])
@@ -457,5 +457,5 @@ def listar_oficinas():
     else:
         oficinas = Oficina.query.all()
 
-    return render_template('oficina/oficinas.html', oficinas=oficinas)
+    return render_template('oficinas.html', oficinas=oficinas)
 

--- a/routes/sorteio_routes.py
+++ b/routes/sorteio_routes.py
@@ -1,12 +1,12 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, render_template, request, redirect, url_for, flash
 from flask_login import current_user, login_required
 from datetime import datetime
 import random
-from models import Sorteio, Usuario, Inscricao
+from models import Sorteio, Usuario, Inscricao, Evento, Oficina
 from extensions import db
 
 # Criação do blueprint
-sorteio_routes = Blueprint('sorteio_routes', __name__)
+sorteio_routes = Blueprint('sorteio_routes', __name__, template_folder="../templates/sorteio")
 
 @sorteio_routes.route('/api/sorteio_info/<int:sorteio_id>')
 @login_required


### PR DESCRIPTION
## Summary
- register event, workshop and drawing blueprints with template folders
- fix template paths for event and workshop views
- import request and other helpers in sorteio routes
- adjust blueprint template folders

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ceb8286c8324b435cfc85394537e