### PR TITLE
Import lote_service for route registration

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -47,6 +47,8 @@ def register_routes(app):
     from .mercadopago_routes import mercadopago_routes
     from .util_routes import util_routes
     from .relatorio_pdf_routes import relatorio_pdf_routes
+    # Importa servicos que registram rotas diretamente no blueprint
+    from services import lote_service  # noqa: F401
 
     # Registra o blueprint principal somente após importar rotas que o utilizam
     app.register_blueprint(routes)


### PR DESCRIPTION
## Summary
- ensure `/api/lote_vigente/<int:evento_id>` is registered by importing `services.lote_service`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d4911ae083249f7731ae80cf9b8a