### PR TITLE
Add missing queries in cadastro_participante

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -84,17 +84,32 @@ def cadastro_participante(identifier: str | None = None):
     # 5) Carregar outras variáveis para o template (como oficinas, programação etc.)
     # ---------------------------------------------------------------------
     grouped_oficinas = {}  # ajustar conforme sua lógica
-    sorted_keys = []      
-    return render_template("auth/cadastro_participante.html",
-                           evento=evento,
-                           tipos_inscricao=tipos_inscricao,
-                           lote_vigente=lote_vigente,
-                           lote_stats=lote_stats,
-                           grouped_oficinas=grouped_oficinas,
-                           sorted_keys=sorted_keys,
-                           ministrantes=ministrantes,
-                           campos_personalizados=campos_personalizados,
-                           token=identifier)
+    sorted_keys = []
+
+    # Dados adicionais esperados pelo template
+    ministrantes = (
+        Ministrante.query.join(Oficina)
+        .filter(Oficina.evento_id == evento.id)
+        .distinct()
+        .all()
+    )
+    campos_personalizados = CampoPersonalizadoCadastro.query.filter_by(
+        cliente_id=evento.cliente_id
+    ).all()
+    lotes_ativos = LoteInscricao.query.filter_by(evento_id=evento.id, ativo=True).all()
+    return render_template(
+        "auth/cadastro_participante.html",
+        evento=evento,
+        tipos_inscricao=tipos_inscricao,
+        lote_vigente=lote_vigente,
+        lote_stats=lote_stats,
+        grouped_oficinas=grouped_oficinas,
+        sorted_keys=sorted_keys,
+        ministrantes=ministrantes,
+        campos_personalizados=campos_personalizados,
+        lotes_ativos=lotes_ativos,
+        token=identifier,
+    )
 
 
 


### PR DESCRIPTION
## Summary
- fetch `ministrantes`, `campos_personalizados` and `lotes_ativos` in `cadastro_participante`
- pass the new variables when rendering the template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d492ae048324abb7a5d6d4060f70