### PR TITLE
Add current lote section for dynamic updates

### DIFF
--- a/static/css/cadastro_participante.css
+++ b/static/css/cadastro_participante.css
@@ -767,10 +767,16 @@
     margin-bottom: 8px;
     }
     
-    .lote-info p {
+.lote-info p {
     margin-bottom: 5px;
     font-size: 0.9rem;
-    }
+}
+
+.current-lote {
+    font-weight: 600;
+    color: var(--primary-color);
+    margin-bottom: 15px;
+}
     
     .outros-lotes {
     margin-top: 15px;

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -298,6 +298,7 @@
                                 <p>Vagas: {{ lote_stats.vagas_usadas }}/{{ lote_stats.vagas_totais if lote_stats.vagas_totais != "ilimitado" else "Ilimitadas" }}</p>
                                 <p>Período: {{ lote_stats.data_inicio }} a {{ lote_stats.data_fim }}</p>
                             </div>
+                            <div class="current-lote"></div>
 
                             <div class="ticket-options">
                                 {% for lote_tipo in lote_vigente.tipos_inscricao %}


### PR DESCRIPTION
## Summary
- show current lote info in participant signup template
- add styling for `.current-lote` to match design

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d494053c8324b88020252246edc6