### PR TITLE
Improve price validation

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -267,8 +267,9 @@ def configurar_evento():
                 tipos_inscricao = []
                 for nome_tipo, preco_tipo in zip(nomes_tipos, precos_tipos):
                     if nome_tipo:  # Só adicionar se o nome for preenchido
-                        # Se for inscrição gratuita, definir preço como 0.00
-                        preco_efetivo = 0.0 if inscricao_gratuita else float(preco_tipo)
+                        # Se o preço estiver vazio, trata como 0
+                        preco_tipo_str = preco_tipo.strip() if preco_tipo else ''
+                        preco_efetivo = 0.0 if inscricao_gratuita or preco_tipo_str == '' else float(preco_tipo_str)
                         
                         # Verificar se já existe um tipo com este nome
                         tipo_existente = None
@@ -385,10 +386,11 @@ def configurar_evento():
                                 # O formato do nome do campo: lote_tipo_preco_[lote_id]_[tipo_id]
                                 preco_key = f'lote_tipo_preco_{lote.id}_{tipo.id}'
                                 preco_valor = request.form.get(preco_key)
-                                
+
                                 if preco_valor is not None:
-                                    # Se for gratuito, todos os preços são 0
-                                    preco_final = 0.0 if inscricao_gratuita else float(preco_valor)
+                                    preco_valor = preco_valor.strip()
+                                    # Se o valor estiver vazio ou for gratuito, usar 0
+                                    preco_final = 0.0 if inscricao_gratuita or preco_valor == '' else float(preco_valor)
                                     
                                     # Verificar se já existe um registro de preço para este lote e tipo
                                     lote_tipo = LoteTipoInscricao.query.filter_by(
@@ -427,8 +429,9 @@ def configurar_evento():
                 tipos_inscricao = []
                 for nome_tipo, preco_tipo in zip(nomes_tipos, precos_tipos):
                     if nome_tipo:  # Só adicionar se o nome for preenchido
-                        # Se for inscrição gratuita, definir preço como 0.00
-                        preco_efetivo = 0.0 if inscricao_gratuita else float(preco_tipo)
+                        # Se o preço estiver vazio, trata como 0
+                        preco_tipo_str = preco_tipo.strip() if preco_tipo else ''
+                        preco_efetivo = 0.0 if inscricao_gratuita or preco_tipo_str == '' else float(preco_tipo_str)
                         
                         tipo = EventoInscricaoTipo(
                             evento_id=evento.id,
@@ -488,10 +491,11 @@ def configurar_evento():
                                 preco_key = f'lote_tipo_preco_new_{i}_{tipo.id}'
                                 # Verificar também o formato alternativo para compatibilidade
                                 preco_valor = request.form.get(preco_key) or request.form.get(f'lote_tipo_preco_new_{i}_new_{j}')
-                                
+
                                 if preco_valor is not None:
-                                    # Se for gratuito, todos os preços são 0
-                                    preco_final = 0.0 if inscricao_gratuita else float(preco_valor)
+                                    preco_valor = preco_valor.strip()
+                                    # Se o valor estiver vazio ou for gratuito, usar 0
+                                    preco_final = 0.0 if inscricao_gratuita or preco_valor == '' else float(preco_valor)
                                     
                                     novo_lote_tipo = LoteTipoInscricao(
                                         lote_id=lote.id,
@@ -652,7 +656,9 @@ def criar_evento():
                 tipos_inscricao = []
                 for i, nome in enumerate(nomes_tipos):
                     if nome.strip():  # Só criar se o nome não estiver vazio
-                        preco = 0.0 if inscricao_gratuita else float(precos[i])
+                        preco_tipo = precos[i] if i < len(precos) else ''
+                        preco_tipo = preco_tipo.strip() if preco_tipo else ''
+                        preco = 0.0 if inscricao_gratuita or preco_tipo == '' else float(preco_tipo)
                         novo_tipo = EventoInscricaoTipo(
                             evento_id=novo_evento.id,
                             nome=nome,
@@ -708,10 +714,11 @@ def criar_evento():
                                 # O formato do name é lote_tipo_preco_0_1 onde 0 é o índice do lote e 1 é o índice do tipo
                                 preco_key = f'lote_tipo_preco_{i}_{j}'
                                 preco_lote = request.form.get(preco_key)
-                                
+
                                 if preco_lote:
-                                    # Se o evento for gratuito, todos os preços são 0
-                                    preco_valor = 0.0 if inscricao_gratuita else float(preco_lote)
+                                    preco_lote = preco_lote.strip()
+                                    # Se o evento for gratuito ou o valor estiver vazio, usar 0
+                                    preco_valor = 0.0 if inscricao_gratuita or preco_lote == '' else float(preco_lote)
                                     
                                     novo_preco = LoteTipoInscricao(
                                         lote_id=novo_lote.id,


### PR DESCRIPTION
## Summary
- handle empty price inputs when editing or creating events and lots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499ad12a608324987971dc15099771