### PR TITLE
Fix modals tilt on dashboard

### DIFF
--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -5,9 +5,7 @@
 {{ super() }}
 <link rel="stylesheet" href="/static/css/dashboard_cliente.css">
 <link rel="stylesheet" href="/static/css/dashboard_cliente_responsive.css">
-<link rel="stylesheet" href="/static/css/dashboard_cliente_modals.css">
 <link rel="stylesheet" href="/static/css/dashboard_cliente_table.css">
-<link rel="stylesheet" href="/static/css/dashboard_cliente_modals_responsive.css">
 {% endblock %}
 
 {% block content %}
@@ -1241,6 +1239,7 @@
 <!-- Mantendo a integração com o script original sem modificações -->
 <!-- Javascript com ícones e labels melhorados -->
 
+</div>
 
 <!-- MODALS -->
 <!-- Modal do Relatório de Mensagem -->


### PR DESCRIPTION
## Summary
- remove references to missing CSS files in `dashboard_cliente.html`
- close main container before modals so they aren't nested in transformed elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499c29fe4c8324b0f427c5cfe0ca73