### PR TITLE
Fix registration lots display

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -67,37 +67,6 @@ def cadastro_participante(identifier: str | None = None):
 
     tipos_inscricao = EventoInscricaoTipo.query.filter_by(evento_id=evento.id).all()
 
-    # ---------------------------------------------------------------------
-    # 5) Carregar outras variáveis para o template (como oficinas, programação etc.)
-    # ---------------------------------------------------------------------
-    grouped_oficinas = {}  # ajustar conforme sua lógica
-    sorted_keys = []
-
-    # Dados adicionais esperados pelo template
-    ministrantes = (
-        Ministrante.query.join(Oficina)
-        .filter(Oficina.evento_id == evento.id)
-        .distinct()
-        .all()
-    )
-    campos_personalizados = CampoPersonalizadoCadastro.query.filter_by(
-        cliente_id=evento.cliente_id
-    ).all()
-    lotes_ativos = LoteInscricao.query.filter_by(evento_id=evento.id, ativo=True).all()
-    return render_template(
-        "auth/cadastro_participante.html",
-        evento=evento,
-        tipos_inscricao=tipos_inscricao,
-        lote_vigente=lote_vigente,
-        lote_stats=lote_stats,
-        grouped_oficinas=grouped_oficinas,
-        sorted_keys=sorted_keys,
-        ministrantes=ministrantes,
-        campos_personalizados=campos_personalizados,
-        lotes_ativos=lotes_ativos,
-        token=identifier,
-    )
-
     # ------------------------------------------------------------------
     # 3) Processamento do POST
     # ------------------------------------------------------------------

--- a/tests/test_inscricao_routes.py
+++ b/tests/test_inscricao_routes.py
@@ -1,0 +1,54 @@
+import pytest
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+
+from app import create_app
+from extensions import db
+from models import Cliente, Evento, EventoInscricaoTipo, LoteInscricao, LoteTipoInscricao, LinkCadastro
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+
+    with app.app_context():
+        db.create_all()
+
+        cliente = Cliente(nome='Cliente', email='c@example.com', senha='123')
+        db.session.add(cliente)
+        db.session.commit()
+
+        evento = Evento(cliente_id=cliente.id, nome='Evento Teste', habilitar_lotes=True, inscricao_gratuita=False)
+        db.session.add(evento)
+        db.session.commit()
+
+        tipo = EventoInscricaoTipo(evento_id=evento.id, nome='Pago', preco=20.0)
+        db.session.add(tipo)
+        db.session.commit()
+
+        lote = LoteInscricao(evento_id=evento.id, nome='Lote 1')
+        db.session.add(lote)
+        db.session.commit()
+
+        lt = LoteTipoInscricao(lote_id=lote.id, tipo_inscricao_id=tipo.id, preco=20.0)
+        db.session.add(lt)
+        db.session.commit()
+
+        link = LinkCadastro(cliente_id=cliente.id, evento_id=evento.id, token='testtoken')
+        db.session.add(link)
+        db.session.commit()
+
+    yield app
+
+@pytest.fixture
+
+def client(app):
+    return app.test_client()
+
+def test_get_inscricao_page(client):
+    resp = client.get('/inscricao/token/testtoken')
+    assert resp.status_code == 200
+    assert b'Evento Teste' in resp.data
+


### PR DESCRIPTION
## Summary
- fix registration modal route to avoid premature return
- add regression test for registration page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cc52249483249558de57da971f55