### PR TITLE
Fix missing payment flag in event templates

### DIFF
--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 <div class="container py-5">
+  <input type="hidden" id="pagamento_habilitado" value="{{ 1 if current_user.habilita_pagamento else 0 }}">
   <div class="bg-primary bg-gradient rounded-3 p-4 mb-4 shadow-sm">
     <h1 class="h3 fw-bold text-white mb-0">
       <i class="bi bi-calendar-event me-2"></i>Configurar Evento

--- a/templates/evento/criar_evento.html
+++ b/templates/evento/criar_evento.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 
 <div class="container py-5">
+  <input type="hidden" id="pagamento_habilitado" value="{{ 1 if current_user.habilita_pagamento else 0 }}">
   <!-- Cabeçalho -->
   <div class="bg-primary bg-gradient rounded-3 p-4 mb-4 shadow-sm">
     <h1 class="h3 fw-bold text-white mb-0">


### PR DESCRIPTION
## Summary
- add hidden field `pagamento_habilitado` in `criar_evento.html`
- add same hidden field in `configurar_evento.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d0819ae48324ad141b779f64a9c2