### PR TITLE
Fix missing error template

### DIFF
--- a/templates/erro.html
+++ b/templates/erro.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Erro{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="alert alert-danger" role="alert">
+        {{ mensagem or "Ocorreu um erro inesperado." }}
+    </div>
+    <a href="{{ url_for('routes.index') }}" class="btn btn-primary">Voltar</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `templates/erro.html` for error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e7872e888324b263e80d5a095d71