### PR TITLE
Fix scroll script for navbar links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -686,7 +686,16 @@
             // Smooth scroll para links com âncora
             document.querySelectorAll('a[href^="#"]').forEach(anchor => {
                 anchor.addEventListener('click', function(e) {
-                    const target = document.querySelector(this.getAttribute('href'));
+                    const href = this.getAttribute('href');
+                    if (!href || href === '#') return;  // links como "#" servem para abrir dropdowns
+
+                    let target;
+                    try {
+                        target = document.querySelector(href);
+                    } catch (err) {
+                        return; // href inválido
+                    }
+
                     if (target) {
                         e.preventDefault();
                         target.scrollIntoView({


### PR DESCRIPTION
## Summary
- skip smooth-scroll for dropdown links

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_684a0a309f7c8324bf1686c1958c8dbb