### PR TITLE
Support lote and tipo IDs on Inscricao init

### DIFF
--- a/models.py
+++ b/models.py
@@ -255,12 +255,14 @@ class Inscricao(db.Model):
         index=True        # ➊  (gera índice)
     )
 
-    def __init__(self, usuario_id, cliente_id, oficina_id=None, evento_id=None, status_pagamento="pending"):
+    def __init__(self, usuario_id, cliente_id, oficina_id=None, evento_id=None, status_pagamento="pending", lote_id=None, tipo_inscricao_id=None):
         self.usuario_id = usuario_id
         self.cliente_id = cliente_id
         self.oficina_id = oficina_id
         self.evento_id = evento_id
         self.status_pagamento = status_pagamento
+        self.lote_id = lote_id
+        self.tipo_inscricao_id = tipo_inscricao_id
 
         # Gera um token único garantido
         while True:

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -478,16 +478,14 @@ def inscrever(oficina_id):
     
     # Criar a inscrição
     inscricao = Inscricao(
-        usuario_id=current_user.id, 
-        oficina_id=oficina.id, 
+        usuario_id=current_user.id,
+        oficina_id=oficina.id,
         cliente_id=current_user.cliente_id,
-        evento_id=oficina.evento_id  # Importante: associar ao evento da oficina
+        evento_id=oficina.evento_id,  # Importante: associar ao evento da oficina
+        tipo_inscricao_id=tipo_inscricao_id if tipo_inscricao_id else None,
     )
-    
-    if tipo_inscricao_id:
-        inscricao.tipo_inscricao_id = tipo_inscricao_id
-        # Aqui você pode chamar a função que integra com o Mercado Pago
-        # Exemplo: url_pagamento = iniciar_pagamento(inscricao)
+    # Aqui você pode chamar a função que integra com o Mercado Pago
+    # Exemplo: url_pagamento = iniciar_pagamento(inscricao)
     
     try:
         db.session.add(inscricao)


### PR DESCRIPTION
## Summary
- allow `Inscricao` to accept `lote_id` and `tipo_inscricao_id`
- propagate these parameters when creating inscricoes for oficinas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a15c8322083248f3040cd5aa43afe