### PR TITLE
Fix MercadoPago callback endpoints

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -241,11 +241,11 @@ def _criar_preferencia_mp(sdk, preco: float, titulo: str, inscricao: Inscricao, 
         "payer": {"email": usuario.email, "name": usuario.nome},
         "external_reference": str(inscricao.id),
         "back_urls": {
-            "success": url_for("routes.pagamento_sucesso", _external=True),
-            "failure": url_for("routes.pagamento_falha", _external=True),
-            "pending": url_for("routes.pagamento_pendente", _external=True),
+            "success": url_for("mercadopago_routes.pagamento_sucesso", _external=True),
+            "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
+            "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True),
         },
-        "notification_url": url_for("routes.webhook_mp", _external=True),
+        "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True),
         "auto_return": "approved",
     }
 

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -4076,12 +4076,12 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
         "payer": {"email": usuario.email},
         "external_reference": str(usuario.id),
         "back_urls": {
-            "success": url_for("routes.pagamento_sucesso", _external=True),
-            "failure": url_for("routes.pagamento_falhou", _external=True),
-            "pending": url_for("routes.pagamento_pendente", _external=True)
+            "success": url_for("mercadopago_routes.pagamento_sucesso", _external=True),
+            "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
+            "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True)
         },
         "auto_return": "approved",
-        "notification_url": url_for("routes.webhook_mp", _external=True)
+        "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True)
     }
     try:
         pref = sdk.preference().create(preference_data)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -983,12 +983,12 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
         "payer": {"email": usuario.email},
         "external_reference": str(usuario.id),
         "back_urls": {
-            "success": url_for("routes.pagamento_sucesso", _external=True),
-            "failure": url_for("routes.pagamento_falhou", _external=True),
-            "pending": url_for("routes.pagamento_pendente", _external=True)
+            "success": url_for("mercadopago_routes.pagamento_sucesso", _external=True),
+            "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
+            "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True)
         },
         "auto_return": "approved",
-        "notification_url": url_for("routes.webhook_mp", _external=True)
+        "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True)
     }
     pref = sdk.preference().create(preference_data)
     return pref["response"]["init_point"]


### PR DESCRIPTION
## Summary
- use mercadopago_routes endpoints in services and utils
- use mercadopago_routes in inscricao_routes

## Testing
- `pytest -q`
- `flake8` *(fails: E501 and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a27c26b0883249604058fc611a7d7