### PR TITLE
Fix Mercado Pago auto_return handling

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -246,8 +246,11 @@ def _criar_preferencia_mp(sdk, preco: float, titulo: str, inscricao: Inscricao, 
             "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True),
         },
         "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True),
-        "auto_return": "approved",
     }
+
+    auto_return = os.getenv("MP_AUTO_RETURN")
+    if auto_return:
+        preference_data["auto_return"] = auto_return
 
     try:
         pref = sdk.preference().create(preference_data)

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -4047,9 +4047,11 @@ def criar_preferencia_pagamento(nome, email, descricao, valor, return_url):
             "success": return_url,
             "failure": return_url,
             "pending": return_url
-        },
-        "auto_return": "approved"
+        }
     }
+    auto_return = os.getenv("MP_AUTO_RETURN")
+    if auto_return:
+        preference_data["auto_return"] = auto_return
     try:
         preference_response = sdk.preference().create(preference_data)
         return preference_response["response"]["init_point"]
@@ -4080,9 +4082,11 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
             "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
             "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True)
         },
-        "auto_return": "approved",
         "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True)
     }
+    auto_return = os.getenv("MP_AUTO_RETURN")
+    if auto_return:
+        preference_data["auto_return"] = auto_return
     try:
         pref = sdk.preference().create(preference_data)
         return pref["response"]["init_point"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -958,9 +958,11 @@ def criar_preferencia_pagamento(nome, email, descricao, valor, return_url):
             "success": return_url,
             "failure": return_url,
             "pending": return_url
-        },
-        "auto_return": "approved"
+        }
     }
+    auto_return = os.getenv("MP_AUTO_RETURN")
+    if auto_return:
+        preference_data["auto_return"] = auto_return
     preference_response = sdk.preference().create(preference_data)
     return preference_response["response"]["init_point"]
 
@@ -987,9 +989,11 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
             "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
             "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True)
         },
-        "auto_return": "approved",
         "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True)
     }
+    auto_return = os.getenv("MP_AUTO_RETURN")
+    if auto_return:
+        preference_data["auto_return"] = auto_return
     pref = sdk.preference().create(preference_data)
     return pref["response"]["init_point"]
 


### PR DESCRIPTION
## Summary
- make Mercado Pago auto_return optional via `MP_AUTO_RETURN`
- avoid API failures when `back_urls.success` isn't public

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2e1c63288324b7df7d2600c0ec45