### PR TITLE
Fix Mercado Pago webhook URL generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ export MAIL_USERNAME="seu_email@gmail.com"
 export MAIL_PASSWORD="sua_senha"
 export GOOGLE_CLIENT_ID="<cliente_id_do_google>"
 export GOOGLE_CLIENT_SECRET="<cliente_secret_do_google>"
+export APP_BASE_URL="https://seu-dominio.com"
 ```
 
 Essas variaveis substituem o antigo arquivo `credentials.json` utilizado para a
 autenticacao com a API do Gmail. O arquivo `token.json` sera gerado apos a
 primeira autenticacao.
+
+`APP_BASE_URL` define a URL base para gerar links externos, como o `notification_url` do Mercado Pago. Em desenvolvimento, aponte para um endereço público (ex.: URL do ngrok).

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -16,6 +16,7 @@ import logging
 from dateutil import parser
 from sqlalchemy import func
 from services.lote_service import lote_disponivel
+from utils import external_url
 
 
 class LoteEsgotadoError(RuntimeError):
@@ -241,11 +242,11 @@ def _criar_preferencia_mp(sdk, preco: float, titulo: str, inscricao: Inscricao, 
         "payer": {"email": usuario.email, "name": usuario.nome},
         "external_reference": str(inscricao.id),
         "back_urls": {
-            "success": url_for("mercadopago_routes.pagamento_sucesso", _external=True),
-            "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
-            "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True),
+            "success": external_url("mercadopago_routes.pagamento_sucesso"),
+            "failure": external_url("mercadopago_routes.pagamento_falha"),
+            "pending": external_url("mercadopago_routes.pagamento_pendente"),
         },
-        "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True),
+        "notification_url": external_url("mercadopago_routes.webhook_mp"),
     }
 
     auto_return = os.getenv("MP_AUTO_RETURN")

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1,4 +1,5 @@
 from flask_login import login_required
+from utils import external_url
 
 def gerar_lista_frequencia_pdf(oficina, pdf_path):
     """
@@ -4078,11 +4079,11 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
         "payer": {"email": usuario.email},
         "external_reference": str(usuario.id),
         "back_urls": {
-            "success": url_for("mercadopago_routes.pagamento_sucesso", _external=True),
-            "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
-            "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True)
+            "success": external_url("mercadopago_routes.pagamento_sucesso"),
+            "failure": external_url("mercadopago_routes.pagamento_falha"),
+            "pending": external_url("mercadopago_routes.pagamento_pendente"),
         },
-        "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True)
+        "notification_url": external_url("mercadopago_routes.webhook_mp")
     }
     auto_return = os.getenv("MP_AUTO_RETURN")
     if auto_return:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -985,11 +985,11 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
         "payer": {"email": usuario.email},
         "external_reference": str(usuario.id),
         "back_urls": {
-            "success": url_for("mercadopago_routes.pagamento_sucesso", _external=True),
-            "failure": url_for("mercadopago_routes.pagamento_falha", _external=True),
-            "pending": url_for("mercadopago_routes.pagamento_pendente", _external=True)
+            "success": external_url("mercadopago_routes.pagamento_sucesso"),
+            "failure": external_url("mercadopago_routes.pagamento_falha"),
+            "pending": external_url("mercadopago_routes.pagamento_pendente"),
         },
-        "notification_url": url_for("mercadopago_routes.webhook_mp", _external=True)
+        "notification_url": external_url("mercadopago_routes.webhook_mp")
     }
     auto_return = os.getenv("MP_AUTO_RETURN")
     if auto_return:
@@ -1002,6 +1002,13 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
 from functools import wraps
 from flask_login import current_user
 from flask import flash, redirect, url_for, request
+
+def external_url(endpoint: str, **values) -> str:
+    """Gera URL absoluta usando APP_BASE_URL se definido."""
+    base = os.getenv("APP_BASE_URL")
+    if base:
+        return base.rstrip("/") + url_for(endpoint, _external=False, **values)
+    return url_for(endpoint, _external=True, **values)
 
 def pagamento_necessario(f):
     @wraps(f)


### PR DESCRIPTION
## Summary
- add `external_url` helper using new `APP_BASE_URL` env var
- use helper when creating Mercado Pago preferences
- document `APP_BASE_URL` setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a311945e88324846e38a7ccbf0695