### PR TITLE
Harmonize event setup page with creation workflow

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -185,8 +185,10 @@ def configurar_evento():
         programacao = request.form.get('programacao')
         localizacao = request.form.get('localizacao')
         link_mapa = request.form.get('link_mapa')
-        inscricao_gratuita = request.form.get('inscricao_gratuita') == 'on'  # Checkbox retorna 'on' se marcado
-        habilitar_lotes = request.form.get('habilitar_lotes') == 'on'  # Novo campo
+        inscricao_gratuita_val = request.form.get('inscricao_gratuita')
+        inscricao_gratuita = inscricao_gratuita_val in ['on', '1', 'true']
+        habilitar_lotes_val = request.form.get('habilitar_lotes')
+        habilitar_lotes = habilitar_lotes_val in ['on', '1', 'true']
         nomes_tipos = request.form.getlist('nome_tipo[]')  # Lista de nomes dos tipos
         precos_tipos = request.form.getlist('preco_tipo[]')  # Lista de preços dos tipos
         
@@ -629,10 +631,12 @@ def criar_evento():
         hora_fim = time.fromisoformat(hora_fim_str) if hora_fim_str else None
         
         # Verificar se é gratuito
-        inscricao_gratuita = (request.form.get('inscricao_gratuita') == 'on')
-        
+        inscricao_gratuita_val = request.form.get('inscricao_gratuita')
+        inscricao_gratuita = inscricao_gratuita_val in ['on', '1', 'true']
+
         # Verificar se habilita lotes
-        habilitar_lotes = (request.form.get('habilitar_lotes') == 'on')
+        habilitar_lotes_val = request.form.get('habilitar_lotes')
+        habilitar_lotes = habilitar_lotes_val in ['on', '1', 'true']
     
         # Cria o objeto Evento
         novo_evento = Evento(

--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -185,33 +185,61 @@
             </h5>
           </div>
           
-          <div class="card bg-white shadow-sm border-0 mb-4">
-            <div class="card-body">
-              <div class="form-check form-switch mb-3">
-                <input type="checkbox" class="form-check-input" id="inscricao_gratuita" name="inscricao_gratuita" 
-                       {% if evento and evento.inscricao_gratuita %}checked{% endif %}>
-                <label class="form-check-label" for="inscricao_gratuita">
-                  Inscrição Gratuita
-                </label>
-                <small class="form-text text-muted d-block mt-1">
-                  Quando marcado, todos os tipos de inscrição terão o preço definido como R$ 0,00.
-                </small>
+          {% if not habilita_pagamento %}
+          <div class="alert alert-info bg-info bg-opacity-10 border-info d-flex mb-4" role="alert">
+            <div class="me-3"><i class="bi bi-info-circle-fill fs-3 text-info"></i></div>
+            <div>
+              <h6 class="alert-heading fw-bold mb-1">Plano Gratuito</h6>
+              <p class="mb-0 text-muted">Seu plano atual permite apenas inscrições gratuitas. Para habilitar cobranças, faça upgrade do seu plano.</p>
+            </div>
+          </div>
+          {% endif %}
+
+          <div class="row g-4 mb-4">
+            <div class="col-md-6">
+              <div class="card h-100 hover-shadow cursor-pointer inscription-type-card" onclick="document.getElementById('inscricao_gratuita').click()">
+                <div class="card-body p-4">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="inscricao_gratuita" id="inscricao_gratuita" value="1"
+                           {% if evento is none or evento.inscricao_gratuita %}checked{% endif %}>
+                    <label class="form-check-label w-100" for="inscricao_gratuita">
+                      <div class="d-flex align-items-center mb-2">
+                        <i class="bi bi-ticket-fill fs-3 text-success me-2"></i>
+                        <h6 class="mb-0">Inscrição Gratuita</h6>
+                      </div>
+                      <p class="text-muted small mb-0">Evento sem cobrança de taxa de inscrição</p>
+                    </label>
+                  </div>
+                </div>
               </div>
-              
-              <div class="form-check form-switch mb-3">
-                <input type="checkbox" class="form-check-input" id="habilitar_lotes" name="habilitar_lotes" 
-                       {% if evento and evento.habilitar_lotes %}checked{% endif %}>
-                <label class="form-check-label" for="habilitar_lotes">
-                  Habilitar inscrição em lotes
-                </label>
-                <small class="form-text text-muted d-block mt-1">
-                  Quando marcado, você poderá configurar diferentes lotes de inscrição com preços e períodos específicos.
-                </small>
+            </div>
+            <div class="col-md-6">
+              <div class="card h-100 hover-shadow cursor-pointer inscription-type-card" onclick="document.getElementById('inscricao_paga').click()">
+                <div class="card-body p-4">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="inscricao_gratuita" id="inscricao_paga" value="0"
+                           {% if evento and not evento.inscricao_gratuita %}checked{% endif %}
+                           {% if not habilita_pagamento %}disabled{% endif %}>
+                    <label class="form-check-label w-100" for="inscricao_paga">
+                      <div class="d-flex align-items-center mb-2">
+                        <i class="bi bi-credit-card-fill fs-3 text-primary me-2"></i>
+                        <h6 class="mb-0">Inscrição Paga</h6>
+                      </div>
+                      <p class="text-muted small mb-0">Evento com cobrança de taxa de inscrição</p>
+                    </label>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
 
-          <div id="tipos-inscricao-container" class="card bg-white shadow-sm border-0 mb-4">
+          <div class="form-check form-switch mb-3" id="habilitar-lotes-container" {% if not evento or evento.inscricao_gratuita %}style="display:none;"{% endif %}>
+            <input type="checkbox" class="form-check-input" id="habilitar_lotes" name="habilitar_lotes" {% if evento and evento.habilitar_lotes %}checked{% endif %}>
+            <label class="form-check-label" for="habilitar_lotes">Habilitar inscrição em lotes</label>
+            <small class="form-text text-muted d-block mt-1">Quando marcado, você poderá configurar diferentes lotes de inscrição com preços e períodos específicos.</small>
+          </div>
+
+          <div id="tipos-inscricao-container" class="card bg-white shadow-sm border-0 mb-4" {% if not evento or evento.inscricao_gratuita %}style="display:none;"{% endif %}>
             <div class="card-body">
               <h6 class="card-title fw-bold mb-3">Tipos de Inscrição</h6>
               <p class="text-muted small mb-3">Configure os tipos de inscrição e seus respectivos valores:</p>
@@ -761,33 +789,40 @@ function updateProgressBar(step) {
 
   // Toggle price fields visibility
   const inscricaoGratuita = document.getElementById('inscricao_gratuita');
+  const inscricaoPaga = document.getElementById('inscricao_paga');
   const tiposContainer = document.getElementById('tipos-inscricao-container');
   const tiposList = document.getElementById('tipos-inscricao-list');
-  
+
   // Toggle lotes visibility
   const habilitarLotes = document.getElementById('habilitar_lotes');
+  const habilitarLotesContainer = document.getElementById('habilitar-lotes-container');
   const lotesSection = document.getElementById('lotes-section');
-  
-  function toggleLotesVisibility() {
-    console.log('Habilitar Lotes:', habilitarLotes.checked); // Debugging
-    if (habilitarLotes.checked) {
-      lotesSection.style.display = 'block';
-    } else {
+
+  function toggleInscricaoOptions() {
+    const isPaga = inscricaoPaga && inscricaoPaga.checked;
+    tiposContainer.style.display = isPaga ? 'block' : 'none';
+    habilitarLotesContainer.style.display = isPaga ? 'block' : 'none';
+    if (!isPaga) {
       lotesSection.style.display = 'none';
+      habilitarLotes.checked = false;
     }
+    updatePriceFields();
   }
-  
-  // Ensure visibility is updated on page load
-  toggleLotesVisibility();
-  
+
+  function toggleLotesVisibility() {
+    lotesSection.style.display = habilitarLotes.checked ? 'block' : 'none';
+  }
+
+  toggleInscricaoOptions();
   habilitarLotes.addEventListener('change', toggleLotesVisibility);
+  inscricaoGratuita.addEventListener('change', toggleInscricaoOptions);
+  if (inscricaoPaga) {
+    inscricaoPaga.addEventListener('change', toggleInscricaoOptions);
+  }
   
   // Function to update price fields visibility and values
   function updatePriceFields() {
     const isGratuito = inscricaoGratuita.checked;
-    
-    // Manter o container visível sempre
-    tiposContainer.style.display = 'block';
     
     // Selecionar todos os campos de preço e seus containers
     const precoFields = document.querySelectorAll('input[name="preco_tipo[]"]');
@@ -804,11 +839,6 @@ function updateProgressBar(step) {
     precoContainers.forEach(container => {
       container.style.display = isGratuito ? 'none' : 'block';
     });
-    
-    // Se for gratuito, garantir que pelo menos um tipo de inscrição exista
-    if (isGratuito && tiposList.querySelectorAll('.tipo-inscricao-item').length === 0) {
-      addTipoInscricao('Inscrição Gratuita', '0.00');
-    }
 
     // Também atualizar os preços nos lotes
     updateLotePriceFields();
@@ -816,9 +846,6 @@ function updateProgressBar(step) {
   
   // Verificar estado inicial
   updatePriceFields();
-  
-  // Adicionar event listener
-  inscricaoGratuita.addEventListener('change', updatePriceFields);
 
   // Função para adicionar novo tipo de inscrição
   function addTipoInscricao(nome = '', preco = '') {


### PR DESCRIPTION
## Summary
- accept radio values when saving `inscricao_gratuita` and `habilitar_lotes`
- align `configurar_evento.html` with the visual style of `criar_evento.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_684ad83c27a883249db48f5bb0c9daa0