### PR TITLE
Fix ConfiguracaoCliente reference in PDF service

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -2269,7 +2269,7 @@ from datetime import datetime
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
 from flask_login import login_required, current_user
-from models import Checkin, Evento
+from models import Checkin, Evento, ConfiguracaoCliente
 import unicodedata
 
 


### PR DESCRIPTION
## Summary
- import `ConfiguracaoCliente` in `pdf_service.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c51df72d88324b61f15651c0c997c