### PR TITLE
Implementar escolha de exibição da taxa de serviço

### DIFF
--- a/models.py
+++ b/models.py
@@ -569,8 +569,11 @@ class ConfiguracaoCliente(db.Model):
     
     # Relacionamento com o cliente (opcional se quiser acessar .cliente)
     cliente = db.relationship('Cliente', back_populates='configuracao')
-    
+
     habilitar_submissao_trabalhos = db.Column(db.Boolean, default=False)
+
+    # Exibe a taxa de serviço separadamente no preço da inscrição
+    mostrar_taxa = db.Column(db.Boolean, default=True)
 
     
     

--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -175,6 +175,27 @@ def toggle_submissao_trabalhos_cliente():
     flash("Configuração de submissão de trabalhos atualizada!", "success")
     return redirect(url_for('dashboard_routes.dashboard'))
 
+@config_cliente_routes.route('/toggle_mostrar_taxa', methods=['POST'])
+@login_required
+def toggle_mostrar_taxa():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+
+    config = current_user.configuracao
+    if not config:
+        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config)
+        db.session.commit()
+
+    config.mostrar_taxa = not config.mostrar_taxa
+    db.session.commit()
+
+    return jsonify({
+        "success": True,
+        "value": config.mostrar_taxa,
+        "message": "Exibição da taxa atualizada!"
+    })
+
 @config_cliente_routes.route("/api/configuracao_cliente_atual", methods=["GET"])
 @login_required
 def configuracao_cliente_atual():
@@ -196,7 +217,8 @@ def configuracao_cliente_atual():
         "permitir_checkin_global": config_cliente.permitir_checkin_global,
         "habilitar_feedback": config_cliente.habilitar_feedback,
         "habilitar_certificado_individual": config_cliente.habilitar_certificado_individual,
-        "habilitar_qrcode_evento_credenciamento": config_cliente.habilitar_qrcode_evento_credenciamento
+        "habilitar_qrcode_evento_credenciamento": config_cliente.habilitar_qrcode_evento_credenciamento,
+        "mostrar_taxa": config_cliente.mostrar_taxa
     })
 
 @config_cliente_routes.route("/toggle_qrcode_evento_credenciamento", methods=["POST"])

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -8,7 +8,7 @@ from models import (
     Evento, Oficina, Inscricao, Usuario, LinkCadastro,
     LoteInscricao, EventoInscricaoTipo, LoteTipoInscricao,
     CampoPersonalizadoCadastro, RespostaCampo, RegraInscricaoEvento,
-    Patrocinador, Ministrante, InscricaoTipo
+    Patrocinador, Ministrante, InscricaoTipo, ConfiguracaoCliente
 )
 import os
 import uuid
@@ -321,6 +321,9 @@ def _render_form(*, link, evento, lote_vigente, lotes_ativos, cliente_id):
     else:
         tipos_inscricao = []
 
+    config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
+    mostrar_taxa = config_cli.mostrar_taxa if config_cli else True
+
     # Estatísticas do lote vigente
     lote_stats = None
     if lote_vigente:
@@ -359,6 +362,8 @@ def _render_form(*, link, evento, lote_vigente, lotes_ativos, cliente_id):
         lote_stats=lote_stats,
         lotes_ativos=lotes_ativos,
         tipos_inscricao=tipos_inscricao,
+        mostrar_taxa=mostrar_taxa,
+        preco_com_taxa=preco_com_taxa
     )
 
 @inscricao_routes.route('/editar_participante', methods=['GET', 'POST'])

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -135,11 +135,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const btnFeedback = document.getElementById('btnToggleFeedback');
         const btnCertificado = document.getElementById('btnToggleCertificado');
         const btnQrCredenciamento = document.getElementById('btnToggleQrCredenciamento');
+        const btnMostrarTaxa = document.getElementById('btnToggleMostrarTaxa');
 
         if (btnCheckin) atualizarBotao(btnCheckin, data.permitir_checkin_global);
         if (btnFeedback) atualizarBotao(btnFeedback, data.habilitar_feedback);
         if (btnCertificado) atualizarBotao(btnCertificado, data.habilitar_certificado_individual);
         if (btnQrCredenciamento) atualizarBotao(btnQrCredenciamento, data.habilitar_qrcode_evento_credenciamento);
+        if (btnMostrarTaxa) atualizarBotao(btnMostrarTaxa, data.mostrar_taxa);
       })
       .catch(err => {
         console.error("Erro ao buscar config do cliente:", err);
@@ -153,7 +155,8 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('btnToggleCheckin'),
     document.getElementById('btnToggleFeedback'),
     document.getElementById('btnToggleCertificado'),
-    document.getElementById('btnToggleQrCredenciamento')
+    document.getElementById('btnToggleQrCredenciamento'),
+    document.getElementById('btnToggleMostrarTaxa')
   ];
 
   toggleButtons.forEach(button => {

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -306,19 +306,28 @@
 
                             <div class="ticket-options">
                                 {% for lote_tipo in lote_vigente.tipos_inscricao %}
+                                {% set final = preco_com_taxa(lote_tipo.preco) %}
                                 <div class="ticket-option">
-                                    <input type="radio" 
-                                           id="lote_tipo_{{ lote_tipo.id }}" 
-                                           name="lote_tipo_inscricao_id" 
+                                    <input type="radio"
+                                           id="lote_tipo_{{ lote_tipo.id }}"
+                                           name="lote_tipo_inscricao_id"
                                            value="{{ lote_tipo.id }}"
                                            data-lote-id="{{ lote_vigente.id }}"
                                            data-tipo-id="{{ lote_tipo.tipo_inscricao_id }}"
                                            data-preco="{{ lote_tipo.preco }}"
+                                           data-preco-final="{{ final }}"
                                            required>
                                     <label for="lote_tipo_{{ lote_tipo.id }}">
                                         <span class="ticket-name">{{ lote_tipo.tipo_inscricao.nome }}</span>
                                         {% if not evento.inscricao_gratuita %}
-                                        <span class="ticket-price">R$ {{ lote_tipo.preco }}</span>
+                                        <span class="ticket-price">
+                                            {% if mostrar_taxa %}
+                                            R$ {{ "%.2f"|format(final) }}
+                                            <small class="text-muted">(inclui R$ {{ "%.2f"|format(final - lote_tipo.preco) }} de taxa)</small>
+                                            {% else %}
+                                            R$ {{ "%.2f"|format(final) }}
+                                            {% endif %}
+                                        </span>
                                         {% endif %}
                                     </label>
                                 </div>
@@ -329,17 +338,26 @@
                             {% elif evento and not evento.habilitar_lotes and tipos_inscricao %}
                             <div class="ticket-options">
                                 {% for tipo in tipos_inscricao %}
+                                {% set final = preco_com_taxa(tipo.preco) %}
                                 <div class="ticket-option">
-                                    <input type="radio" 
-                                           id="tipo_{{ tipo.id }}" 
-                                           name="tipo_inscricao_id" 
+                                    <input type="radio"
+                                           id="tipo_{{ tipo.id }}"
+                                           name="tipo_inscricao_id"
                                            value="{{ tipo.id }}"
                                            data-preco="{{ tipo.preco }}"
+                                           data-preco-final="{{ final }}"
                                            required>
                                     <label for="tipo_{{ tipo.id }}">
                                         <span class="ticket-name">{{ tipo.nome }}</span>
                                         {% if not evento.inscricao_gratuita %}
-                                        <span class="ticket-price">R$ {{ tipo.preco }}</span>
+                                        <span class="ticket-price">
+                                            {% if mostrar_taxa %}
+                                            R$ {{ "%.2f"|format(final) }}
+                                            <small class="text-muted">(inclui R$ {{ "%.2f"|format(final - tipo.preco) }} de taxa)</small>
+                                            {% else %}
+                                            R$ {{ "%.2f"|format(final) }}
+                                            {% endif %}
+                                        </span>
                                         {% endif %}
                                     </label>
                                 </div>
@@ -714,6 +732,7 @@
     
     // Formulário
     document.addEventListener('DOMContentLoaded', function() {
+        const MOSTRAR_TAXA = {{ 'true' if mostrar_taxa else 'false' }};
         // Máscara de CPF
         const cpfField = document.getElementById('cpf');
         if (cpfField) {
@@ -731,10 +750,16 @@
             radio.addEventListener('change', function() {
                 if (this.checked) {
                     const preco = this.getAttribute('data-preco');
+                    const precoFinal = this.getAttribute('data-preco-final');
                     const display = document.getElementById('selectedTicketText');
-                    
-                    if (preco) {
-                        display.textContent = `Valor: R$ ${preco}`;
+
+                    if (precoFinal) {
+                        let txt = `Valor: R$ ${precoFinal}`;
+                        if (MOSTRAR_TAXA) {
+                            const diff = (parseFloat(precoFinal) - parseFloat(preco)).toFixed(2);
+                            txt += ` (inclui R$ ${diff} de taxa)`;
+                        }
+                        display.textContent = txt;
                     } else {
                         display.textContent = 'Inscrição selecionada';
                     }

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -802,12 +802,30 @@
                     </h6>
                     <p class="text-muted small mb-0">Permite que participantes baixem certificados</p>
                   </div>
-                  <button type="button" 
+                  <button type="button"
                           id="btnToggleCertificado"
                           class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_certificado_individual else 'danger' }}"
                           data-toggle-url="{{ url_for('config_cliente_routes.toggle_certificado_cliente') }}">
                     <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_certificado_individual else 'x-circle-fill' }}"></i>
                     {{ 'Ativo' if config_cliente and config_cliente.habilitar_certificado_individual else 'Desativado' }}
+                  </button>
+                </div>
+
+                <!-- Mostrar Taxa de Serviço -->
+                <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+                  <div>
+                    <h6 class="mb-0 fw-semibold d-flex align-items-center">
+                      <i class="bi bi-cash-coin text-primary me-2"></i>
+                      Mostrar Taxa de Serviço
+                    </h6>
+                    <p class="text-muted small mb-0">Exibe a taxa de serviço separadamente no valor da inscrição</p>
+                  </div>
+                  <button type="button"
+                          id="btnToggleMostrarTaxa"
+                          class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.mostrar_taxa else 'danger' }}"
+                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_mostrar_taxa') }}">
+                    <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.mostrar_taxa else 'x-circle-fill' }}"></i>
+                    {{ 'Ativo' if config_cliente and config_cliente.mostrar_taxa else 'Desativado' }}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add `mostrar_taxa` column for client configuration
- include toggle route and dashboard button
- return new configuration on API
- allow registration page to embed or display service fee
- update dashboard JS for new button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68502195db348324aed17f096aec6c3e