### PR TITLE
Fix Decimal subtraction in cadastro template

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -323,7 +323,7 @@
                                         <span class="ticket-price">
                                             {% if mostrar_taxa %}
                                             R$ {{ "%.2f"|format(final) }}
-                                            <small class="text-muted">(inclui R$ {{ "%.2f"|format(final - lote_tipo.preco) }} de taxa)</small>
+                                            <small class="text-muted">(inclui R$ {{ "%.2f"|format((final|float) - (lote_tipo.preco|float)) }} de taxa)</small>
                                             {% else %}
                                             R$ {{ "%.2f"|format(final) }}
                                             {% endif %}
@@ -353,7 +353,7 @@
                                         <span class="ticket-price">
                                             {% if mostrar_taxa %}
                                             R$ {{ "%.2f"|format(final) }}
-                                            <small class="text-muted">(inclui R$ {{ "%.2f"|format(final - tipo.preco) }} de taxa)</small>
+                                            <small class="text-muted">(inclui R$ {{ "%.2f"|format((final|float) - (tipo.preco|float)) }} de taxa)</small>
                                             {% else %}
                                             R$ {{ "%.2f"|format(final) }}
                                             {% endif %}


### PR DESCRIPTION
## Summary
- fix Jinja template using float filter when subtracting prices to avoid Decimal/float error

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68502a5e0e70832491bc788d7eccb662