### PR TITLE
Implement shift-based check-in categorization

### DIFF
--- a/models.py
+++ b/models.py
@@ -362,6 +362,12 @@ class Checkin(db.Model):
     def __repr__(self):
         return f"<Checkin (usuario={self.usuario_id}, oficina={self.oficina_id}, evento={self.evento_id}, data={self.data_hora})>"
 
+    @property
+    def turno(self) -> str:
+        """Retorna o turno baseado no horário do check-in."""
+        from utils import determinar_turno
+        return determinar_turno(self.data_hora)
+
 # =================================
 #            FEEDBACK
 # =================================

--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from models import (
     Checkin, Inscricao, Oficina, ConfiguracaoCliente, AgendamentoVisita, Evento
 )
-from utils import formatar_brasilia
+from utils import formatar_brasilia, determinar_turno
 
 checkin_routes = Blueprint('checkin_routes', __name__)
 
@@ -334,7 +334,8 @@ def leitor_checkin_json():
     # prepara carga para front‑end
     payload = {
         'participante': inscricao.usuario.nome,
-        'data_hora'   : novo.data_hora.strftime('%d/%m/%Y %H:%M:%S')
+        'data_hora'   : novo.data_hora.strftime('%d/%m/%Y %H:%M:%S'),
+        'turno'       : determinar_turno(novo.data_hora)
     }
     if novo.evento_id:
         payload['evento'] = inscricao.evento.nome
@@ -350,7 +351,6 @@ def leitor_checkin_json():
                    **payload)
 
 
-from utils import formatar_brasilia  # coloque no topo do routes.py
 
 @checkin_routes.route('/lista_checkins_json')
 @login_required
@@ -372,12 +372,14 @@ def lista_checkins_json():
     resultado = []
     for c in checkins:
         data_formatada = formatar_brasilia(c.data_hora)
+        turno = determinar_turno(c.data_hora)
 
         if c.evento_id:
             resultado.append({
                 'participante': c.usuario.nome,
                 'evento'      : c.evento.nome if c.evento else "Evento Desconhecido",
                 'data_hora'   : data_formatada,
+                'turno'       : turno,
                 'tipo_checkin': 'evento'
             })
         elif c.oficina_id:
@@ -385,6 +387,7 @@ def lista_checkins_json():
                 'participante': c.usuario.nome,
                 'oficina'     : c.oficina.titulo if c.oficina else "Oficina Desconhecida",
                 'data_hora'   : data_formatada,
+                'turno'       : turno,
                 'tipo_checkin': 'oficina'
             })
         else:
@@ -392,6 +395,7 @@ def lista_checkins_json():
                 'participante': c.usuario.nome,
                 'atividade'   : "N/A",
                 'data_hora'   : data_formatada,
+                'turno'       : turno,
                 'tipo_checkin': 'nenhum'
             })
 

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1,5 +1,5 @@
 from flask_login import login_required
-from utils import external_url
+from utils import external_url, determinar_turno
 
 def gerar_lista_frequencia_pdf(oficina, pdf_path):
     """
@@ -1950,6 +1950,7 @@ def gerar_pdf_checkins_qr():
         table_data = [[
             Paragraph("Nome do Participante", styles["Normal"]),
             Paragraph("E-mail", styles["Normal"]),
+            Paragraph("Turno", styles["Normal"]),
             Paragraph("Data/Hora do Check-in", styles["Normal"])
         ]]
         
@@ -1962,17 +1963,20 @@ def gerar_pdf_checkins_qr():
             dt_local = convert_to_brasilia(ck.data_hora)
             data_str = dt_local.strftime('%d/%m/%Y %H:%M') if dt_local else "N/A"
             
+            turno = determinar_turno(ck.data_hora)
             table_data.append([
                 Paragraph(nome, styles["Normal"]),
                 Paragraph(email, styles["Normal"]),
+                Paragraph(turno, styles["Normal"]),
                 Paragraph(data_str, styles["Normal"])
             ])
         
         # Definir larguras das colunas
         col_widths = [
-            doc.width * 0.35,
-            doc.width * 0.35,
-            doc.width * 0.3
+            doc.width * 0.30,
+            doc.width * 0.30,
+            doc.width * 0.20,
+            doc.width * 0.20
         ]
         
         table = LongTable(table_data, colWidths=col_widths)
@@ -2388,7 +2392,8 @@ def exportar_checkins_pdf_opcoes():
         p.setFont("Helvetica-Bold", 10)
         p.drawString(1.2*cm, y - 0.4*cm, "Participante")
         p.drawString(7*cm, y - 0.4*cm, "Palavra-chave")
-        p.drawString(13*cm, y - 0.4*cm, "Data/Hora")
+        p.drawString(12*cm, y - 0.4*cm, "Turno")
+        p.drawString(16*cm, y - 0.4*cm, "Data/Hora")
         
         y -= 0.7*cm
         
@@ -2408,7 +2413,8 @@ def exportar_checkins_pdf_opcoes():
                 p.setFont("Helvetica-Bold", 10)
                 p.drawString(1.2*cm, y - 0.4*cm, "Participante")
                 p.drawString(7*cm, y - 0.4*cm, "Palavra-chave")
-                p.drawString(13*cm, y - 0.4*cm, "Data/Hora")
+                p.drawString(12*cm, y - 0.4*cm, "Turno")
+                p.drawString(16*cm, y - 0.4*cm, "Data/Hora")
                 
                 y -= 0.7*cm
             
@@ -2423,7 +2429,8 @@ def exportar_checkins_pdf_opcoes():
             p.setFont("Helvetica", 9)
             p.drawString(1.2*cm, y - 0.3*cm, c.usuario.nome[:28])
             p.drawString(7*cm, y - 0.3*cm, c.palavra_chave[:20])
-            p.drawString(13*cm, y - 0.3*cm, c.data_hora.strftime('%d/%m/%Y %H:%M'))
+            p.drawString(12*cm, y - 0.3*cm, determinar_turno(c.data_hora))
+            p.drawString(16*cm, y - 0.3*cm, c.data_hora.strftime('%d/%m/%Y %H:%M'))
             
             # Descer para próxima linha
             y -= 0.5*cm
@@ -2648,7 +2655,7 @@ def exportar_checkins_evento_pdf(evento_id):
     elementos.append(Spacer(1, 0.2*cm))
     
     # Dados para tabela principal
-    dados_tabela = [["Nome", "CPF", "Data/Hora", "Palavra-chave"]]
+    dados_tabela = [["Nome", "CPF", "Turno", "Data/Hora", "Palavra-chave"]]
     
     # Preencher dados na tabela
     for checkin in checkins:
@@ -2656,12 +2663,13 @@ def exportar_checkins_evento_pdf(evento_id):
         dados_tabela.append([
             usuario.nome[:40],
             usuario.cpf or "-",
+            determinar_turno(checkin.data_hora),
             checkin.data_hora.strftime('%d/%m/%Y %H:%M'),
             checkin.palavra_chave or "-"
         ])
     
     # Criar e estilizar tabela
-    tabela = Table(dados_tabela, colWidths=[5*cm, 3*cm, 4*cm, 4*cm])
+    tabela = Table(dados_tabela, colWidths=[5*cm, 3*cm, 3*cm, 3*cm, 3*cm])
     tabela.setStyle(TableStyle([
         ('BACKGROUND', (0, 0), (-1, 0), cor_primaria),
         ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),

--- a/templates/checkin/scan_qr.html
+++ b/templates/checkin/scan_qr.html
@@ -64,6 +64,7 @@
                     <tr>
                       <th>Nome</th>
                       <th>Oficina</th>
+                      <th>Turno</th>
                       <th>Data/Hora</th>
                     </tr>
                   </thead>
@@ -182,7 +183,7 @@
                         <div>${data.message}</div>
                     </div>
                 </div>`;
-                addScannedItem(data.participante, data.oficina, data.data_hora);
+                addScannedItem(data.participante, data.oficina, data.turno, data.data_hora);
             } else if (data.status === "warning") {
                 // ex.: "Check-in já realizado!"
                 resultElement.innerHTML = `<div class="alert alert-warning">
@@ -211,7 +212,7 @@
         }
     }
     
-    function addScannedItem(participante, oficina, dataHora) {
+    function addScannedItem(participante, oficina, turno, dataHora) {
         // Monta a "chave"
         const chave = participante + oficina;
         // Se já existe, sai
@@ -229,6 +230,7 @@
         tr.innerHTML = `
             <td>${participante}</td>
             <td>${oficina}</td>
+            <td>${turno}</td>
             <td>${agora}</td>
         `;
         const tbody = document.getElementById('checkinBody');
@@ -244,7 +246,7 @@
             const data = await resp.json();
             if (data.status === 'success' && Array.isArray(data.checkins)) {
                 data.checkins.forEach(chk => {
-                    addScannedItem(chk.participante, chk.oficina, chk.data_hora);
+                    addScannedItem(chk.participante, chk.oficina, chk.turno, chk.data_hora);
                 });
             }
         } catch (err) {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,3 +20,18 @@ def test_arquivo_permitido_extensoes_rejeitadas():
     assert not arquivo_permitido('imagem.png')
     assert not arquivo_permitido('documento.pdf')
     assert not arquivo_permitido('arquivo.txt')
+
+
+def test_determinar_turno():
+    from utils.time_helpers import determinar_turno
+    from pytz import timezone
+    from datetime import datetime
+
+    tz = timezone("America/Sao_Paulo")
+    manha = tz.localize(datetime(2024, 1, 1, 8, 0))
+    tarde = tz.localize(datetime(2024, 1, 1, 15, 0))
+    noite = tz.localize(datetime(2024, 1, 1, 20, 0))
+
+    assert determinar_turno(manha) == "Matutino"
+    assert determinar_turno(tarde) == "Vespertino"
+    assert determinar_turno(noite) == "Noturno"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
-from .time_helpers import formatar_brasilia
-__all__ = ["formatar_brasilia"]
+from .time_helpers import formatar_brasilia, determinar_turno
+__all__ = ["formatar_brasilia", "determinar_turno"]
 
 
 import requests

--- a/utils/time_helpers.py
+++ b/utils/time_helpers.py
@@ -12,3 +12,17 @@ def formatar_brasilia(dt: datetime | None = None,
     if dt is None:
         dt = datetime.utcnow()
     return dt.astimezone(tz_brasilia).strftime(fmt)
+
+
+def determinar_turno(dt: datetime | None = None) -> str:
+    """Retorna o turno (Matutino, Vespertino ou Noturno) para o horário informado."""
+    tz_brasilia = timezone("America/Sao_Paulo")
+    if dt is None:
+        dt = datetime.utcnow()
+    hora = dt.astimezone(tz_brasilia).hour
+    if 6 <= hora < 12:
+        return "Matutino"
+    elif 12 <= hora < 18:
+        return "Vespertino"
+    else:
+        return "Noturno"


### PR DESCRIPTION
## Summary
- add new helper `determinar_turno` for determining check‑in shift
- expose helper in utils package
- add `turno` property to `Checkin` model
- include shift in check-in routes and JSON payloads
- show shift column in QR check-in page
- generate PDFs with shift information
- test new helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68503202eb008324ac70197867cb6b84