### PR TITLE
Fix oficina title max length

### DIFF
--- a/migrations/versions/885a38754a79_increase_oficina_titulo_length.py
+++ b/migrations/versions/885a38754a79_increase_oficina_titulo_length.py
@@ -1,0 +1,22 @@
+"""increase oficina titulo length
+
+Revision ID: 885a38754a79
+Revises: 2744d4add4b2
+Create Date: 2025-06-20 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '885a38754a79'
+down_revision = '2744d4add4b2'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('oficina') as batch_op:
+        batch_op.alter_column('titulo', type_=sa.String(length=255))
+
+def downgrade():
+    with op.batch_alter_table('oficina') as batch_op:
+        batch_op.alter_column('titulo', type_=sa.String(length=100))

--- a/models.py
+++ b/models.py
@@ -131,7 +131,7 @@ class Oficina(db.Model):
     __tablename__ = 'oficina'
     
     id = db.Column(db.Integer, primary_key=True)
-    titulo = db.Column(db.String(100), nullable=False)
+    titulo = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=False)
     ministrante_id = db.Column(db.Integer, db.ForeignKey('ministrante.id'), nullable=True)
     ministrante_obj = db.relationship("Ministrante", backref="oficinas", lazy=True)

--- a/templates/oficina/criar_oficina.html
+++ b/templates/oficina/criar_oficina.html
@@ -79,7 +79,7 @@
 
             <div class="col-md-6 mb-3">
               <label for="titulo" class="form-label fw-bold">Título da atividade:</label>
-              <input type="text" class="form-control form-control-lg border border-secondary bg-white" id="titulo" name="titulo" required>
+              <input type="text" class="form-control form-control-lg border border-secondary bg-white" id="titulo" name="titulo" maxlength="255" required>
             </div>
             <div class="col-md-6 mb-3">
               <label for="descricao" class="form-label fw-bold">Descrição:</label>

--- a/templates/oficina/editar_oficina.html
+++ b/templates/oficina/editar_oficina.html
@@ -38,7 +38,7 @@
 
         <div class="mb-3">
           <label for="titulo" class="form-label">Título da Atividade</label>
-          <input type="text" class="form-control" id="titulo" name="titulo" value="{{ oficina.titulo }}" required>
+          <input type="text" class="form-control" id="titulo" name="titulo" value="{{ oficina.titulo }}" maxlength="255" required>
         </div>
 
         <div class="mb-3">


### PR DESCRIPTION
## Summary
- allow longer titles for Oficina
- cap title input fields at 255 characters
- add Alembic migration for new column length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504c1863208324a9d3185359a22280