### PR TITLE
Include tax in event price data

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -14,6 +14,7 @@ from models import (
     Usuario, RegraInscricaoEvento, LoteTipoInscricao, Inscricao,
     ConfiguracaoCertificadoEvento
 )
+from utils import preco_com_taxa
 
 evento_routes = Blueprint('evento_routes', __name__, template_folder="../templates")
 
@@ -92,6 +93,7 @@ def api_eventos_destaque():
 def _serializa_eventos(eventos):
     lista = []
     for ev in eventos:
+        preco_base = min((t.preco for t in ev.tipos_inscricao), default=0)
         dado = {
             'id':          ev.id,
             'nome':        ev.nome,
@@ -103,7 +105,8 @@ def _serializa_eventos(eventos):
             'localizacao': ev.localizacao or 'Local a definir',
             'banner_url':  ev.banner_url or url_for('static',
                                                     filename='images/event-placeholder.jpg'),
-            'preco_base':  min((t.preco for t in ev.tipos_inscricao), default=0),
+            'preco_base':  preco_base,
+            'preco_final': float(preco_com_taxa(preco_base)),
             'link_inscricao': None
         }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -189,8 +189,9 @@ function renderizarEventos(eventos) {
             : formatDate(evento.data_inicio) || 'Data a definir';
         
         // Formata o preço do evento
-        const price = evento.preco_base > 0 
-            ? `R$ ${parseFloat(evento.preco_base).toFixed(2).replace('.', ',')}`
+        let priceValue = evento.preco_final !== undefined ? evento.preco_final : evento.preco_base;
+        const price = priceValue > 0
+            ? `R$ ${parseFloat(priceValue).toFixed(2).replace('.', ',')}`
             : 'Gratuito';
         
         // Gera um elemento div colorido como fallback de imagem


### PR DESCRIPTION
## Summary
- compute event price with tax in API
- show price with tax on index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685052e7a4d48324b2e983571bc470a3