### PR TITLE
Corrige categorias de patrocinadores com acentuação

### DIFF
--- a/routes/patrocinador_routes.py
+++ b/routes/patrocinador_routes.py
@@ -9,6 +9,14 @@ from extensions import db
 import os
 from flask import jsonify
 
+# Mapeamento de categorias para usar acentuação correta
+categoria_map = {
+    "realizacao": "Realização",
+    "patrocinio": "Patrocínio",
+    "organizacao": "Organização",
+    "apoio": "Apoio",
+}
+
 
 @patrocinador_routes.route('/adicionar_patrocinadores_categorizados', methods=['POST'])
 @login_required
@@ -41,11 +49,12 @@ def adicionar_patrocinadores_categorizados():
 
                     logo_path = os.path.join('uploads', 'patrocinadores', filename)
 
-                    # Ajuste aqui para categoria com inicial maiúscula
+                    # Categoria com acentuação correta
+                    categoria = categoria_map.get(categoria_label.lower())
                     novo_pat = Patrocinador(
                         evento_id=evento_id,
                         logo_path=logo_path,
-                        categoria=categoria_label.capitalize()  # Realizacao, Patrocinio, Organizacao, Apoio
+                        categoria=categoria
                     )
                     db.session.add(novo_pat)
                     imported_count += 1

--- a/update_patrocinador_categorias.py
+++ b/update_patrocinador_categorias.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Atualiza categorias de patrocinadores para usar acentuação correta."""
+from app import create_app
+from extensions import db
+from models import Patrocinador
+
+CATEGORIA_MAP = {
+    "Realizacao": "Realização",
+    "Patrocinio": "Patrocínio",
+    "Organizacao": "Organização",
+    "realizacao": "Realização",
+    "patrocinio": "Patrocínio",
+    "organizacao": "Organização",
+}
+
+
+def main():
+    app = create_app()
+    with app.app_context():
+        patrocinadores = Patrocinador.query.filter(
+            Patrocinador.categoria.in_(CATEGORIA_MAP.keys())
+        ).all()
+        count = 0
+        for pat in patrocinadores:
+            pat.categoria = CATEGORIA_MAP.get(pat.categoria, pat.categoria)
+            count += 1
+        if count:
+            db.session.commit()
+        print(f"Categorias atualizadas: {count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- mapeia categorias de patrocinador para usar acentuação correta
- usa o mapa de categorias em `salvar_uploads`
- adiciona script para atualizar registros antigos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506fceada48324931268f3ad3785df