### PR TITLE
Use Stadia Stay22 tile layer in participant map

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -697,9 +697,9 @@
     function setupMap(latitude, longitude) {
         const map = L.map('map-container').setView([latitude, longitude], 15);
         
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-            maxZoom: 19
+        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png', {
+            maxZoom: 20,
+            attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
         }).addTo(map);
         
         const marker = L.marker([latitude, longitude]).addTo(map)
@@ -730,9 +730,9 @@
     
     function showDefaultMap() {
         const map = L.map('map-container').setView([-15.77972, -47.92972], 4);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-            maxZoom: 19
+        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png', {
+            maxZoom: 20,
+            attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
         }).addTo(map);
     }
     


### PR DESCRIPTION
## Summary
- switch map tiles from OpenStreetMap to Stadia's Stay22 layer for participant registration form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507383f6ec832484572b0a4c7ac402