### PR TITLE
Use Stadia geocoding for event maps

### DIFF
--- a/static/js/criar_evento.js
+++ b/static/js/criar_evento.js
@@ -52,10 +52,10 @@ document.addEventListener('DOMContentLoaded', function() {
     function initMap() {
       map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
      
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19
-      }).addTo(map);
+        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+          maxZoom: 20,
+          attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
+        }).addTo(map);
      
       // Adicionar marker no mapa se já existir localização
       if (document.getElementById('latitude').value && document.getElementById('longitude').value) {
@@ -87,19 +87,19 @@ document.addEventListener('DOMContentLoaded', function() {
       document.getElementById('info-longitude').textContent = lng.toFixed(6);
      
       // Fazer geocoding reverso para obter o endereço
-      fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`)
-        .then(response => response.json())
-        .then(data => {
-          if (data && data.display_name) {
-            document.getElementById('endereco-completo').textContent = data.display_name;
-            // Guardar temporariamente
-            currentLocation = {
-              lat: lat,
-              lng: lng,
-              address: data.display_name
-            };
-          }
-        })
+        fetch(`https://api.stadiamaps.com/geocoding/v1/reverse?point.lat=${lat}&point.lon=${lng}&apikey=5b05060b-8e26-4d1c-bcaa-306d76157824`)
+          .then(response => response.json())
+          .then(data => {
+            if (data && data.features && data.features.length > 0) {
+              const label = data.features[0].properties.label;
+              document.getElementById('endereco-completo').textContent = label;
+              currentLocation = {
+                lat: lat,
+                lng: lng,
+                address: label
+              };
+            }
+          })
         .catch(error => {
           console.error('Erro ao obter endereço:', error);
           document.getElementById('endereco-completo').textContent = 'Endereço não disponível';
@@ -112,9 +112,9 @@ document.addEventListener('DOMContentLoaded', function() {
      
       if (query.length < 3) return;
      
-      fetch(`https://photon.komoot.io/api/?q=${encodeURIComponent(query)}&limit=5`)
-        .then(response => response.json())
-        .then(data => {
+        fetch(`https://api.stadiamaps.com/geocoding/v1/search?text=${encodeURIComponent(query)}&apikey=5b05060b-8e26-4d1c-bcaa-306d76157824`)
+          .then(response => response.json())
+          .then(data => {
           if (modalSearch) {
             // Se for busca no modal, centraliza o primeiro resultado no mapa
             if (data.features && data.features.length > 0) {
@@ -139,34 +139,20 @@ document.addEventListener('DOMContentLoaded', function() {
            
             if (data.features && data.features.length > 0) {
               data.features.forEach(feature => {
-                const properties = feature.properties;
                 const coords = feature.geometry.coordinates;
-               
-                // Criar texto para exibição
-                let displayText = [];
-                if (properties.name) displayText.push(properties.name);
-                if (properties.street) displayText.push(properties.street);
-                if (properties.city) displayText.push(properties.city);
-                if (properties.state) displayText.push(properties.state);
-               
+                const label = feature.properties.label;
+
                 const item = document.createElement('div');
                 item.className = 'suggestion-item';
-                item.textContent = displayText.join(', ');
+                item.textContent = label;
                 item.addEventListener('click', function() {
-                  // Preencher o campo de localização
-                  localizacaoInput.value = displayText.join(', ');
-                 
-                  // Guardar coordenadas
+                  localizacaoInput.value = label;
                   document.getElementById('latitude').value = coords[1];
                   document.getElementById('longitude').value = coords[0];
-                 
-                  // Gerar link do Google Maps
                   document.getElementById('link_mapa').value = `https://www.google.com/maps?q=${coords[1]},${coords[0]}`;
-                 
-                  // Esconder sugestões
                   suggestionsContainer.style.display = 'none';
                 });
-               
+
                 suggestionsContainer.appendChild(item);
               });
              

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -697,9 +697,9 @@
     function setupMap(latitude, longitude) {
         const map = L.map('map-container').setView([latitude, longitude], 15);
         
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-            maxZoom: 19
+        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+            maxZoom: 20,
+            attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
         }).addTo(map);
         
         const marker = L.marker([latitude, longitude]).addTo(map)
@@ -730,9 +730,9 @@
     
     function showDefaultMap() {
         const map = L.map('map-container').setView([-15.77972, -47.92972], 4);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-            maxZoom: 19
+        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+            maxZoom: 20,
+            attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
         }).addTo(map);
     }
     

--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -1440,10 +1440,10 @@ function updateProgressBar(step) {
    function initMap() {
      map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
      
-     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-       maxZoom: 19
-     }).addTo(map);
+      L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+        maxZoom: 20,
+        attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
+      }).addTo(map);
      
      // Adicionar marker no mapa se já existir localização
      if (document.getElementById('latitude').value && document.getElementById('longitude').value) {
@@ -1475,19 +1475,19 @@ function updateProgressBar(step) {
      document.getElementById('info-longitude').textContent = lng.toFixed(6);
      
      // Fazer geocoding reverso para obter o endereço
-     fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`)
-       .then(response => response.json())
-       .then(data => {
-         if (data && data.display_name) {
-           document.getElementById('endereco-completo').textContent = data.display_name;
-           // Guardar temporariamente
-           currentLocation = {
-             lat: lat,
-             lng: lng,
-             address: data.display_name
-           };
-         }
-       })
+      fetch(`https://api.stadiamaps.com/geocoding/v1/reverse?point.lat=${lat}&point.lon=${lng}&apikey=5b05060b-8e26-4d1c-bcaa-306d76157824`)
+        .then(response => response.json())
+        .then(data => {
+          if (data && data.features && data.features.length > 0) {
+            const label = data.features[0].properties.label;
+            document.getElementById('endereco-completo').textContent = label;
+            currentLocation = {
+              lat: lat,
+              lng: lng,
+              address: label
+            };
+          }
+        })
        .catch(error => {
          console.error('Erro ao obter endereço:', error);
          document.getElementById('endereco-completo').textContent = 'Endereço não disponível';
@@ -1500,9 +1500,9 @@ function updateProgressBar(step) {
      
      if (query.length < 3) return;
      
-     fetch(`https://photon.komoot.io/api/?q=${encodeURIComponent(query)}&limit=5`)
-       .then(response => response.json())
-       .then(data => {
+      fetch(`https://api.stadiamaps.com/geocoding/v1/search?text=${encodeURIComponent(query)}&apikey=5b05060b-8e26-4d1c-bcaa-306d76157824`)
+        .then(response => response.json())
+        .then(data => {
          if (modalSearch) {
            // Se for busca no modal, centraliza o primeiro resultado no mapa
            if (data.features && data.features.length > 0) {
@@ -1527,34 +1527,20 @@ function updateProgressBar(step) {
            
            if (data.features && data.features.length > 0) {
              data.features.forEach(feature => {
-               const properties = feature.properties;
                const coords = feature.geometry.coordinates;
-               
-               // Criar texto para exibição
-               let displayText = [];
-               if (properties.name) displayText.push(properties.name);
-               if (properties.street) displayText.push(properties.street);
-               if (properties.city) displayText.push(properties.city);
-               if (properties.state) displayText.push(properties.state);
-               
+               const label = feature.properties.label;
+
                const item = document.createElement('div');
                item.className = 'suggestion-item';
-               item.textContent = displayText.join(', ');
+               item.textContent = label;
                item.addEventListener('click', function() {
-                 // Preencher o campo de localização
-                 localizacaoInput.value = displayText.join(', ');
-                 
-                 // Guardar coordenadas
+                 localizacaoInput.value = label;
                  document.getElementById('latitude').value = coords[1];
                  document.getElementById('longitude').value = coords[0];
-                 
-                 // Gerar link do Google Maps
                  document.getElementById('link_mapa').value = `https://www.google.com/maps?q=${coords[1]},${coords[0]}`;
-                 
-                 // Esconder sugestões
                  suggestionsContainer.style.display = 'none';
                });
-               
+
                suggestionsContainer.appendChild(item);
              });
              

--- a/templates/evento/criar_evento.html
+++ b/templates/evento/criar_evento.html
@@ -976,10 +976,10 @@ document.addEventListener('DOMContentLoaded', function() {
   function initMap() {
     map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
     
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-      maxZoom: 19
-    }).addTo(map);
+      L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+        maxZoom: 20,
+        attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
+      }).addTo(map);
     
     // Adicionar marker no mapa se já existir localização
     if (document.getElementById('latitude').value && document.getElementById('longitude').value) {
@@ -1011,19 +1011,19 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('info-longitude').textContent = lng.toFixed(6);
     
     // Fazer geocoding reverso para obter o endereço
-    fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`)
-      .then(response => response.json())
-      .then(data => {
-        if (data && data.display_name) {
-          document.getElementById('endereco-completo').textContent = data.display_name;
-          // Guardar temporariamente
-          currentLocation = {
-            lat: lat,
-            lng: lng,
-            address: data.display_name
-          };
-        }
-      })
+      fetch(`https://api.stadiamaps.com/geocoding/v1/reverse?point.lat=${lat}&point.lon=${lng}&apikey=5b05060b-8e26-4d1c-bcaa-306d76157824`)
+        .then(response => response.json())
+        .then(data => {
+          if (data && data.features && data.features.length > 0) {
+            const label = data.features[0].properties.label;
+            document.getElementById('endereco-completo').textContent = label;
+            currentLocation = {
+              lat: lat,
+              lng: lng,
+              address: label
+            };
+          }
+        })
       .catch(error => {
         console.error('Erro ao obter endereço:', error);
         document.getElementById('endereco-completo').textContent = 'Endereço não disponível';
@@ -1036,9 +1036,9 @@ document.addEventListener('DOMContentLoaded', function() {
     
     if (query.length < 3) return;
     
-    fetch(`https://photon.komoot.io/api/?q=${encodeURIComponent(query)}&limit=5`)
-      .then(response => response.json())
-      .then(data => {
+      fetch(`https://api.stadiamaps.com/geocoding/v1/search?text=${encodeURIComponent(query)}&apikey=5b05060b-8e26-4d1c-bcaa-306d76157824`)
+        .then(response => response.json())
+        .then(data => {
         if (modalSearch) {
           // Se for busca no modal, centraliza o primeiro resultado no mapa
           if (data.features && data.features.length > 0) {
@@ -1061,38 +1061,24 @@ document.addEventListener('DOMContentLoaded', function() {
           // Se for busca no campo, mostra sugestões
           suggestionsContainer.innerHTML = '';
           
-          if (data.features && data.features.length > 0) {
-            data.features.forEach(feature => {
-              const properties = feature.properties;
-              const coords = feature.geometry.coordinates;
-              
-              // Criar texto para exibição
-              let displayText = [];
-              if (properties.name) displayText.push(properties.name);
-              if (properties.street) displayText.push(properties.street);
-              if (properties.city) displayText.push(properties.city);
-              if (properties.state) displayText.push(properties.state);
-              
-              const item = document.createElement('div');
-              item.className = 'suggestion-item';
-              item.textContent = displayText.join(', ');
-              item.addEventListener('click', function() {
-                // Preencher o campo de localização
-                localizacaoInput.value = displayText.join(', ');
-                
-                // Guardar coordenadas
-                document.getElementById('latitude').value = coords[1];
-                document.getElementById('longitude').value = coords[0];
-                
-                // Gerar link do Google Maps
-                document.getElementById('link_mapa').value = `https://www.google.com/maps?q=${coords[1]},${coords[0]}`;
-                
-                // Esconder sugestões
-                suggestionsContainer.style.display = 'none';
+            if (data.features && data.features.length > 0) {
+              data.features.forEach(feature => {
+                const coords = feature.geometry.coordinates;
+                const label = feature.properties.label;
+
+                const item = document.createElement('div');
+                item.className = 'suggestion-item';
+                item.textContent = label;
+                item.addEventListener('click', function() {
+                  localizacaoInput.value = label;
+                  document.getElementById('latitude').value = coords[1];
+                  document.getElementById('longitude').value = coords[0];
+                  document.getElementById('link_mapa').value = `https://www.google.com/maps?q=${coords[1]},${coords[0]}`;
+                  suggestionsContainer.style.display = 'none';
+                });
+
+                suggestionsContainer.appendChild(item);
               });
-              
-              suggestionsContainer.appendChild(item);
-            });
             
             suggestionsContainer.style.display = 'block';
           } else {


### PR DESCRIPTION
## Summary
- swap map tiles and geocoder to Stadia in event creation and configuration
- update the helper JavaScript used for these pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68507383f6ec832484572b0a4c7ac402