### PR TITLE
Add fallback tile layer for map

### DIFF
--- a/static/js/criar_evento.js
+++ b/static/js/criar_evento.js
@@ -51,11 +51,19 @@ document.addEventListener('DOMContentLoaded', function() {
     // Inicializar o mapa
     function initMap() {
       map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
-     
-        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+
+        const stay22Layer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
           maxZoom: 20,
           attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
         }).addTo(map);
+
+        stay22Layer.on('tileerror', function() {
+          map.removeLayer(stay22Layer);
+          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; OpenStreetMap contributors'
+          }).addTo(map);
+        });
      
       // Adicionar marker no mapa se já existir localização
       if (document.getElementById('latitude').value && document.getElementById('longitude').value) {

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -697,11 +697,18 @@
    function setupMap(latitude, longitude) {
     const map = L.map('map-container').setView([latitude, longitude], 15);
 
-    // Camada de mapa (Stadia Stay22 com API Key)
-    L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+    const stay22Layer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
         maxZoom: 20,
         attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
     }).addTo(map);
+
+    stay22Layer.on('tileerror', function() {
+        map.removeLayer(stay22Layer);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+    });
 
     // Adiciona marcador no mapa
     const marker = L.marker([latitude, longitude]).addTo(map)
@@ -734,11 +741,18 @@
     function showDefaultMap() {
         const map = L.map('map-container').setView([-15.77972, -47.92972], 4);
 
-        // Camada de mapa Stadia Maps Stay22 com API Key
-        L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+        const stay22Layer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
             maxZoom: 20,
             attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
         }).addTo(map);
+
+        stay22Layer.on('tileerror', function() {
+            map.removeLayer(stay22Layer);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                maxZoom: 19,
+                attribution: '&copy; OpenStreetMap contributors'
+            }).addTo(map);
+        });
     }
 
     

--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -1437,13 +1437,21 @@ function updateProgressBar(step) {
    });
    
    // Inicializar o mapa
-   function initMap() {
-     map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
-     
-      L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+  function initMap() {
+    map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
+
+      const stay22Layer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
         maxZoom: 20,
         attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
       }).addTo(map);
+
+      stay22Layer.on('tileerror', function() {
+        map.removeLayer(stay22Layer);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 19,
+          attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+      });
      
      // Adicionar marker no mapa se já existir localização
      if (document.getElementById('latitude').value && document.getElementById('longitude').value) {

--- a/templates/evento/criar_evento.html
+++ b/templates/evento/criar_evento.html
@@ -975,11 +975,19 @@ document.addEventListener('DOMContentLoaded', function() {
   // Inicializar o mapa
   function initMap() {
     map = L.map('mapa-container').setView([currentLocation.lat, currentLocation.lng], 13);
-    
-      L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
+
+      const stay22Layer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stay22/{z}/{x}/{y}{r}.png?api_key=5b05060b-8e26-4d1c-bcaa-306d76157824', {
         maxZoom: 20,
         attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> &copy; OpenStreetMap contributors'
       }).addTo(map);
+
+      stay22Layer.on('tileerror', function() {
+        map.removeLayer(stay22Layer);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 19,
+          attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+      });
     
     // Adicionar marker no mapa se já existir localização
     if (document.getElementById('latitude').value && document.getElementById('longitude').value) {


### PR DESCRIPTION
## Summary
- ensure map displays even if Stay22 tiles fail to load
- load OpenStreetMap tiles as a fallback layer in the participant form, event creation template, event configuration template and JS map initialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68507bc9d4108324aff2a0735ec8a7e5