### PR TITLE
Add duplicate user flow for registration

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -266,6 +266,13 @@
                             <input type="password" id="senha" name="senha" placeholder="Crie uma senha segura" required>
                             <small class="password-hint">Mínimo de 8 caracteres</small>
                         </div>
+
+                        {% if solicitar_senha %}
+                        <div class="form-group">
+                            <label for="senha_existente">Confirme sua senha cadastrada</label>
+                            <input type="password" id="senha_existente" name="senha_existente" placeholder="Senha já cadastrada" required>
+                        </div>
+                        {% endif %}
                         
                         <div class="form-group full-width">
                             <label for="formacao">Formação Acadêmica</label>


### PR DESCRIPTION
## Summary
- verify existing users on registration and allow using existing account
- request password confirmation if duplicate info is detected
- display confirmation field when needed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850c91c5b608324be3e802395b15762