### PR TITLE
Add static marketing pages and footer links

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -47,6 +47,7 @@ def register_routes(app):
     from .mercadopago_routes import mercadopago_routes
     from .util_routes import util_routes
     from .relatorio_pdf_routes import relatorio_pdf_routes
+    from .static_page_routes import static_page_routes
     # Importa servicos que registram rotas diretamente no blueprint
     from services import lote_service  # noqa: F401
 
@@ -86,5 +87,6 @@ def register_routes(app):
     app.register_blueprint(relatorio_pdf_routes)
     app.register_blueprint(certificado_routes)
     app.register_blueprint(placeholder_routes)
+    app.register_blueprint(static_page_routes)
 
 

--- a/routes/static_page_routes.py
+++ b/routes/static_page_routes.py
@@ -1,0 +1,32 @@
+from flask import Blueprint, render_template, abort
+
+static_page_routes = Blueprint('static_page_routes', __name__, template_folder="../templates/pages")
+
+# Map slugs to page titles
+PAGES = {
+    'empresa': 'Empresa',
+    'sobre-nos': 'Sobre nós',
+    'nosso-time': 'Nosso time',
+    'carreiras': 'Carreiras',
+    'blog': 'Blog',
+    'eventos': 'Eventos',
+    'conferencias': 'Conferências',
+    'workshops': 'Workshops',
+    'formacoes': 'Formações',
+    'seminarios': 'Seminários',
+    'suporte': 'Suporte',
+    'faq': 'FAQ',
+    'central-de-ajuda': 'Central de ajuda',
+    'contato': 'Contato',
+    'tutoriais': 'Tutoriais',
+    'legal': 'Legal',
+    'termos-de-uso': 'Termos de uso',
+    'privacidade': 'Privacidade',
+    'cookies': 'Cookies',
+}
+
+@static_page_routes.route('/<slug>')
+def show_page(slug):
+    if slug in PAGES:
+        return render_template(f'pages/{slug}.html', page_title=PAGES[slug])
+    abort(404)

--- a/templates/base.html
+++ b/templates/base.html
@@ -484,30 +484,30 @@
                 <div class="col-lg-2 col-md-4 col-6 mb-4">
                     <h6 class="fw-bold mb-3">Suporte</h6>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><a href="#">Central de Ajuda</a></li>
-                        <li class="mb-2"><a href="#">Documentação</a></li>
-                        <li class="mb-2"><a href="#">Status do Sistema</a></li>
-                        <li><a href="#">Contato</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='central-de-ajuda') }}">Central de Ajuda</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='tutoriais') }}">Documentação</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='suporte') }}">Status do Sistema</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='contato') }}">Contato</a></li>
                     </ul>
                 </div>
                 
                 <div class="col-lg-2 col-md-4 col-6 mb-4">
                     <h6 class="fw-bold mb-3">Legal</h6>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><a href="#">Termos de Uso</a></li>
-                        <li class="mb-2"><a href="#">Privacidade</a></li>
-                        <li class="mb-2"><a href="#">Cookies</a></li>
-                        <li><a href="#">LGPD</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='termos-de-uso') }}">Termos de Uso</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='privacidade') }}">Privacidade</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='cookies') }}">Cookies</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='legal') }}">LGPD</a></li>
                     </ul>
                 </div>
                 
                 <div class="col-lg-2 col-md-4 col-6 mb-4">
                     <h6 class="fw-bold mb-3">Empresa</h6>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><a href="#">Sobre nós</a></li>
-                        <li class="mb-2"><a href="#">Blog</a></li>
-                        <li class="mb-2"><a href="#">Trabalhe Conosco</a></li>
-                        <li><a href="#">Parceiros</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='sobre-nos') }}">Sobre nós</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='blog') }}">Blog</a></li>
+                        <li class="mb-2"><a href="{{ url_for('static_page_routes.show_page', slug='carreiras') }}">Trabalhe Conosco</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='empresa') }}">Parceiros</a></li>
                     </ul>
                 </div>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -254,39 +254,39 @@
                 <div class="col-lg-2 col-md-6 mb-4 mb-md-0">
                     <h4 class="footer-heading">Empresa</h4>
                     <ul class="footer-links">
-                        <li><a href="#">Sobre nós</a></li>
-                        <li><a href="#">Nosso time</a></li>
-                        <li><a href="#">Carreiras</a></li>
-                        <li><a href="#">Blog</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='sobre-nos') }}">Sobre nós</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='nosso-time') }}">Nosso time</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='carreiras') }}">Carreiras</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='blog') }}">Blog</a></li>
                     </ul>
                 </div>
                 
                 <div class="col-lg-2 col-md-6 mb-4 mb-md-0">
                     <h4 class="footer-heading">Eventos</h4>
                     <ul class="footer-links">
-                        <li><a href="#">Conferências</a></li>
-                        <li><a href="#">Workshops</a></li>
-                        <li><a href="#">Formações</a></li>
-                        <li><a href="#">Seminários</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='conferencias') }}">Conferências</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='workshops') }}">Workshops</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='formacoes') }}">Formações</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='seminarios') }}">Seminários</a></li>
                     </ul>
                 </div>
                 
                 <div class="col-lg-2 col-md-6 mb-4 mb-md-0">
                     <h4 class="footer-heading">Suporte</h4>
                     <ul class="footer-links">
-                        <li><a href="#">FAQ</a></li>
-                        <li><a href="#">Central de ajuda</a></li>
-                        <li><a href="#">Contato</a></li>
-                        <li><a href="#">Tutoriais</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='faq') }}">FAQ</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='central-de-ajuda') }}">Central de ajuda</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='contato') }}">Contato</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='tutoriais') }}">Tutoriais</a></li>
                     </ul>
                 </div>
                 
                 <div class="col-lg-2 col-md-6">
                     <h4 class="footer-heading">Legal</h4>
                     <ul class="footer-links">
-                        <li><a href="#">Termos de uso</a></li>
-                        <li><a href="#">Privacidade</a></li>
-                        <li><a href="#">Cookies</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='termos-de-uso') }}">Termos de uso</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='privacidade') }}">Privacidade</a></li>
+                        <li><a href="{{ url_for('static_page_routes.show_page', slug='cookies') }}">Cookies</a></li>
                     </ul>
                 </div>
             </div>

--- a/templates/pages/base_page.html
+++ b/templates/pages/base_page.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}{{ page_title }} - AppFiber{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">{{ page_title }}</h1>
+  <p class="lead">Plataforma completa para gestão de eventos, criando experiências memoráveis e simplificando todos os processos administrativos.</p>
+  <p>Conteúdo em construção.</p>
+</div>
+{% endblock %}

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/carreiras.html
+++ b/templates/pages/carreiras.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/central-de-ajuda.html
+++ b/templates/pages/central-de-ajuda.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/conferencias.html
+++ b/templates/pages/conferencias.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/contato.html
+++ b/templates/pages/contato.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/cookies.html
+++ b/templates/pages/cookies.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/empresa.html
+++ b/templates/pages/empresa.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/eventos.html
+++ b/templates/pages/eventos.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/faq.html
+++ b/templates/pages/faq.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/formacoes.html
+++ b/templates/pages/formacoes.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/legal.html
+++ b/templates/pages/legal.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/nosso-time.html
+++ b/templates/pages/nosso-time.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/privacidade.html
+++ b/templates/pages/privacidade.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/seminarios.html
+++ b/templates/pages/seminarios.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/sobre-nos.html
+++ b/templates/pages/sobre-nos.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/suporte.html
+++ b/templates/pages/suporte.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/termos-de-uso.html
+++ b/templates/pages/termos-de-uso.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/tutoriais.html
+++ b/templates/pages/tutoriais.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}

--- a/templates/pages/workshops.html
+++ b/templates/pages/workshops.html
@@ -1,0 +1,1 @@
+{% extends 'pages/base_page.html' %}


### PR DESCRIPTION
## Summary
- add `static_page_routes` blueprint with generic page handler
- register new blueprint
- add marketing page templates with placeholder text
- link footer items in `index.html` and `base.html` to these pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6850cade838083249d35d1a3024502e7