### PR TITLE
Add prefix before price on index

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -191,7 +191,7 @@ function renderizarEventos(eventos) {
         // Formata o preço do evento
         let priceValue = evento.preco_final !== undefined ? evento.preco_final : evento.preco_base;
         const price = priceValue > 0
-            ? `R$ ${parseFloat(priceValue).toFixed(2).replace('.', ',')}`
+            ? `A partir de R$ ${parseFloat(priceValue).toFixed(2).replace('.', ',')}`
             : 'Gratuito';
         
         // Gera um elemento div colorido como fallback de imagem


### PR DESCRIPTION
## Summary
- adjust price formatting in `index.js` so price is displayed as `A partir de R$ ...`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6851916c342483249a776836a9d4b5a2