### PR TITLE
Ensure Bootstrap JS loads

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -340,6 +340,13 @@
     {% block scripts %}
     <!-- Bootstrap Bundle -->
     <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+    <script>
+        if (typeof bootstrap === 'undefined') {
+            const cdn = document.createElement('script');
+            cdn.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js';
+            document.head.appendChild(cdn);
+        }
+    </script>
     
     <!-- PWA Scripts -->
     <script src="{{ url_for('static', filename='js/pwa.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -262,6 +262,13 @@
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+    <script>
+        if (typeof bootstrap === 'undefined') {
+            const cdn = document.createElement('script');
+            cdn.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js';
+            document.head.appendChild(cdn);
+        }
+    </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"></script>
     <!-- Importação do arquivo JavaScript customizado -->
     <script src="{{ url_for('static', filename='js/index.js') }}"></script>


### PR DESCRIPTION
## Summary
- add fallback CDN script in base template
- add fallback CDN script in index page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for psycopg2 and bleach)*

------
https://chatgpt.com/codex/tasks/task_e_685193108d048324bf13710fc86ed301