### PR TITLE
Fix navbar script on cliente dashboard

### DIFF
--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1483,6 +1483,13 @@
 {% block scripts %}
 {{ super() }}
 <script src="{{ url_for('static', filename='js/dashboard_cliente.js') }}"></script>
+<script>
+  if (typeof bootstrap === 'undefined') {
+    const cdn = document.createElement('script');
+    cdn.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js';
+    document.head.appendChild(cdn);
+  }
+</script>
   <script>
     const URL_EXPORTAR_CHECKINS_PDF = "{{ url_for('routes.exportar_checkins_filtrados') }}";
   </script>


### PR DESCRIPTION
## Summary
- add fallback bootstrap loading to `dashboard_cliente.html` to ensure navbar works even when local JS fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519625b94883248f258cc835f33cbf