### PR TITLE
Add profile edit menu for all user types

### DIFF
--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -37,13 +37,21 @@
                         <i class="bi bi-person-circle me-2 fs-5"></i>{{ current_user.nome }}
                     </a>
                     <ul class="dropdown-menu dropdown-menu-end shadow-lg border-0">
-                        {% if current_user.tipo == 'participante' %}
                         <li>
+                            {% if current_user.tipo == 'participante' %}
                             <a class="dropdown-item py-2" href="{{ url_for('inscricao_routes.editar_participante') }}">
+                            {% elif current_user.tipo == 'cliente' %}
+                            <a class="dropdown-item py-2" href="{{ url_for('cliente_routes.editar_cliente', cliente_id=current_user.id) }}">
+                            {% elif current_user.tipo == 'ministrante' %}
+                            <a class="dropdown-item py-2" href="{{ url_for('ministrante_routes.editar_ministrante', ministrante_id=current_user.id) }}">
+                            {% else %}
+                            <a class="dropdown-item py-2" href="#">
+                            {% endif %}
                                 <i class="bi bi-person-badge me-2"></i>Editar Perfil
                             </a>
                         </li>
                         <li><hr class="dropdown-divider my-1"></li>
+                        {% if current_user.tipo == 'participante' %}
                         <li>
                             <a class="dropdown-item py-2" href="{{ url_for('dashboard_participante_routes.dashboard_participante') }}">
                                 <i class="bi bi-speedometer2 me-2"></i>Dashboard
@@ -64,6 +72,12 @@
                         {% elif current_user.tipo == 'admin' %}
                         <li>
                             <a class="dropdown-item py-2" href="{{ url_for('dashboard_routes.dashboard') }}">
+                                <i class="bi bi-speedometer2 me-2"></i>Dashboard
+                            </a>
+                        </li>
+                        {% elif current_user.tipo == 'professor' %}
+                        <li>
+                            <a class="dropdown-item py-2" href="{{ url_for('dashboard_professor.dashboard_professor') }}">
                                 <i class="bi bi-speedometer2 me-2"></i>Dashboard
                             </a>
                         </li>


### PR DESCRIPTION
## Summary
- always show "Editar Perfil" in user dropdown
- link to each user type's edit page and add professor dashboard route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519a60fa5883249bbc25589ade3a32