### PR TITLE
Fix missing import in PDF generation

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3265,6 +3265,8 @@ def gerar_programacao_evento_pdf(evento_id):
     from reportlab.pdfgen import canvas
     from reportlab.lib.pagesizes import A4, landscape
     from reportlab.lib.units import cm
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
     # 1. Data Retrieval and Preparation
     evento = Evento.query.get_or_404(evento_id)


### PR DESCRIPTION
## Summary
- fix NameError in PDF generation by importing TA_CENTER and TA_LEFT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b7dd48108324a214a629d031cb77