### PR TITLE
Update event cleanup in client deletion

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -138,6 +138,8 @@ def excluir_cliente(cliente_id):
             Sorteio,
             Pagamento,
             Usuario,
+            AgendamentoVisita,
+            AlunoVisitante,
         )
 
         # ===============================
@@ -229,6 +231,20 @@ def excluir_cliente(cliente_id):
 
         for evento in eventos:
             with db.session.no_autoflush:
+                agendamento_ids = (
+                    db.session.query(AgendamentoVisita.id)
+                    .join(HorarioVisitacao)
+                    .filter(HorarioVisitacao.evento_id == evento.id)
+                )
+
+                AlunoVisitante.query.filter(
+                    AlunoVisitante.agendamento_id.in_(agendamento_ids)
+                ).delete(synchronize_session=False)
+
+                AgendamentoVisita.query.filter(
+                    AgendamentoVisita.id.in_(agendamento_ids)
+                ).delete(synchronize_session=False)
+
                 HorarioVisitacao.query.filter_by(evento_id=evento.id).delete()
                 ConfiguracaoAgendamento.query.filter_by(evento_id=evento.id).delete()
                 Patrocinador.query.filter_by(evento_id=evento.id).delete()


### PR DESCRIPTION
## Summary
- fix deletion of events when removing a client by clearing visit schedules and registrations in the right order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520473272083248cace5e452a330fe