### PR TITLE
Add event deletion feature

### DIFF
--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -495,6 +495,13 @@
           </div>
         </div>
       </form>
+      {% if evento %}
+      <form method="POST" action="{{ url_for('evento_routes.excluir_evento', evento_id=evento.id) }}" class="mt-3" onsubmit="return confirm('Tem certeza que deseja excluir este evento?');">
+        <button type="submit" class="btn btn-danger">
+          <i class="bi bi-trash me-2"></i>Excluir Evento
+        </button>
+      </form>
+      {% endif %}
       <!-- Etapa 5: Certificado -->
       <div class="step" id="step-5" style="display: none;">
         {% if evento %}


### PR DESCRIPTION
## Summary
- implement route to delete an event and its related data
- allow clients or admins to trigger event deletion in configure page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_685204f42b288324a1f2bea3daa1a11c