### PR TITLE
Fix deletion of clientes with blocked professors

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -140,6 +140,7 @@ def excluir_cliente(cliente_id):
             Usuario,
             AgendamentoVisita,
             AlunoVisitante,
+            ProfessorBloqueado,
         )
 
         # ===============================
@@ -244,6 +245,8 @@ def excluir_cliente(cliente_id):
                 AgendamentoVisita.query.filter(
                     AgendamentoVisita.id.in_(agendamento_ids)
                 ).delete(synchronize_session=False)
+
+                ProfessorBloqueado.query.filter_by(evento_id=evento.id).delete()
 
                 HorarioVisitacao.query.filter_by(evento_id=evento.id).delete()
                 ConfiguracaoAgendamento.query.filter_by(evento_id=evento.id).delete()


### PR DESCRIPTION
## Summary
- remove professor block records when deleting cliente events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520684edd0832499f3a941ac7ae6e0