### PR TITLE
Fix cascading form deletes in client removal

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -281,7 +281,9 @@ def excluir_cliente(cliente_id):
             CampoFormularioTemplate.template_id.in_(template_ids)
         ).delete(synchronize_session=False)
         FormularioTemplate.query.filter_by(cliente_id=cliente.id).delete()
-        Formulario.query.filter_by(cliente_id=cliente.id).delete()
+        formularios = Formulario.query.filter_by(cliente_id=cliente.id).all()
+        for f in formularios:
+            db.session.delete(f)  # cascades to campos and respostas
 
         # Sorteios e pagamentos
         Sorteio.query.filter_by(cliente_id=cliente.id).delete()


### PR DESCRIPTION
## Summary
- adjust client deletion logic so form deletions use session deletes
- keep commit after removing the client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520bfab2ac83248b8af0d58f180edf