### PR TITLE
Fix feedback cleanup on workshop removal

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -193,6 +193,7 @@ def excluir_cliente(cliente_id):
             OficinaDia.query.filter_by(oficina_id=oficina.id).delete()
             MaterialOficina.query.filter_by(oficina_id=oficina.id).delete()
             RelatorioOficina.query.filter_by(oficina_id=oficina.id).delete()
+            Feedback.query.filter_by(oficina_id=oficina.id).delete()
 
             db.session.execute(
                 text(

--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -15,7 +15,8 @@ from models import (
     ConfiguracaoCertificadoEvento, Checkin, OficinaDia, MaterialOficina,
     RelatorioOficina, ConfiguracaoAgendamento, SalaVisitacao,
     HorarioVisitacao, AgendamentoVisita, AlunoVisitante,
-    ProfessorBloqueado, Patrocinador, Sorteio, TrabalhoCientifico
+    ProfessorBloqueado, Patrocinador, Sorteio, TrabalhoCientifico,
+    Feedback
 )
 from utils import preco_com_taxa
 
@@ -611,6 +612,7 @@ def excluir_evento(evento_id):
             OficinaDia.query.filter_by(oficina_id=oficina.id).delete()
             MaterialOficina.query.filter_by(oficina_id=oficina.id).delete()
             RelatorioOficina.query.filter_by(oficina_id=oficina.id).delete()
+            Feedback.query.filter_by(oficina_id=oficina.id).delete()
             from sqlalchemy import text
             db.session.execute(
                 text('DELETE FROM oficina_ministrantes_association WHERE oficina_id = :oid'),

--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -1,6 +1,6 @@
 from flask import render_template, request, redirect, url_for, flash, jsonify, session
 from flask_login import login_required, current_user
-from models import Oficina, OficinaDia, Ministrante, Evento, Cliente, Checkin, Inscricao, MaterialOficina, RelatorioOficina, InscricaoTipo
+from models import Oficina, OficinaDia, Ministrante, Evento, Cliente, Checkin, Inscricao, MaterialOficina, RelatorioOficina, InscricaoTipo, Feedback
 from extensions import db
 from datetime import datetime
 from utils import obter_estados  # ou de onde essa função vem
@@ -337,7 +337,10 @@ def excluir_oficina(oficina_id):
         db.session.query(RelatorioOficina).filter_by(oficina_id=oficina.id).delete()
         print("✅ [DEBUG] Relatórios da oficina removidos.")
 
-        # 6️⃣ **Excluir associações com ministrantes na tabela de associação**
+        # 6️⃣ **Excluir feedbacks relacionados à oficina**
+        db.session.query(Feedback).filter_by(oficina_id=oficina.id).delete()
+        print("✅ [DEBUG] Feedbacks da oficina removidos.")
+        # 7️⃣ **Excluir associações com ministrantes na tabela de associação**
         from sqlalchemy import text
         db.session.execute(
             text('DELETE FROM oficina_ministrantes_association WHERE oficina_id = :oficina_id'),
@@ -345,7 +348,7 @@ def excluir_oficina(oficina_id):
         )
         print("✅ [DEBUG] Associações com ministrantes removidas.")
 
-        # 7️⃣ **Excluir a própria oficina**
+        # 8️⃣ **Excluir a própria oficina**
         db.session.delete(oficina)
         db.session.commit()
         print("✅ [DEBUG] Oficina removida com sucesso!")
@@ -382,6 +385,7 @@ def excluir_todas_oficinas():
             db.session.query(OficinaDia).filter_by(oficina_id=oficina.id).delete()
             db.session.query(MaterialOficina).filter_by(oficina_id=oficina.id).delete()
             db.session.query(RelatorioOficina).filter_by(oficina_id=oficina.id).delete()
+            db.session.query(Feedback).filter_by(oficina_id=oficina.id).delete()
             db.session.delete(oficina)
 
         db.session.commit()


### PR DESCRIPTION
## Summary
- ensure feedback entries are purged when removing workshops individually, in bulk, or via event and client deletions
- add `Feedback` model import where needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520fd59d3c8324bc820b6094e30fb0