### PR TITLE
Fix missing InscricaoTipo import

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -117,6 +117,7 @@ def excluir_cliente(cliente_id):
             EventoInscricaoTipo,
             Feedback,
             HorarioVisitacao,
+            InscricaoTipo,
             Inscricao,
             LinkCadastro,
             LoteInscricao,


### PR DESCRIPTION
## Summary
- ensure `InscricaoTipo` is imported when deleting a client

## Testing
- `pytest -q tests/test_inscricao_routes.py::test_delete_cliente` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_685213ac88908324bcf372a5e744cc85