### PR TITLE
Fix client deletion for event registration clean-up

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -237,6 +237,14 @@ def excluir_cliente(cliente_id):
 
         for evento in eventos:
             with db.session.no_autoflush:
+                # Limpar referências em usuários para tipos de inscrição deste evento
+                Usuario.query.filter(
+                    Usuario.tipo_inscricao_id.in_(
+                        db.session.query(EventoInscricaoTipo.id).filter_by(
+                            evento_id=evento.id
+                        )
+                    )
+                ).update({"tipo_inscricao_id": None}, synchronize_session=False)
                 agendamento_ids = (
                     db.session.query(AgendamentoVisita.id)
                     .join(HorarioVisitacao)


### PR DESCRIPTION
## Summary
- prevent foreign-key violations by clearing `Usuario.tipo_inscricao_id` before removing `EventoInscricaoTipo`
- keep cleanup within the no-autoflush block

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685216073e908324b1c3fc767be43996