### PR TITLE
Fix link_mapa string concatenation

### DIFF
--- a/populate_script.py
+++ b/populate_script.py
@@ -168,7 +168,7 @@ def criar_eventos(clientes, quantidade_por_cliente=5):
                 banner_url=f"banners/evento_{i}_{cliente.id}.jpg",
                 programacao=fake.paragraph(nb_sentences=3),
                 localizacao=fake.address(),
-                link_mapa="https://maps.google.com/?q=" + fake.latitude() + "," + fake.longitude(),
+                link_mapa=f"https://maps.google.com/?q={fake.latitude()},{fake.longitude()}",
                 data_inicio=data_inicio,
                 data_fim=data_fim,
                 hora_inicio=datetime.strptime(f"{random.randint(8, 10)}:00", "%H:%M").time(),


### PR DESCRIPTION
## Summary
- refactor populate_script to use an f-string for `link_mapa`
- ensure file ends with a newline

## Testing
- `python -m py_compile populate_script.py`

------
https://chatgpt.com/codex/tasks/task_e_685219f0b5748324b664435e8ebdfd44