### PR TITLE
Enable dynamic PDF preview

### DIFF
--- a/templates/certificado/upload_personalizacao_cert.html
+++ b/templates/certificado/upload_personalizacao_cert.html
@@ -159,9 +159,35 @@
   </div>
 
   <script>
-    document.getElementById('btnGerarPreview').addEventListener('click', function () {
-      const iframe = document.getElementById('certPreviewFrame');
-      iframe.src = '{{ url_for('certificado_routes.preview_certificado') }}?t=' + Date.now();
+    const previewUrl = '{{ url_for('certificado_routes.preview_certificado') }}';
+
+    function enviarPreview() {
+      const formData = new FormData();
+      const logo = document.querySelector('input[name="logo_certificado"]').files[0];
+      if (logo) formData.append('logo_certificado', logo);
+      const ass = document.querySelector('input[name="assinatura_certificado"]').files[0];
+      if (ass) formData.append('assinatura_certificado', ass);
+      const fundo = document.querySelector('input[name="fundo_certificado"]').files[0];
+      if (fundo) formData.append('fundo_certificado', fundo);
+      formData.append('texto_personalizado', document.querySelector('textarea[name="texto_personalizado"]').value);
+
+      fetch(previewUrl, {
+        method: 'POST',
+        body: formData
+      })
+        .then(r => r.ok ? r.blob() : Promise.reject())
+        .then(blob => {
+          const iframe = document.getElementById('certPreviewFrame');
+          const url = URL.createObjectURL(blob);
+          iframe.src = url;
+        })
+        .catch(() => console.error('Erro ao gerar preview'));
+    }
+
+    document.getElementById('btnGerarPreview').addEventListener('click', enviarPreview);
+    document.querySelector('textarea[name="texto_personalizado"]').addEventListener('input', enviarPreview);
+    ['logo_certificado', 'assinatura_certificado', 'fundo_certificado'].forEach(name => {
+      document.querySelector(`input[name="${name}"]`).addEventListener('change', enviarPreview);
     });
   </script>
 


### PR DESCRIPTION
## Summary
- allow `/preview_certificado` to accept POST uploads and generate a temporary preview
- automatically send preview data when customizing the certificate and refresh the iframe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685413a2e99883249af8544642141dff