### PR TITLE
Add binary file handling

### DIFF
--- a/models.py
+++ b/models.py
@@ -1050,3 +1050,20 @@ class LoteTipoInscricao(db.Model):
     def __repr__(self):
         return f"<LoteTipoInscricao Lote={self.lote_id}, Tipo={self.tipo_inscricao_id}, Preço={self.preco}>"
 
+
+# =================================
+#            ARQUIVO BINÁRIO
+# =================================
+class ArquivoBinario(db.Model):
+    """Modelo para armazenar arquivos binários no banco de dados."""
+    __tablename__ = 'arquivo_binario'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(255), nullable=False)
+    conteudo = db.Column(db.LargeBinary, nullable=False)
+    mimetype = db.Column(db.String(255), nullable=False)
+    uploaded_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<ArquivoBinario id={self.id} nome={self.nome}>"
+

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -45,6 +45,7 @@ def register_routes(app):
     from .sorteio_routes import sorteio_routes
     from .api_cidades import api_cidades
     from .mercadopago_routes import mercadopago_routes
+    from .binary_routes import binary_routes
     from .util_routes import util_routes
     from .relatorio_pdf_routes import relatorio_pdf_routes
     from .static_page_routes import static_page_routes
@@ -83,6 +84,7 @@ def register_routes(app):
     app.register_blueprint(sorteio_routes)
     app.register_blueprint(api_cidades)
     app.register_blueprint(mercadopago_routes)
+    app.register_blueprint(binary_routes)
     app.register_blueprint(util_routes)
     app.register_blueprint(relatorio_pdf_routes)
     app.register_blueprint(certificado_routes)

--- a/routes/binary_routes.py
+++ b/routes/binary_routes.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, request, jsonify, send_file
+from flask_login import login_required
+from werkzeug.utils import secure_filename
+from io import BytesIO
+
+from extensions import db
+from models import ArquivoBinario
+
+binary_routes = Blueprint('binary_routes', __name__)
+
+
+@binary_routes.route('/api/binarios', methods=['POST'])
+@login_required
+def upload_binario():
+    """Endpoint para upload de arquivos binários."""
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'Nenhum arquivo enviado'}), 400
+    novo = ArquivoBinario(
+        nome=secure_filename(file.filename),
+        conteudo=file.read(),
+        mimetype=file.mimetype or 'application/octet-stream'
+    )
+    db.session.add(novo)
+    db.session.commit()
+    return jsonify({'id': novo.id, 'nome': novo.nome}), 201
+
+
+@binary_routes.route('/api/binarios/<int:arquivo_id>', methods=['GET'])
+@login_required
+def download_binario(arquivo_id):
+    """Baixa um arquivo binário armazenado no banco."""
+    arq = ArquivoBinario.query.get_or_404(arquivo_id)
+    return send_file(
+        BytesIO(arq.conteudo),
+        mimetype=arq.mimetype,
+        as_attachment=True,
+        download_name=arq.nome
+    )

--- a/tests/test_binary_routes.py
+++ b/tests/test_binary_routes.py
@@ -1,0 +1,32 @@
+import io
+import pytest
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+
+from app import create_app
+from extensions import db
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['LOGIN_DISABLED'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_upload_and_download_binary(client):
+    data = {'file': (io.BytesIO(b'\x01\x02\x03'), 'dados.bin')}
+    resp = client.post('/api/binarios', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 201
+    arquivo_id = resp.get_json()['id']
+    resp = client.get(f'/api/binarios/{arquivo_id}')
+    assert resp.status_code == 200
+    assert resp.data == b'\x01\x02\x03'


### PR DESCRIPTION
## Summary
- store binary file in DB via `ArquivoBinario`
- expose `/api/binarios` endpoints for upload and download
- register new blueprint
- test binary upload/download functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542ee44e3c832495e3ca9048c664af