### PR TITLE
Remove root route clash

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,9 +90,9 @@ def on_join(data):
         join_room(sala)
 
 
-# Rota básica
-@app.route("/")
-def index():
+# Rota para verificar o horário atual do servidor
+@app.route("/time")
+def current_time():
     now = datetime.utcnow()
     return f"Horário de Brasília: {brasilia_filter(now)}"
 


### PR DESCRIPTION
## Summary
- rename index route in `app.py` to avoid duplicate root handler
- keep `/` handled by `evento_routes.home`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854412b124c8324ac13f7e53a9120d0