### PR TITLE
Improve secret key handling and add session persistence test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ export MAIL_USERNAME="seu_email@gmail.com"
 export MAIL_PASSWORD="sua_senha"
 export GOOGLE_CLIENT_ID="<cliente_id_do_google>"
 export GOOGLE_CLIENT_SECRET="<cliente_secret_do_google>"
+export SECRET_KEY="<sua_chave_secreta>"
 export APP_BASE_URL="https://seu-dominio.com"
 ```
+
+`SECRET_KEY` garante que as sessões geradas por uma instância do Flask possam
+ser lidas por outra. Em produção, utilize um valor seguro e idêntico em todas as
+réplicas do aplicativo.
 
 Essas variaveis substituem o antigo arquivo `credentials.json` utilizado para a
 autenticacao com a API do Gmail. O arquivo `token.json` sera gerado apos a

--- a/config.py
+++ b/config.py
@@ -6,7 +6,11 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class Config:
-    SECRET_KEY = os.urandom(24)  # Gera uma chave aleatória
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    if not SECRET_KEY:
+        if os.getenv("FLASK_ENV") == "production":
+            raise RuntimeError("SECRET_KEY environment variable not set")
+        SECRET_KEY = "dev_secret_key"  # Fixed key for development
 
     # URLs dos bancos de dados
     DB_ONLINE = 'postgresql://iafap:tOsydfgBrVx1o57X7oqznlABbwlFek84@dpg-cug5itl6l47c739tgung-a/iafap_database'

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -1,0 +1,36 @@
+from flask import session
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+
+from app import create_app
+
+
+def add_routes(app):
+    @app.route('/set')
+    def set_route():
+        session['value'] = 'works'
+        return 'ok'
+
+    @app.route('/get')
+    def get_route():
+        return session.get('value', 'missing')
+
+
+def test_session_persists_between_app_instances(monkeypatch):
+    monkeypatch.setenv('SECRET_KEY', 'session-test')
+
+    app1 = create_app()
+    add_routes(app1)
+    c1 = app1.test_client()
+    c1.get('/set')
+    cookie_name = app1.config['SESSION_COOKIE_NAME']
+    cookie = c1.get_cookie(cookie_name).value
+
+    app2 = create_app()
+    add_routes(app2)
+    c2 = app2.test_client()
+    c2.set_cookie(cookie_name, cookie, domain='localhost')
+    resp = c2.get('/get')
+    assert resp.data == b'works'


### PR DESCRIPTION
## Summary
- load `SECRET_KEY` from the environment with a fallback for dev only
- document the new variable in the README
- add a regression test ensuring session cookies work across app instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544132e0348324a658a214a46993f9