### PR TITLE
Enable payment by default

### DIFF
--- a/models.py
+++ b/models.py
@@ -450,7 +450,7 @@ class Cliente(db.Model, UserMixin):
     cliente_id = db.Column(db.Integer, db.ForeignKey('cliente.id'), nullable=True)  # ✅ Adicionando relação com Cliente
 
     # Campo novo para pagamento:
-    habilita_pagamento = db.Column(db.Boolean, default=False)
+    habilita_pagamento = db.Column(db.Boolean, default=True)
 
      # Relacionamento com Oficina
     oficinas = db.relationship("Oficina", back_populates="cliente")  # ✅ Agora usa `back_populates`

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -150,13 +150,12 @@ def cadastrar_cliente_publico():
             flash('Já existe um cliente com esse e-mail!', 'danger')
             return redirect(url_for('auth_routes.cadastrar_cliente_publico'))
 
-        habilita_pagamento = True if request.form.get('habilita_pagamento') == 'on' else False
-
+        # Pagamento habilitado por padrão para novos clientes
         novo_cliente = Cliente(
             nome=nome,
             email=email,
             senha=generate_password_hash(senha),
-            habilita_pagamento=habilita_pagamento,
+            habilita_pagamento=True,
         )
 
         db.session.add(novo_cliente)

--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -36,15 +36,12 @@ def cadastrar_cliente():
             flash("Já existe um cliente com esse e-mail!", "danger")
             return redirect(url_for("cliente_routes.cadastrar_cliente"))
 
-        # Cria o cliente
-        habilita_pagamento = (
-            True if request.form.get("habilita_pagamento") == "on" else False
-        )
+        # Cria o cliente com pagamento habilitado por padrão
         novo_cliente = Cliente(
             nome=nome,
             email=email,
             senha=generate_password_hash(senha),
-            habilita_pagamento=habilita_pagamento,
+            habilita_pagamento=True,
         )
 
         db.session.add(novo_cliente)
@@ -71,17 +68,8 @@ def editar_cliente(cliente_id):
         if nova_senha:  # Só atualiza a senha se fornecida
             cliente.senha = generate_password_hash(nova_senha)
 
-        # Valor recebido do checkbox
-        debug_checkbox = request.form.get("habilita_pagamento")
-        logger.debug("Valor recebido do checkbox 'habilita_pagamento': %s", debug_checkbox)
-
-        cliente.habilita_pagamento = True if debug_checkbox == "on" else False
-
-        # Valor que será salvo
-        logger.debug(
-            "Valor salvo em cliente.habilita_pagamento: %s",
-            cliente.habilita_pagamento,
-        )
+        # Pagamento sempre habilitado para clientes
+        cliente.habilita_pagamento = True
 
         try:
             db.session.commit()

--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -564,7 +564,7 @@ def configurar_evento():
         "evento/configurar_evento.html",
         eventos=eventos,
         evento=evento,
-        habilita_pagamento=current_user.habilita_pagamento,
+        habilita_pagamento=True,
         config_certificado=config_certificado,
         oficinas=oficinas,
     )
@@ -775,10 +775,9 @@ def criar_evento():
             db.session.add(novo_evento)
             db.session.flush()  # precisamos do ID para criar tipos de inscrição
 
-            # Se o cliente tiver pagamento habilitado, tratar tipos de inscrição
-            if current_user.habilita_pagamento:
-                nomes_tipos = request.form.getlist('nome_tipo[]')
-                precos = request.form.getlist('preco_tipo[]')
+            # Tratar tipos de inscrição
+            nomes_tipos = request.form.getlist('nome_tipo[]')
+            precos = request.form.getlist('preco_tipo[]')
                 
                 # Verificar se os tipos de inscrição foram fornecidos
                 if not nomes_tipos:

--- a/static/js/criar_evento.js
+++ b/static/js/criar_evento.js
@@ -8,18 +8,8 @@ document.addEventListener('DOMContentLoaded', function() {
     };
     let suggestionTimeout;
 
-    // ——— pagamento habilitado?  (1 = sim / 0 = não)
-    const pagamentoHabilitado = document.getElementById('pagamento_habilitado').value === '1';
-
-    // Se o cliente NÃO pode cobrar:
-    //   – força o checkbox "inscrição gratuita"
-    //   – desabilita seu uso
-    //   – oculta qualquer coluna de preços
-    if (!pagamentoHabilitado) {
-      inscricaoGratuita.checked = true;
-      inscricaoGratuita.disabled = true;
-      updatePriceFields();          // já esconde colunas de preço
-    }
+    // Pagamento habilitado para todos os clientes
+    const pagamentoHabilitado = true;
 
     // Configuração de sugestões para o campo de localização
     const localizacaoInput = document.getElementById('localizacao-input');

--- a/templates/agendamento/criar_evento_agendamento.html
+++ b/templates/agendamento/criar_evento_agendamento.html
@@ -113,7 +113,6 @@
         </div>
 
 
-                  {% if current_user.habilita_pagamento %}
                 <div class="row">
                   <!-- Location Section -->
                   <div class="col-md-6">
@@ -180,7 +179,6 @@
                       </div>
                     </div>
                   </div>
-                  {% endif %}
                 </div>
         
         <div class="row mt-4">
@@ -238,7 +236,6 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
-{% if current_user.habilita_pagamento %}
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     // Toggle registration types visibility
@@ -292,5 +289,4 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 </script>
-{% endif %}
 {% endblock %}

--- a/templates/auth/cadastrar_cliente.html
+++ b/templates/auth/cadastrar_cliente.html
@@ -4,9 +4,11 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h2 class="mb-4">Cadastrar Novo Cliente</h2>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h2 class="mb-4">Cadastrar Novo Cliente</h2>
 
-    <form method="POST">
+      <form method="POST">
         <div class="mb-3">
             <label for="nome" class="form-label">Nome</label>
             <input type="text" class="form-control" id="nome" name="nome" required>
@@ -19,13 +21,9 @@
             <label for="senha" class="form-label">Senha</label>
             <input type="password" class="form-control" id="senha" name="senha" required>
         </div>
-        <div class="form-check mb-3">
-            <input class="form-check-input" type="checkbox" id="habilita_pagamento" name="habilita_pagamento">
-            <label class="form-check-label" for="habilita_pagamento">
-                Habilitar Pagamento
-            </label>
-        </div>
         <button type="submit" class="btn btn-success">Cadastrar Cliente</button>
-    </form>
+      </form>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/auth/cadastrar_cliente_publico.html
+++ b/templates/auth/cadastrar_cliente_publico.html
@@ -4,9 +4,11 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h2 class="mb-4">Cadastrar Novo Cliente</h2>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h2 class="mb-4">Cadastrar Novo Cliente</h2>
 
-    <form method="POST">
+      <form method="POST">
         {{ form.hidden_tag() }}
         <div class="mb-3">
             <label for="nome" class="form-label">Nome</label>
@@ -20,16 +22,12 @@
             <label for="senha" class="form-label">Senha</label>
             <input type="password" class="form-control" id="senha" name="senha" required>
         </div>
-        <div class="form-check mb-3">
-            <input class="form-check-input" type="checkbox" id="habilita_pagamento" name="habilita_pagamento">
-            <label class="form-check-label" for="habilita_pagamento">
-                Habilitar Pagamento
-            </label>
-        </div>
         <div class="mb-3">
             {{ form.recaptcha }}
         </div>
         <button type="submit" class="btn btn-success">Cadastrar Cliente</button>
-    </form>
+      </form>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/auth/editar_cliente.html
+++ b/templates/auth/editar_cliente.html
@@ -2,8 +2,10 @@
 {% block title %}Editar Cliente{% endblock %}
 {% block content %}
 <div class="container mt-4">
-  <h2>Editar Cliente</h2>
-  <form method="POST">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h2>Editar Cliente</h2>
+      <form method="POST">
     <div class="mb-3">
       <label for="nome" class="form-label">Nome</label>
       <input type="text" id="nome" name="nome" class="form-control" value="{{ cliente.nome }}" required>
@@ -16,11 +18,9 @@
       <label for="senha" class="form-label">Nova Senha (opcional)</label>
       <input type="password" id="senha" name="senha" class="form-control">
     </div>
-    <div class="form-check mb-3">
-      <input class="form-check-input" type="checkbox" id="habilita_pagamento" name="habilita_pagamento" {% if cliente.habilita_pagamento %}checked{% endif %}>
-      <label class="form-check-label" for="habilita_pagamento">Habilitar Pagamento</label>
-    </div>
     <button type="submit" class="btn btn-primary">Salvar</button>
-  </form>
+      </form>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -141,8 +141,7 @@
                                         data-bs-target="#modalEditarCliente"
                                         data-id="{{ cliente.id }}"
                                         data-nome="{{ cliente.nome }}"
-                                        data-email="{{ cliente.email }}"
-                                        data-habilita-pagamento="{{ cliente.habilita_pagamento }}">
+                                        data-email="{{ cliente.email }}">
                                   <i class="bi bi-pencil"></i>
                                 </button>
                               
@@ -276,12 +275,6 @@
             <input type="password" class="form-control" name="senha" id="clienteSenha" placeholder="Deixe em branco para manter a senha atual">
             <small class="form-text text-muted">A senha só será alterada se você preencher este campo.</small>
           </div>
-          <div class="form-check mb-3">
-            <input type="checkbox" class="form-check-input" id="habilita_pagamento" name="habilita_pagamento">
-            <label class="form-check-label" for="habilita_pagamento">
-              Habilitar Pagamento
-            </label>
-          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-primary">Salvar Alterações</button>
@@ -302,16 +295,10 @@
       var clienteId = button.getAttribute('data-id');
       var nome = button.getAttribute('data-nome');
       var email = button.getAttribute('data-email');
-      var habilitaPagamento = button.getAttribute('data-habilita-pagamento'); // Novo atributo
-
       var form = modalEditarCliente.querySelector('#formEditarCliente');
       form.querySelector('#clienteNome').value = nome;
       form.querySelector('#clienteEmail').value = email;
       form.querySelector('#clienteSenha').value = ''; // Mantém em branco
-      
-      // Converte para minúsculas e verifica se é "true"
-      var isPagamentoEnabled = (habilitaPagamento && habilitaPagamento.toLowerCase() === 'true');
-      form.querySelector('#habilita_pagamento').checked = isPagamentoEnabled;
       
       form.action = editarClienteBaseUrl + '/' + clienteId;
   });

--- a/templates/evento/configurar_evento.html
+++ b/templates/evento/configurar_evento.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="container py-5">
-  <input type="hidden" id="pagamento_habilitado" value="{{ 1 if current_user.habilita_pagamento else 0 }}">
+  <input type="hidden" id="pagamento_habilitado" value="1">
   <div class="bg-primary bg-gradient rounded-3 p-4 mb-4 shadow-sm">
     <h1 class="h3 fw-bold text-white mb-0">
       <i class="bi bi-calendar-event me-2"></i>Configurar Evento
@@ -182,22 +182,11 @@
         
         <!-- Etapa 4: Configuração de Inscrição -->
         <div class="step" id="step-4" style="display: none;">
-          {% if habilita_pagamento %}
           <div class="border-bottom border-primary pb-2 mb-4">
             <h5 class="text-primary d-flex align-items-center">
               <i class="bi bi-cash-coin me-2"></i>Configuração de Inscrição
             </h5>
           </div>
-          
-          {% if not habilita_pagamento %}
-          <div class="alert alert-info bg-info bg-opacity-10 border-info d-flex mb-4" role="alert">
-            <div class="me-3"><i class="bi bi-info-circle-fill fs-3 text-info"></i></div>
-            <div>
-              <h6 class="alert-heading fw-bold mb-1">Plano Gratuito</h6>
-              <p class="mb-0 text-muted">Seu plano atual permite apenas inscrições gratuitas. Para habilitar cobranças, faça upgrade do seu plano.</p>
-            </div>
-          </div>
-          {% endif %}
 
           <div class="row g-4 mb-4">
             <div class="col-md-6">
@@ -222,8 +211,7 @@
                 <div class="card-body p-4">
                   <div class="form-check">
                     <input class="form-check-input" type="radio" name="inscricao_gratuita" id="inscricao_paga" value="0"
-                           {% if evento and not evento.inscricao_gratuita %}checked{% endif %}
-                           {% if not habilita_pagamento %}disabled{% endif %}>
+                           {% if evento and not evento.inscricao_gratuita %}checked{% endif %}>
                     <label class="form-check-label w-100" for="inscricao_paga">
                       <div class="d-flex align-items-center mb-2">
                         <i class="bi bi-credit-card-fill fs-3 text-primary me-2"></i>
@@ -777,7 +765,6 @@
 </style>
 
 <!-- Scripts -->
-{% if current_user.habilita_pagamento %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   // Controle de etapas
@@ -1314,7 +1301,6 @@ function updateProgressBar(step) {
   });
 });
 </script>
-{% endif %}
 
   <script>
   function carregarEvento(eventoId) {

--- a/templates/evento/criar_evento.html
+++ b/templates/evento/criar_evento.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 
 <div class="container py-5">
-  <input type="hidden" id="pagamento_habilitado" value="{{ 1 if current_user.habilita_pagamento else 0 }}">
+  <input type="hidden" id="pagamento_habilitado" value="1">
   <!-- Cabeçalho -->
   <div class="bg-primary bg-gradient rounded-3 p-4 mb-4 shadow-sm">
     <h1 class="h3 fw-bold text-white mb-0">
@@ -167,16 +167,7 @@
             </h5>
           </div>
           
-          <!-- Plano Gratuito Alert -->
-          {% if not current_user.habilita_pagamento %}
-          <div class="alert alert-info bg-info bg-opacity-10 border-info d-flex mb-4" role="alert">
-            <div class="me-3"><i class="bi bi-info-circle-fill fs-3 text-info"></i></div>
-            <div>
-              <h6 class="alert-heading fw-bold mb-1">Plano Gratuito</h6>
-              <p class="mb-0 text-muted">Seu plano atual permite apenas inscrições gratuitas. Para habilitar cobranças, faça upgrade do seu plano.</p>
-            </div>
-          </div>
-          {% endif %}
+
           
           <!-- Opções de Tipo de Inscrição -->
           <div class="row g-4 mb-4">
@@ -203,9 +194,8 @@
                    onclick="document.getElementById('inscricaoPaga').click()">
                 <div class="card-body p-4">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="inscricao_gratuita" 
-                           id="inscricaoPaga" value="0" 
-                           {% if not current_user.habilita_pagamento %}disabled{% endif %}>
+                    <input class="form-check-input" type="radio" name="inscricao_gratuita"
+                           id="inscricaoPaga" value="0">
                     <label class="form-check-label w-100" for="inscricaoPaga">
                       <div class="d-flex align-items-center mb-2">
                         <i class="bi bi-credit-card-fill fs-3 text-primary me-2"></i>

--- a/templates/oficina/criar_oficina.html
+++ b/templates/oficina/criar_oficina.html
@@ -288,7 +288,6 @@
             </div>
           </div>
 
-          {% if current_user.habilita_pagamento %}
           <!-- Configuração de Inscrição para Clientes com Pagamento Habilitado -->
           <div class="card bg-white shadow-sm border-0 mb-4">
             <div class="card-header bg-light">
@@ -834,7 +833,6 @@
   });
 </script>
 
-{% if current_user.habilita_pagamento %}
 <script>
 document.getElementById('inscricao_gratuita').addEventListener('change', function() {
   var container = document.getElementById('tipos-inscricao-container');
@@ -869,7 +867,6 @@ document.getElementById('tipos-inscricao-list').addEventListener('click', functi
   }
 });
 </script>
-{% endif %}
 
 <!-- Bootstrap Bundle -->
 <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>

--- a/templates/oficina/editar_oficina.html
+++ b/templates/oficina/editar_oficina.html
@@ -237,7 +237,6 @@
           </div>
         </div>
 
-        {% if current_user.habilita_pagamento %}
         <!-- Configuração de Inscrição para Clientes com Pagamento Habilitado -->
         <div class="mb-3">
           <label class="form-label">Configuração de Inscrição:</label>
@@ -285,7 +284,6 @@
           </div>
           <button type="button" id="adicionar-tipo-inscricao" class="btn btn-secondary">+ Adicionar Tipo de Inscrição</button>
         </div>
-        {% endif %}
 
         <button type="submit" class="btn btn-success w-100 mt-3">Salvar Alterações</button>
       </form>
@@ -405,7 +403,6 @@
     button.closest('.data-item').remove();
   }
 
-  {% if current_user.habilita_pagamento %}
   document.getElementById('inscricao_gratuita').addEventListener('change', function(){
     var container = document.getElementById('tipos-inscricao-container');
     if(this.checked){
@@ -440,7 +437,6 @@
       e.target.parentElement.parentElement.remove();
     }
   });
-  {% endif %}
 
   document.querySelector("form").addEventListener("submit", function(event) {
     var estado = document.getElementById("estado").value;


### PR DESCRIPTION
## Summary
- enable payment for new clients and remove setting from admin
- always show payment options in event/org pages
- simplify event creation JS
- tweak client forms with cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_685447d12c088324ac8b2ee088d75544