### PR TITLE
Update reCAPTCHA defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ export GOOGLE_CLIENT_ID="<cliente_id_do_google>"
 export GOOGLE_CLIENT_SECRET="<cliente_secret_do_google>"
 export SECRET_KEY="<sua_chave_secreta>"
 export APP_BASE_URL="https://seu-dominio.com"
+export RECAPTCHA_PUBLIC_KEY="<sua_chave_publica_recaptcha>"
+export RECAPTCHA_PRIVATE_KEY="<sua_chave_privada_recaptcha>"
 ```
 
 `SECRET_KEY` garante que as sessões geradas por uma instância do Flask possam
@@ -24,6 +26,8 @@ autenticacao com a API do Gmail. O arquivo `token.json` sera gerado apos a
 primeira autenticacao.
 
 `APP_BASE_URL` define a URL base para gerar links externos, como o `notification_url` do Mercado Pago. Em desenvolvimento, aponte para um endereço público (ex.: URL do ngrok).
+
+`RECAPTCHA_PUBLIC_KEY` e `RECAPTCHA_PRIVATE_KEY` devem conter as chaves obtidas no [Google reCAPTCHA](https://www.google.com/recaptcha/admin). Sem valores válidos, o CAPTCHA não funcionará em produção.
 
 ## Acessibilidade
 

--- a/config.py
+++ b/config.py
@@ -51,5 +51,5 @@ class Config:
     MAIL_DEFAULT_SENDER = os.getenv('MAIL_USERNAME')  # O e-mail que enviará as mensagens
 
     # Chaves do reCAPTCHA
-    RECAPTCHA_PUBLIC_KEY = os.getenv('RECAPTCHA_PUBLIC_KEY', 'test')
-    RECAPTCHA_PRIVATE_KEY = os.getenv('RECAPTCHA_PRIVATE_KEY', 'test')
+    RECAPTCHA_PUBLIC_KEY = os.getenv('RECAPTCHA_PUBLIC_KEY') or ''
+    RECAPTCHA_PRIVATE_KEY = os.getenv('RECAPTCHA_PRIVATE_KEY') or ''


### PR DESCRIPTION
## Summary
- make reCAPTCHA keys optional in config
- document RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854512d4368832496543f8eb0143a7f