### PR TITLE
Add participant export route

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ Para oferecer acessibilidade em Libras e suporte a pessoas cegas:
 ## Programacao em PDF
 
 Use a rota `/gerar_folder_evento/<evento_id>` para baixar a programacao do evento no formato de folder. Esta rota gera um PDF em modo paisagem com duas colunas, facilitando a impressao frente e verso.
+
+### Exportar participantes
+
+No dashboard do cliente é possível exportar a lista de inscritos de um evento em dois formatos. Escolha o evento desejado e utilize o botão **Exportar Participantes** para baixar um arquivo XLSX ou PDF contendo os campos padrões e personalizados do cadastro.

--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -1,12 +1,18 @@
 from flask import Blueprint, send_file, flash, redirect, url_for, request
 from flask_login import login_required, current_user
-from models import Oficina, Feedback
+from models import Oficina, Feedback, Evento, Inscricao, Usuario, CampoPersonalizadoCadastro, RespostaCampo
 from services.pdf_service import (
     gerar_pdf_inscritos_pdf,
     gerar_lista_frequencia_pdf,
     gerar_certificados_pdf,
     gerar_pdf_feedback
 )
+from io import BytesIO
+from openpyxl import Workbook
+from reportlab.lib.pagesizes import A4
+from reportlab.lib import colors
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer
+from reportlab.lib.styles import getSampleStyleSheet
 
 relatorio_pdf_routes = Blueprint("relatorio_pdf_routes", __name__)
 
@@ -16,3 +22,71 @@ def gerar_inscritos_pdf_route(oficina_id):
     return gerar_pdf_inscritos_pdf(oficina_id)
 
 # faça o mesmo para outras rotas PDF...
+
+@relatorio_pdf_routes.route('/exportar_participantes_evento')
+@login_required
+def exportar_participantes_evento():
+    """Exporta participantes de um evento em XLSX ou PDF."""
+    evento_id = request.args.get('evento_id', type=int)
+    formato = request.args.get('formato', 'xlsx')
+    if not evento_id:
+        flash('Evento não encontrado.', 'warning')
+        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+    evento = Evento.query.get_or_404(evento_id)
+    if current_user.tipo == 'cliente' and evento.cliente_id != current_user.id:
+        flash('Acesso negado ao evento.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+    inscricoes = (
+        Inscricao.query
+        .filter_by(evento_id=evento.id)
+        .join(Usuario)
+        .all()
+    )
+    campos_custom = CampoPersonalizadoCadastro.query.filter_by(cliente_id=evento.cliente_id).all()
+
+    headers = ['Nome', 'CPF', 'Email', 'Formação'] + [c.nome for c in campos_custom]
+    dados = []
+    for insc in inscricoes:
+        usuario = insc.usuario
+        row = [usuario.nome, usuario.cpf, usuario.email, usuario.formacao]
+        for campo in campos_custom:
+            resp = RespostaCampo.query.filter_by(
+                resposta_formulario_id=usuario.id,
+                campo_id=campo.id
+            ).first()
+            row.append(resp.valor if resp else '')
+        dados.append(row)
+
+    if formato == 'pdf':
+        buffer = BytesIO()
+        doc = SimpleDocTemplate(buffer, pagesize=A4)
+        styles = getSampleStyleSheet()
+        elementos = [Paragraph(f'Participantes - {evento.nome}', styles['Title']), Spacer(1, 12)]
+        tabela = Table([headers] + dados, repeatRows=1)
+        tabela.setStyle(TableStyle([
+            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#023E8A')),
+            ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),
+            ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+            ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+        ]))
+        elementos.append(tabela)
+        doc.build(elementos)
+        buffer.seek(0)
+        nome = f'participantes_evento_{evento.id}.pdf'
+        return send_file(buffer, as_attachment=True, download_name=nome, mimetype='application/pdf')
+
+    # padrão XLSX
+    output = BytesIO()
+    wb = Workbook()
+    ws = wb.active
+    ws.title = 'Participantes'
+    ws.append(headers)
+    for row in dados:
+        ws.append(row)
+    wb.save(output)
+    output.seek(0)
+    nome = f'participantes_evento_{evento.id}.xlsx'
+    return send_file(output, as_attachment=True, download_name=nome, mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -682,6 +682,25 @@ document.addEventListener('DOMContentLoaded', function() {
       }, 800); // Pequeno delay para o spinner ser visível
     });
   }
+
+  const exportPartBtn = document.getElementById('btnExportarParticipantes');
+  if (exportPartBtn) {
+    exportPartBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      const eventoId = document.getElementById('eventoExportParticipantes').value;
+      const formato = document.getElementById('formatoExportParticipantes').value;
+      let url;
+      if (this.dataset.exportUrl) {
+        url = `${this.dataset.exportUrl}?evento_id=${encodeURIComponent(eventoId)}&formato=${encodeURIComponent(formato)}`;
+      } else if (typeof URL_EXPORTAR_PARTICIPANTES !== 'undefined') {
+        url = `${URL_EXPORTAR_PARTICIPANTES}?evento_id=${encodeURIComponent(eventoId)}&formato=${encodeURIComponent(formato)}`;
+      } else {
+        console.error('URL de exportação não definida.');
+        return;
+      }
+      window.location.href = url;
+    });
+  }
   
   // Melhorar estilo dos selects ao focar/desfocar
   const selects = document.querySelectorAll('.form-select');

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -247,6 +247,42 @@
     </div>
   </div>
 </div>
+
+<!-- Exportar Participantes do Evento -->
+<div class="card shadow mt-4">
+  <div class="card-header">
+    <h5 class="m-0 fw-bold">Exportar Participantes</h5>
+  </div>
+  <div class="card-body">
+    <div class="row g-3">
+      <div class="col-12 col-md-6">
+        <label class="form-label fw-bold text-secondary">
+          <i class="bi bi-calendar-event me-2"></i>Selecionar Evento
+        </label>
+        <select id="eventoExportParticipantes" class="form-select border-0 bg-light">
+          {% for evento in eventos %}
+          <option value="{{ evento.id }}">{{ evento.nome }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-12 col-md-6">
+        <label class="form-label fw-bold text-secondary">
+          <i class="bi bi-file-earmark me-2"></i>Formato
+        </label>
+        <select id="formatoExportParticipantes" class="form-select border-0 bg-light">
+          <option value="xlsx">XLSX</option>
+          <option value="pdf">PDF</option>
+        </select>
+      </div>
+      <div class="col-12 mt-4">
+        <button id="btnExportarParticipantes" data-export-url="{{ url_for('relatorio_pdf_routes.exportar_participantes_evento') }}" class="btn btn-success w-100 py-2 shadow-sm d-flex align-items-center justify-content-center">
+          <i class="bi bi-download fs-5 me-3"></i>
+          <span class="fw-bold">Exportar Participantes</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
           
         </div><!-- /ABA 1: ESTATÍSTICAS -->
 
@@ -1319,6 +1355,9 @@
   // Declarar a variável somente se ainda não existir
   if (typeof URL_EXPORTAR_CHECKINS_PDF === 'undefined') {
     window.URL_EXPORTAR_CHECKINS_PDF = "{{ url_for('routes.exportar_checkins_filtrados') }}";
+  }
+  if (typeof URL_EXPORTAR_PARTICIPANTES === 'undefined') {
+    window.URL_EXPORTAR_PARTICIPANTES = "{{ url_for('relatorio_pdf_routes.exportar_participantes_evento') }}";
   }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement `exportar_participantes_evento` with XLSX and PDF output
- add export option in dashboard_cliente UI
- support export via JS handlers
- document participant export in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68553136e60483249fd3f7742f2a144d