### PR TITLE
Add financial tab

### DIFF
--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -13,6 +13,9 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib import colors
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer
 from reportlab.lib.styles import getSampleStyleSheet
+from sqlalchemy import func
+from decimal import Decimal
+from models import EventoInscricaoTipo, Configuracao
 
 relatorio_pdf_routes = Blueprint("relatorio_pdf_routes", __name__)
 
@@ -90,3 +93,66 @@ def exportar_participantes_evento():
     output.seek(0)
     nome = f'participantes_evento_{evento.id}.xlsx'
     return send_file(output, as_attachment=True, download_name=nome, mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+
+
+@relatorio_pdf_routes.route('/exportar_financeiro')
+@login_required
+def exportar_financeiro():
+    """Exporta o resumo financeiro do cliente em PDF ou XLSX."""
+    if current_user.tipo != 'cliente':
+        flash('Acesso negado.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    formato = request.args.get('formato', 'xlsx')
+
+    dados = (
+        db.session.query(
+            EventoInscricaoTipo.nome.label('nome'),
+            func.count(Inscricao.id).label('quantidade'),
+            EventoInscricaoTipo.preco.label('preco')
+        )
+        .join(Evento, Evento.id == EventoInscricaoTipo.evento_id)
+        .join(Inscricao, Inscricao.tipo_inscricao_id == EventoInscricaoTipo.id)
+        .filter(
+            Evento.cliente_id == current_user.id,
+            Inscricao.status_pagamento == 'approved'
+        )
+        .group_by(EventoInscricaoTipo.id)
+        .order_by(func.count(Inscricao.id).desc())
+        .all()
+    )
+
+    total = sum(float(r.preco) * r.quantidade for r in dados)
+
+    if formato == 'pdf':
+        buffer = BytesIO()
+        doc = SimpleDocTemplate(buffer, pagesize=A4)
+        styles = getSampleStyleSheet()
+        elementos = [Paragraph('Relatório Financeiro', styles['Title']), Spacer(1, 12)]
+        tabela = Table([
+            ['Tipo', 'Quantidade', 'Valor Unitário']
+        ] + [[r.nome, str(r.quantidade), f'R$ {r.preco:.2f}'] for r in dados] + [['Total', '', f'R$ {total:.2f}']],
+            repeatRows=1
+        )
+        tabela.setStyle(TableStyle([
+            ('GRID', (0,0), (-1,-1), 0.5, colors.grey),
+            ('BACKGROUND', (0,0), (-1,0), colors.HexColor('#023E8A')),
+            ('TEXTCOLOR', (0,0), (-1,0), colors.white),
+            ('FONTNAME', (0,0), (-1,0), 'Helvetica-Bold'),
+        ]))
+        elementos.append(tabela)
+        doc.build(elementos)
+        buffer.seek(0)
+        return send_file(buffer, as_attachment=True, download_name='financeiro.pdf', mimetype='application/pdf')
+
+    output = BytesIO()
+    wb = Workbook()
+    ws = wb.active
+    ws.title = 'Financeiro'
+    ws.append(['Tipo', 'Quantidade', 'Valor Unitário'])
+    for r in dados:
+        ws.append([r.nome, r.quantidade, float(r.preco)])
+    ws.append(['Total', '', total])
+    wb.save(output)
+    output.seek(0)
+    return send_file(output, as_attachment=True, download_name='financeiro.xlsx', mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -76,6 +76,12 @@
             <i class="bi bi-gear-fill me-1"></i> Configurações
           </button>
         </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="financeiro-tab" data-bs-toggle="tab"
+                  data-bs-target="#financeiro" type="button">
+            <i class="bi bi-cash-coin me-1"></i> Financeiro
+          </button>
+        </li>
       </ul>
 
       <!-- Conteúdo das Abas -->
@@ -1303,6 +1309,11 @@
   </div>
 
   <!-- /ABA 4: CONFIGURAÇÕES -->
+  <!-- ABA 5: FINANCEIRO -->
+  <div class="tab-pane fade" id="financeiro" role="tabpanel">
+    {% include 'partials/dashboard_financeiro_aba.html' %}
+  </div>
+  <!-- /ABA 5: FINANCEIRO -->
 <!-- Mantendo a integração com o script original sem modificações -->
 <!-- Javascript com ícones e labels melhorados -->
 
@@ -1358,6 +1369,9 @@
   }
   if (typeof URL_EXPORTAR_PARTICIPANTES === 'undefined') {
     window.URL_EXPORTAR_PARTICIPANTES = "{{ url_for('relatorio_pdf_routes.exportar_participantes_evento') }}";
+  }
+  if (typeof URL_EXPORTAR_FINANCEIRO === 'undefined') {
+    window.URL_EXPORTAR_FINANCEIRO = "{{ url_for('relatorio_pdf_routes.exportar_financeiro') }}";
   }
 </script>
 {% endblock %}

--- a/templates/partials/dashboard_financeiro_aba.html
+++ b/templates/partials/dashboard_financeiro_aba.html
@@ -1,0 +1,30 @@
+<h5 class="mb-3">Resumo Financeiro</h5>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Tipo de Inscrição</th>
+      <th>Quantidade</th>
+      <th>Valor Unitário</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for row in tipos %}
+    <tr>
+      <td>{{ row.nome }}</td>
+      <td>{{ row.quantidade }}</td>
+      <td>R$ {{ "%.2f"|format(row.preco) }}</td>
+    </tr>
+  {% else %}
+    <tr>
+      <td colspan="3" class="text-center">Nenhuma inscrição aprovada.</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<div class="mt-3">
+  <strong>Total em caixa:</strong> R$ {{ "%.2f"|format(valor_caixa) }}
+</div>
+<div class="mt-3 d-flex gap-2">
+  <a href="{{ url_for('relatorio_pdf_routes.exportar_financeiro', formato='pdf') }}" class="btn btn-outline-primary">Exportar PDF</a>
+  <a href="{{ url_for('relatorio_pdf_routes.exportar_financeiro', formato='xlsx') }}" class="btn btn-outline-success">Exportar XLSX</a>
+</div>


### PR DESCRIPTION
## Summary
- summarize registration revenue for each signup type
- allow export of finance data via PDF or XLSX
- render new Financeiro tab in the client dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6855352fbea88324becf305d2b823db7