### PR TITLE
Add PDF placas for event workshops

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ Use a rota `/gerar_folder_evento/<evento_id>` para baixar a programacao do event
 ### Exportar participantes
 
 No dashboard do cliente é possível exportar a lista de inscritos de um evento em dois formatos. Escolha o evento desejado e utilize o botão **Exportar Participantes** para baixar um arquivo XLSX ou PDF contendo os campos padrões e personalizados do cadastro.
+
+### Placas de oficinas
+
+Para sinalizar as atividades de um evento, utilize a rota `/gerar_placas/<evento_id>` ou o botão **Baixar Placas** no dashboard do cliente. Um PDF é gerado com uma página por oficina, contendo título e ministrante.

--- a/routes/pdf_routes.py
+++ b/routes/pdf_routes.py
@@ -12,6 +12,7 @@ from services.pdf_service import (
     gerar_evento_qrcode_pdf,
     gerar_qrcode_token,
     gerar_programacao_evento_pdf,
+    gerar_placas_oficinas_pdf,
     exportar_checkins_pdf_opcoes,
 )
 from . import routes
@@ -87,6 +88,13 @@ def gerar_qrcode_token_route(token):
 @routes.route('/gerar_folder_evento/<int:evento_id>')
 def gerar_folder_evento(evento_id):
     return gerar_programacao_evento_pdf(evento_id)
+
+
+@routes.route('/gerar_placas/<int:evento_id>')
+@login_required
+def gerar_placas_oficinas(evento_id):
+    """Gera PDF com placas simples das oficinas do evento."""
+    return gerar_placas_oficinas_pdf(evento_id)
 
 
 @routes.route('/exportar_checkins_filtrados')

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3149,6 +3149,35 @@ def gerar_programacao_evento_pdf(evento_id):
     c.save()
 
     return send_file(pdf_path, as_attachment=True, download_name=filename, mimetype='application/pdf')
+# Gerar placas simples para oficinas do evento
+
+def gerar_placas_oficinas_pdf(evento_id):
+    """Gera um PDF com uma pagina por oficina, exibindo titulo e ministrante."""
+    from models import Evento, Oficina
+    from flask import current_app, send_file
+    from reportlab.pdfgen import canvas
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.units import cm
+    import os
+    evento = Evento.query.get_or_404(evento_id)
+    oficinas = Oficina.query.filter_by(evento_id=evento_id).all()
+    pdf_dir = os.path.join(current_app.static_folder, "placas", str(evento_id))
+    os.makedirs(pdf_dir, exist_ok=True)
+    filename = f"placas_oficinas_{evento_id}.pdf"
+    pdf_path = os.path.join(pdf_dir, filename)
+    c = canvas.Canvas(pdf_path, pagesize=A4)
+    width, height = A4
+    for ofi in oficinas:
+        c.setFont("Helvetica-Bold", 28)
+        c.drawCentredString(width/2, height-5*cm, ofi.titulo)
+        if ofi.ministrante_obj:
+            c.setFont("Helvetica", 20)
+            c.drawCentredString(width/2, height-7*cm, ofi.ministrante_obj.nome)
+        c.showPage()
+    c.save()
+
+    return send_file(pdf_path, as_attachment=True, download_name=filename, mimetype="application/pdf")
+
 
 
 def gerar_etiquetas(cliente_id):

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -698,7 +698,21 @@ document.addEventListener('DOMContentLoaded', function() {
         console.error('URL de exportação não definida.');
         return;
       }
-      window.location.href = url;
+    window.location.href = url;
+  });
+  }
+
+  const placasBtn = document.getElementById('btnGerarPlacasOficinas');
+  if (placasBtn) {
+    placasBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      const eventoId = document.getElementById('eventoPlacasOficinas').value;
+      const base = this.dataset.baseUrl;
+      if (!base) {
+        console.error('Base URL não definida.');
+        return;
+      }
+      window.location.href = `${base}${encodeURIComponent(eventoId)}`;
     });
   }
   

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -374,6 +374,29 @@
           </div>
         </div>
       </div>
+
+      <!-- Placas das Oficinas -->
+      <div class="col-lg-6 col-xl-3">
+        <div class="card h-100 shadow-sm hover-shadow border-0">
+          <div class="card-body">
+            <div class="text-info mb-3">
+              <i class="bi bi-signpost fs-1"></i>
+            </div>
+            <h5 class="card-title fw-bold">Placas de Oficinas</h5>
+            <p class="card-text text-muted">Selecione o evento e baixe as placas</p>
+            <select id="eventoPlacasOficinas" class="form-select mt-2">
+              {% for evento in eventos %}
+              <option value="{{ evento.id }}">{{ evento.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="card-footer bg-white border-0 pt-0">
+            <button id="btnGerarPlacasOficinas" data-base-url="{{ url_for('routes.gerar_placas_oficinas', evento_id=0)[:-1] }}" class="btn btn-info w-100">
+              <i class="bi bi-download me-2"></i> Baixar Placas
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Gerenciamento de conteúdo -->


### PR DESCRIPTION
## Summary
- add `gerar_placas_oficinas_pdf` in pdf_service
- expose `/gerar_placas/<evento_id>` endpoint
- allow dashboard clients to download placas PDF
- document feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_685543d88a4c8324a50dd71b48f9b2f1