### PR TITLE
Organize admin financial dashboard by client

### DIFF
--- a/templates/partials/dashboard_financeiro_admin.html
+++ b/templates/partials/dashboard_financeiro_admin.html
@@ -1,26 +1,43 @@
-<h5 class="mb-3">Resumo Financeiro Geral</h5>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>Evento</th>
-      <th>Inscrições Aprovadas</th>
-      <th>Receita</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for ev in eventos %}
-    <tr>
-      <td>{{ ev.nome }}</td>
-      <td>{{ ev.quantidade }}</td>
-      <td>R$ {{ "%.2f"|format(ev.receita) }}</td>
-    </tr>
-  {% else %}
-    <tr>
-      <td colspan="3" class="text-center">Nenhum evento pago.</td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-<div class="mt-3"><strong>Total de Eventos com Receita:</strong> {{ total_eventos }}</div>
-<div><strong>Receita Total:</strong> R$ {{ "%.2f"|format(receita_total) }}</div>
-<div><strong>Receita de Taxas:</strong> R$ {{ "%.2f"|format(receita_taxas) }}</div>
+<h5 class="mb-3">Resumo Financeiro por Cliente</h5>
+{% for cliente in finance_clientes %}
+  <div class="card mb-4 shadow-sm">
+    <div class="card-header bg-light">
+      <h6 class="mb-0">{{ cliente.nome }}</h6>
+    </div>
+    <div class="card-body p-0">
+      <table class="table mb-0 table-striped">
+        <thead class="table-light">
+          <tr>
+            <th>Evento</th>
+            <th>Inscrições Aprovadas</th>
+            <th>Receita</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for ev in cliente.eventos.values() %}
+          <tr>
+            <td>{{ ev.nome }}</td>
+            <td>{{ ev.quantidade }}</td>
+            <td>R$ {{ "%.2f"|format(ev.receita) }}</td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="3" class="text-center">Nenhum evento pago.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="p-3">
+        <strong>Total do Cliente:</strong> R$ {{ "%.2f"|format(cliente.receita_total) }}<br>
+        <small class="text-muted">Taxas: R$ {{ "%.2f"|format(cliente.taxas) }}</small>
+      </div>
+    </div>
+  </div>
+{% else %}
+  <div class="alert alert-info">Nenhum dado financeiro.</div>
+{% endfor %}
+<div class="mt-4">
+  <strong>Total de Eventos com Receita:</strong> {{ total_eventos_receita }}<br>
+  <strong>Receita Total:</strong> R$ {{ "%.2f"|format(receita_total) }}<br>
+  <strong>Receita de Taxas:</strong> R$ {{ "%.2f"|format(receita_taxas) }}
+</div>

--- a/tests/test_dashboard_admin.py
+++ b/tests/test_dashboard_admin.py
@@ -41,4 +41,4 @@ def client(app):
 def test_dashboard_admin_financeiro(client):
     resp = client.get('/dashboard_admin')
     assert resp.status_code == 200
-    assert b'Resumo Financeiro Geral' in resp.data
+    assert b'Resumo Financeiro por Cliente' in resp.data


### PR DESCRIPTION
## Summary
- group financial data by client for admin dashboard
- show revenue per client with totals and card formatting
- adjust test for updated text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68554a8578908324a6c8bbf6d8c3e0c2