### PR TITLE
Add dedicated report page with finance option

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -208,30 +208,6 @@ function atualizarBotao(btn, valorAtivo) {
   }
 }
 
-function carregarRelatorioMensagem() {
-  if (typeof URL_GERAR_RELATORIO_MENSAGEM === 'undefined') {
-    alert("Erro de configuração: URL para gerar relatório não definida.");
-    console.error("URL_GERAR_RELATORIO_MENSAGEM não está definida.");
-    return;
-  }
-  fetch(URL_GERAR_RELATORIO_MENSAGEM)
-    .then(response => response.text())
-    .then(data => {
-        const textoRelatorioEl = document.getElementById("textoRelatorio");
-        const modalRelatorioEl = document.getElementById("modalRelatorioMensagem");
-        if (textoRelatorioEl && modalRelatorioEl) {
-            textoRelatorioEl.value = data;
-            var modalRelatorio = new bootstrap.Modal(modalRelatorioEl);
-            modalRelatorio.show();
-        } else {
-            console.error("Elemento 'textoRelatorio' ou 'modalRelatorioMensagem' não encontrado.");
-        }
-    })
-    .catch(error => {
-        console.error("Erro ao carregar relatório:", error);
-        alert("Não foi possível carregar o relatório.");
-    });
-}
 
 function copiarMensagem() {
   const textoRelatorioEl = document.getElementById("textoRelatorio");

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -377,23 +377,28 @@
 
 
       <!-- Relatório de Mensagem -->
-=======
-      <!-- Placas das Oficinas -->
-
       <div class="col-lg-6 col-xl-3">
         <div class="card h-100 shadow-sm hover-shadow border-0">
           <div class="card-body">
             <div class="text-info mb-3">
-
               <i class="bi bi-chat-left-text fs-1"></i>
             </div>
             <h5 class="card-title fw-bold">Relatório Mensagem</h5>
             <p class="card-text text-muted">Gere mensagem para compartilhar relatórios</p>
           </div>
           <div class="card-footer bg-white border-0 pt-0">
-            <button type="button" class="btn btn-info w-100 text-white" onclick="carregarRelatorioMensagem()">
+            <a href="{{ url_for('relatorio_routes.relatorio_mensagem') }}" class="btn btn-info w-100 text-white">
               <i class="bi bi-chat-left-text me-2"></i> Abrir Mensagem
+            </a>
+          </div>
+        </div>
+      </div>
 
+      <!-- Placas das Oficinas -->
+      <div class="col-lg-6 col-xl-3">
+        <div class="card h-100 shadow-sm hover-shadow border-0">
+          <div class="card-body">
+            <div class="text-info mb-3">
               <i class="bi bi-signpost fs-1"></i>
             </div>
             <h5 class="card-title fw-bold">Placas de Oficinas</h5>
@@ -407,7 +412,6 @@
           <div class="card-footer bg-white border-0 pt-0">
             <button id="btnGerarPlacasOficinas" data-base-url="{{ url_for('routes.gerar_placas_oficinas', evento_id=0)[:-1] }}" class="btn btn-info w-100">
               <i class="bi bi-download me-2"></i> Baixar Placas
-
             </button>
           </div>
         </div>
@@ -1357,34 +1361,6 @@
 
 </div>
 
-<!-- MODALS -->
-<!-- Modal do Relatório de Mensagem -->
-<div class="modal fade" id="modalRelatorioMensagem" tabindex="-1"
-     aria-labelledby="modalRelatorioMensagemLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header bg-success text-white">
-        <h5 class="modal-title" id="modalRelatorioMensagemLabel">
-          <i class="bi bi-whatsapp me-2"></i>Relatório - Mensagem de Texto
-        </h5>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
-                aria-label="Fechar"></button>
-      </div>
-      <div class="modal-body">
-        <textarea id="textoRelatorio" class="form-control" rows="8">{{ msg_relatorio }}</textarea>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" onclick="copiarMensagem()">
-          <i class="bi bi-clipboard me-2"></i> Copiar
-        </button>
-        <button type="button" class="btn btn-success" onclick="enviarWhatsAppRelatorio()">
-          <i class="bi bi-whatsapp me-2"></i> Enviar via WhatsApp
-        </button>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
-      </div>
-    </div>
-  </div>
-</div>
 
 <!-- O modal de check-ins via QR foi removido e substituído por uma página dedicada -->
 
@@ -1410,9 +1386,6 @@
   }
   if (typeof URL_EXPORTAR_FINANCEIRO === 'undefined') {
     window.URL_EXPORTAR_FINANCEIRO = "{{ url_for('relatorio_pdf_routes.exportar_financeiro') }}";
-  }
-  if (typeof URL_GERAR_RELATORIO_MENSAGEM === 'undefined') {
-    window.URL_GERAR_RELATORIO_MENSAGEM = "{{ url_for('relatorio_routes.gerar_relatorio_mensagem') }}";
   }
 </script>
 {% endblock %}

--- a/templates/relatorio/relatorio_mensagem.html
+++ b/templates/relatorio/relatorio_mensagem.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Relatório por Mensagem{% endblock %}
+
+{% block content %}
+<div class="container my-5">
+  <h2 class="mb-4">Relatório para Mensagem</h2>
+  <form method="get" class="mb-3">
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="1" id="financeiro" name="financeiro" {% if incluir_financeiro %}checked{% endif %}>
+      <label class="form-check-label" for="financeiro">
+        Incluir dados financeiros do evento
+      </label>
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">Gerar Relatório</button>
+  </form>
+  <textarea id="textoRelatorio" class="form-control mb-3" rows="12" readonly>{{ texto_relatorio }}</textarea>
+  <div class="d-flex gap-2">
+    <button class="btn btn-primary" onclick="copiarMensagem()"><i class="bi bi-clipboard me-2"></i>Copiar</button>
+    <button class="btn btn-success" onclick="enviarWhatsAppRelatorio()"><i class="bi bi-whatsapp me-2"></i>Enviar via WhatsApp</button>
+  </div>
+  <a href="{{ url_for('dashboard_routes.dashboard') }}" class="btn btn-link mt-3">Voltar ao Dashboard</a>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/dashboard_cliente.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace WhatsApp report modal with a standalone page
- extend server logic to optionally include financial data
- update dashboard button and JS helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68554b1ebc308324a86685f58f9548d1