### PR TITLE
Add review workflow models

### DIFF
--- a/migrations/versions/16e80ff4acb5_add_submission_review_assignment_tables.py
+++ b/migrations/versions/16e80ff4acb5_add_submission_review_assignment_tables.py
@@ -1,0 +1,50 @@
+"""add Submission, Review, and Assignment tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '16e80ff4acb5'
+down_revision = '2bb295ff7424'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'submission',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(length=255), nullable=False),
+        sa.Column('abstract', sa.Text(), nullable=True),
+        sa.Column('file_path', sa.String(length=255), nullable=True),
+        sa.Column('locator', sa.String(length=255), nullable=True),
+        sa.Column('code_hash', sa.String(length=64), nullable=True),
+        sa.Column('status', sa.String(length=50), nullable=True),
+        sa.Column('area_id', sa.Integer(), nullable=True),
+        sa.Column('author_id', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    op.create_table(
+        'review',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('submission_id', sa.Integer(), nullable=False),
+        sa.Column('reviewer_id', sa.Integer(), nullable=True),
+        sa.Column('blind_type', sa.String(length=20), nullable=True),
+        sa.Column('scores', sa.JSON(), nullable=True),
+        sa.Column('comments', sa.Text(), nullable=True),
+        sa.Column('file_path', sa.String(length=255), nullable=True),
+        sa.Column('decision', sa.String(length=50), nullable=True),
+        sa.Column('submitted_at', sa.DateTime(), nullable=True),
+    )
+    op.create_table(
+        'assignment',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('submission_id', sa.Integer(), nullable=False),
+        sa.Column('reviewer_id', sa.Integer(), nullable=False),
+        sa.Column('deadline', sa.DateTime(), nullable=True),
+        sa.Column('completed', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+    )
+
+def downgrade():
+    op.drop_table('assignment')
+    op.drop_table('review')
+    op.drop_table('submission')

--- a/models.py
+++ b/models.py
@@ -56,6 +56,9 @@ class Usuario(db.Model, UserMixin):
     
     def is_professor(self):
          return self.tipo == 'professor'
+
+    def is_revisor(self):
+         return self.tipo == 'revisor'
     
     def tem_pagamento_pendente(self):
         pendente = Inscricao.query.filter_by(
@@ -1066,4 +1069,69 @@ class ArquivoBinario(db.Model):
 
     def __repr__(self):
         return f"<ArquivoBinario id={self.id} nome={self.nome}>"
+
+
+# =================================
+#            SUBMISSION
+# =================================
+class Submission(db.Model):
+    __tablename__ = 'submission'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    abstract = db.Column(db.Text, nullable=True)
+    file_path = db.Column(db.String(255), nullable=True)
+    locator = db.Column(db.String(255), nullable=True)
+    code_hash = db.Column(db.String(64), nullable=True)
+    status = db.Column(db.String(50), nullable=True)
+    area_id = db.Column(db.Integer, nullable=True)
+    author_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    author = db.relationship('Usuario', backref=db.backref('submissions', lazy=True))
+
+    def __repr__(self):
+        return f"<Submission {self.title}>"
+
+
+# =================================
+#             REVIEW
+# =================================
+class Review(db.Model):
+    __tablename__ = 'review'
+
+    id = db.Column(db.Integer, primary_key=True)
+    submission_id = db.Column(db.Integer, db.ForeignKey('submission.id'), nullable=False)
+    reviewer_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=True)
+    blind_type = db.Column(db.String(20), nullable=True)
+    scores = db.Column(db.JSON, nullable=True)
+    comments = db.Column(db.Text, nullable=True)
+    file_path = db.Column(db.String(255), nullable=True)
+    decision = db.Column(db.String(50), nullable=True)
+    submitted_at = db.Column(db.DateTime, nullable=True)
+
+    submission = db.relationship('Submission', backref=db.backref('reviews', lazy=True))
+    reviewer = db.relationship('Usuario', backref=db.backref('reviews', lazy=True))
+
+    def __repr__(self):
+        return f"<Review {self.id} submission={self.submission_id}>"
+
+
+# =================================
+#           ASSIGNMENT
+# =================================
+class Assignment(db.Model):
+    __tablename__ = 'assignment'
+
+    id = db.Column(db.Integer, primary_key=True)
+    submission_id = db.Column(db.Integer, db.ForeignKey('submission.id'), nullable=False)
+    reviewer_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    deadline = db.Column(db.DateTime, nullable=True)
+    completed = db.Column(db.Boolean, default=False)
+
+    submission = db.relationship('Submission', backref=db.backref('assignments', lazy=True))
+    reviewer = db.relationship('Usuario', backref=db.backref('assignments', lazy=True))
+
+    def __repr__(self):
+        return f"<Assignment submission={self.submission_id} reviewer={self.reviewer_id}>"
 


### PR DESCRIPTION
## Summary
- add `is_revisor` helper on `Usuario`
- introduce `Submission`, `Review`, and `Assignment` models
- create Alembic migration for new tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6855597e60808324a992e006d79f65c0