### PR TITLE
Add peer review dashboards with navigation

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -49,6 +49,7 @@ def register_routes(app):
     from .util_routes import util_routes
     from .relatorio_pdf_routes import relatorio_pdf_routes
     from .static_page_routes import static_page_routes
+    from .peer_review_routes import peer_review_routes
     # Importa servicos que registram rotas diretamente no blueprint
     from services import lote_service  # noqa: F401
 
@@ -90,5 +91,6 @@ def register_routes(app):
     app.register_blueprint(certificado_routes)
     app.register_blueprint(placeholder_routes)
     app.register_blueprint(static_page_routes)
+    app.register_blueprint(peer_review_routes)
 
 

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, render_template
+
+peer_review_routes = Blueprint(
+    'peer_review_routes',
+    __name__,
+    template_folder="../templates/peer_review"
+)
+
+@peer_review_routes.route('/peer-review/author')
+def author_dashboard():
+    return render_template('peer_review/author/dashboard.html', submissions=[])
+
+@peer_review_routes.route('/peer-review/reviewer')
+def reviewer_dashboard():
+    return render_template('peer_review/reviewer/dashboard.html', tasks=[])
+
+@peer_review_routes.route('/peer-review/editor')
+def editor_dashboard():
+    return render_template('peer_review/editor/dashboard.html', decisions=[])

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -22,6 +22,9 @@
                 <li class="nav-item">
                     <a class="nav-link contato-link" href="{{ url_for('evento_routes.home') }}#contato">Contato</a>
                 </li>
+                <li class="nav-item ms-lg-3">
+                    <a class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#revisorModal">Revisores</a>
+                </li>
                 <li class="nav-item me-2" id="pwa-install-btn">
                     <a class="nav-link btn btn-primary text-white px-3" href="#">
                         <i class="bi bi-download me-1"></i> Instalar App
@@ -76,6 +79,30 @@
         </div>
     </div>
 </nav>
+<!-- Modal Revisores -->
+<div class="modal fade" id="revisorModal" tabindex="-1" aria-labelledby="revisorModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="revisorModalLabel">Acesso dos Revisores</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form method="get" action="{{ url_for('peer_review_routes.reviewer_dashboard') }}">
+          <div class="mb-3">
+            <label for="locatorInput" class="form-label">Localizador</label>
+            <input type="text" class="form-control" id="locatorInput" name="locator">
+          </div>
+          <div class="mb-3">
+            <label for="codeInput" class="form-label">Código de Acesso</label>
+            <input type="password" class="form-control" id="codeInput" name="code">
+          </div>
+          <button type="submit" class="btn btn-primary">Entrar</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Obtém o path atual

--- a/templates/peer_review/author/dashboard.html
+++ b/templates/peer_review/author/dashboard.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Minhas Submissões{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Minhas Submissões</h1>
+  <p class="text-muted">Resumo de todas as submissões enviadas.</p>
+  <table class="table table-striped">
+    <thead>
+      <tr><th>Título</th><th>Status</th><th>Data</th></tr>
+    </thead>
+    <tbody>
+      {% for sub in submissions %}
+      <tr>
+        <td>{{ sub.title }}</td>
+        <td>{{ sub.status }}</td>
+        <td>{{ sub.date }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="text-center">Nenhuma submissão.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/peer_review/editor/dashboard.html
+++ b/templates/peer_review/editor/dashboard.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Decisões Editoriais{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Decisões Editoriais</h1>
+  <p class="text-muted">Resumo das decisões tomadas para cada submissão.</p>
+  <table class="table table-striped">
+    <thead>
+      <tr><th>Título</th><th>Decisão</th><th>Data</th></tr>
+    </thead>
+    <tbody>
+      {% for decision in decisions %}
+      <tr>
+        <td>{{ decision.title }}</td>
+        <td>{{ decision.status }}</td>
+        <td>{{ decision.date }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="text-center">Nenhuma decisão registrada.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/peer_review/reviewer/dashboard.html
+++ b/templates/peer_review/reviewer/dashboard.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Tarefas de Revisão{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Tarefas de Revisão</h1>
+  <p class="text-muted">Lista de trabalhos atribuídos para revisão.</p>
+  <table class="table table-striped">
+    <thead>
+      <tr><th>Título</th><th>Status</th><th>Prazo</th></tr>
+    </thead>
+    <tbody>
+      {% for task in tasks %}
+      <tr>
+        <td>{{ task.title }}</td>
+        <td>{{ task.status }}</td>
+        <td>{{ task.due_date }}</td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="text-center">Nenhuma tarefa pendente.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create peer review blueprint and templates for author, reviewer and editor
- register new routes
- add 'Revisores' button and modal to navbar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_685560c412488324a47fd8781a33c814