### PR TITLE
Add submission toggle in dashboard

### DIFF
--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -25,7 +25,8 @@ def toggle_checkin_global_cliente():
             cliente_id=cliente_id,
             permitir_checkin_global=False,
             habilitar_feedback=False,
-            habilitar_certificado_individual=False
+            habilitar_certificado_individual=False,
+            habilitar_submissao_trabalhos=False
         )
         db.session.add(config_cliente)
         db.session.commit()
@@ -57,7 +58,8 @@ def toggle_feedback_cliente():
             permitir_checkin_global=False,
             habilitar_feedback=False,
             habilitar_certificado_individual=False,
-            habilitar_qrcode_evento_credenciamento=False
+            habilitar_qrcode_evento_credenciamento=False,
+            habilitar_submissao_trabalhos=False
         )
         db.session.add(config_cliente)
         db.session.commit()
@@ -87,7 +89,8 @@ def toggle_certificado_cliente():
             cliente_id=cliente_id,
             permitir_checkin_global=False,
             habilitar_feedback=False,
-            habilitar_certificado_individual=False
+            habilitar_certificado_individual=False,
+            habilitar_submissao_trabalhos=False
         )
         db.session.add(config_cliente)
         db.session.commit()
@@ -157,23 +160,28 @@ def toggle_cliente(cliente_id):
     flash(f"Cliente {'ativado' if cliente.ativo else 'desativado'} com sucesso", "success")
     return redirect(url_for('dashboard_routes.dashboard'))
 
-@config_cliente_routes.route('/toggle_submissao_trabalhos')
+@config_cliente_routes.route('/toggle_submissao_trabalhos', methods=['POST'])
 @login_required
 def toggle_submissao_trabalhos_cliente():
     if current_user.tipo != 'cliente':
-        flash("Apenas clientes podem alterar essa configuração.", "warning")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
 
     config = current_user.configuracao
 
     if not config:
-        flash("Cliente sem configuração associada.", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        config = ConfiguracaoCliente(cliente_id=current_user.id,
+                                     habilitar_submissao_trabalhos=False)
+        db.session.add(config)
+        db.session.commit()
 
     config.habilitar_submissao_trabalhos = not config.habilitar_submissao_trabalhos
     db.session.commit()
-    flash("Configuração de submissão de trabalhos atualizada!", "success")
-    return redirect(url_for('dashboard_routes.dashboard'))
+
+    return jsonify({
+        "success": True,
+        "value": config.habilitar_submissao_trabalhos,
+        "message": "Configuração de submissão de trabalhos atualizada!"
+    })
 
 @config_cliente_routes.route('/toggle_mostrar_taxa', methods=['POST'])
 @login_required
@@ -183,7 +191,8 @@ def toggle_mostrar_taxa():
 
     config = current_user.configuracao
     if not config:
-        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        config = ConfiguracaoCliente(cliente_id=current_user.id,
+                                     habilitar_submissao_trabalhos=False)
         db.session.add(config)
         db.session.commit()
 
@@ -207,7 +216,8 @@ def configuracao_cliente_atual():
             cliente_id=cliente_id,
             permitir_checkin_global=False,
             habilitar_feedback=False,
-            habilitar_certificado_individual=False
+            habilitar_certificado_individual=False,
+            habilitar_submissao_trabalhos=False
         )
         db.session.add(config_cliente)
         db.session.commit()
@@ -218,7 +228,8 @@ def configuracao_cliente_atual():
         "habilitar_feedback": config_cliente.habilitar_feedback,
         "habilitar_certificado_individual": config_cliente.habilitar_certificado_individual,
         "habilitar_qrcode_evento_credenciamento": config_cliente.habilitar_qrcode_evento_credenciamento,
-        "mostrar_taxa": config_cliente.mostrar_taxa
+        "mostrar_taxa": config_cliente.mostrar_taxa,
+        "habilitar_submissao_trabalhos": config_cliente.habilitar_submissao_trabalhos
     })
 
 @config_cliente_routes.route("/toggle_qrcode_evento_credenciamento", methods=["POST"])
@@ -236,7 +247,8 @@ def toggle_qrcode_evento_credenciamento():
             permitir_checkin_global=False,
             habilitar_feedback=False,
             habilitar_certificado_individual=False,
-            habilitar_qrcode_evento_credenciamento=False
+            habilitar_qrcode_evento_credenciamento=False,
+            habilitar_submissao_trabalhos=False
         )
         db.session.add(config_cliente)
         db.session.commit()

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -32,37 +32,7 @@
  * </script>
  */
 
-document.addEventListener('DOMContentLoaded', function () {
-  const btnSubmissao = document.getElementById('btnToggleSubmissao');
 
-  if (btnSubmissao) {
-    btnSubmissao.addEventListener('click', function () {
-      const toggleUrl = btnSubmissao.getAttribute('data-toggle-url'); // Boa prática: URL via atributo data
-
-      if (!toggleUrl) {
-        console.error("Atributo data-toggle-url não encontrado no botão de submissão.");
-        alert("Erro de configuração: URL para alternar submissão não definida.");
-        return;
-      }
-
-      fetch(toggleUrl, {
-        credentials: 'include'
-      })
-        .then(response => {
-          if (response.ok) {
-            location.reload(); // Recarrega para refletir a mudança
-          } else {
-            alert("Erro ao atualizar a configuração de submissão.");
-            response.text().then(text => console.error("Detalhes do erro:", text));
-          }
-        })
-        .catch(error => {
-          console.error("Erro na requisição para alternar submissão:", error);
-          alert("Erro ao conectar com o servidor para alternar submissão.");
-        });
-    });
-  }
-});
 
 // Carregamento inicial - Estados, cidades e configurações
 document.addEventListener('DOMContentLoaded', function() {
@@ -136,12 +106,14 @@ document.addEventListener('DOMContentLoaded', function() {
         const btnCertificado = document.getElementById('btnToggleCertificado');
         const btnQrCredenciamento = document.getElementById('btnToggleQrCredenciamento');
         const btnMostrarTaxa = document.getElementById('btnToggleMostrarTaxa');
+        const btnSubmissao = document.getElementById('btnToggleSubmissao');
 
         if (btnCheckin) atualizarBotao(btnCheckin, data.permitir_checkin_global);
         if (btnFeedback) atualizarBotao(btnFeedback, data.habilitar_feedback);
         if (btnCertificado) atualizarBotao(btnCertificado, data.habilitar_certificado_individual);
         if (btnQrCredenciamento) atualizarBotao(btnQrCredenciamento, data.habilitar_qrcode_evento_credenciamento);
         if (btnMostrarTaxa) atualizarBotao(btnMostrarTaxa, data.mostrar_taxa);
+        if (btnSubmissao) atualizarBotao(btnSubmissao, data.habilitar_submissao_trabalhos);
       })
       .catch(err => {
         console.error("Erro ao buscar config do cliente:", err);
@@ -156,7 +128,8 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('btnToggleFeedback'),
     document.getElementById('btnToggleCertificado'),
     document.getElementById('btnToggleQrCredenciamento'),
-    document.getElementById('btnToggleMostrarTaxa')
+    document.getElementById('btnToggleMostrarTaxa'),
+    document.getElementById('btnToggleSubmissao')
   ];
 
   toggleButtons.forEach(button => {

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -911,6 +911,24 @@
                   </button>
                 </div>
 
+                <!-- Submissão de Trabalhos -->
+                <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+                  <div>
+                    <h6 class="mb-0 fw-semibold d-flex align-items-center">
+                      <i class="bi bi-upload text-primary me-2"></i>
+                      Submissão de Trabalhos
+                    </h6>
+                    <p class="text-muted small mb-0">Permite que participantes submetam trabalhos</p>
+                  </div>
+                  <button type="button"
+                          id="btnToggleSubmissao"
+                          class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'danger' }}"
+                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_submissao_trabalhos_cliente') }}">
+                    <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'x-circle-fill' }}"></i>
+                    {{ 'Ativo' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'Desativado' }}
+                  </button>
+                </div>
+
                 <!-- Mostrar Taxa de Serviço -->
                 <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
                   <div>


### PR DESCRIPTION
## Summary
- enable clients to toggle submission in Configurações Globais
- expose `habilitar_submissao_trabalhos` via API
- handle new toggle in dashboard JavaScript
- support POST/JSON for submission toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855721ff1888324b25d4f851c1ffa81