### PR TITLE
Fix duplicate __repr__ method

### DIFF
--- a/models.py
+++ b/models.py
@@ -1107,13 +1107,6 @@ class AuditLog(db.Model):
     def __repr__(self):
         return f"<AuditLog {self.user_id} {self.event_type} {self.submission_id}>"
 
-
-    def __repr__(self):
-        return (
-            f"<LoteTipoInscricao lote={self.lote_id} tipo={self.tipo_inscricao_id} "
-            f"preco={self.preco}>"
-        )
-
 # -----------------------------------------------------------------------------
 # CONFIGURAÇÃO DE REVISÃO POR EVENTO
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clean up `AuditLog` model by removing stray `__repr__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68557ffd9098832488c8eace7042efcd