### PR TITLE
Add submission config page and cleanup dashboard

### DIFF
--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request, redirect, url_for, flash
+from flask import Blueprint, jsonify, request, redirect, url_for, flash, render_template
 from flask_login import login_required, current_user
 from extensions import db
 from models import ConfiguracaoCliente, Configuracao, Cliente, RevisaoConfig
@@ -378,5 +378,22 @@ def atualizar_revisao_config(evento_id):
     config.modelo_blind = data.get('modelo_blind', config.modelo_blind)
     db.session.commit()
     return jsonify({"success": True})
+
+
+@config_cliente_routes.route('/config_submissao')
+@login_required
+def config_submissao():
+    """Página de configuração das opções de submissão e revisão"""
+    if current_user.tipo != 'cliente':
+        flash('Acesso negado!', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    config_cliente = ConfiguracaoCliente.query.filter_by(cliente_id=current_user.id).first()
+    if not config_cliente:
+        config_cliente = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config_cliente)
+        db.session.commit()
+
+    return render_template('config/config_submissao.html', config_cliente=config_cliente)
 
 

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}Configurações de Submissão{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="h3 mb-4"><i class="bi bi-journal-text me-2"></i>Submissões e Revisão</h1>
+  <div class="card border-info border-top border-4 shadow-sm mb-4">
+    <div class="card-header bg-info text-white">
+      <div class="d-flex align-items-center">
+        <i class="bi bi-journal-text me-2 fs-5"></i>
+        <h5 class="fw-bold mb-0">Submissões e Revisão</h5>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+        <div>
+          <h6 class="mb-0 fw-semibold d-flex align-items-center">
+            <i class="bi bi-upload text-primary me-2"></i>
+            Submissão de Trabalhos
+          </h6>
+          <p class="text-muted small mb-0">Permite que participantes submetam trabalhos</p>
+        </div>
+        <button type="button"
+                id="btnToggleSubmissao"
+                class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'danger' }}"
+                data-toggle-url="{{ url_for('config_cliente_routes.toggle_submissao_trabalhos_cliente') }}">
+          <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'x-circle-fill' }}"></i>
+          {{ 'Ativo' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'Desativado' }}
+        </button>
+      </div>
+      <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+        <div>
+          <h6 class="mb-0 fw-semibold">Modelo de Revisão</h6>
+        </div>
+        <select id="selectReviewModel" class="form-select w-auto" data-update-url="{{ url_for('config_cliente_routes.set_review_model') }}">
+          <option value="single" {% if config_cliente.review_model == 'single' %}selected{% endif %}>Single-blind</option>
+          <option value="double" {% if config_cliente.review_model == 'double' %}selected{% endif %}>Double-blind</option>
+        </select>
+      </div>
+      <div class="config-item p-3">
+        <div class="row g-2 align-items-end">
+          <div class="col">
+            <label class="form-label mb-0">Mínimo Revisores</label>
+            <input type="number" min="1" class="form-control" id="inputRevisoresMin" value="{{ config_cliente.num_revisores_min }}" data-update-url="{{ url_for('config_cliente_routes.set_num_revisores_min') }}">
+          </div>
+          <div class="col">
+            <label class="form-label mb-0">Máximo Revisores</label>
+            <input type="number" min="1" class="form-control" id="inputRevisoresMax" value="{{ config_cliente.num_revisores_max }}" data-update-url="{{ url_for('config_cliente_routes.set_num_revisores_max') }}">
+          </div>
+          <div class="col">
+            <label class="form-label mb-0">Prazo (dias)</label>
+            <input type="number" min="1" class="form-control" id="inputPrazoParecer" value="{{ config_cliente.prazo_parecer_dias }}" data-update-url="{{ url_for('config_cliente_routes.set_prazo_parecer_dias') }}">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/dashboard_cliente.js') }}"></script>
+<script>
+  window.URL_CONFIG_CLIENTE_ATUAL = "{{ url_for('config_cliente_routes.configuracao_cliente_atual') }}";
+</script>
+{% endblock %}

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -159,7 +159,6 @@
           </div>
 
           <!-- Detalhes das oficinas com tabela e gráficos -->
-          <!-- Detalhes das oficinas com tabela e gráficos -->
 <div class="card shadow">
   <div class="card-header">
     <h5 class="m-0 fw-bold">Detalhes das Atividades</h5>
@@ -911,23 +910,7 @@
                   </button>
                 </div>
 
-                <!-- Submissão de Trabalhos -->
-                <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
-                  <div>
-                    <h6 class="mb-0 fw-semibold d-flex align-items-center">
-                      <i class="bi bi-upload text-primary me-2"></i>
-                      Submissão de Trabalhos
-                    </h6>
-                    <p class="text-muted small mb-0">Permite que participantes submetam trabalhos</p>
-                  </div>
-                  <button type="button"
-                          id="btnToggleSubmissao"
-                          class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'danger' }}"
-                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_submissao_trabalhos_cliente') }}">
-                    <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'x-circle-fill' }}"></i>
-                    {{ 'Ativo' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'Desativado' }}
-                  </button>
-                </div>
+
 
                 <!-- Mostrar Taxa de Serviço -->
                 <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
@@ -955,6 +938,7 @@
               <div class="d-flex align-items-center">
                 <i class="bi bi-journal-text me-2 fs-5"></i>
                 <h5 class="fw-bold mb-0">Submissões e Revisão</h5>
+                <a href="{{ url_for('config_cliente_routes.config_submissao') }}" class="ms-auto small text-decoration-none">Abrir página</a>
               </div>
             </div>
             <div class="card-body">
@@ -1448,6 +1432,10 @@
     const cdn = document.createElement('script');
     cdn.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js';
     document.head.appendChild(cdn);
+  }
+
+  if (typeof URL_CONFIG_CLIENTE_ATUAL === 'undefined') {
+    window.URL_CONFIG_CLIENTE_ATUAL = "{{ url_for('config_cliente_routes.configuracao_cliente_atual') }}";
   }
   
   // Declarar a variável somente se ainda não existir


### PR DESCRIPTION
## Summary
- add `/config_submissao` route for submission settings
- create `config_submissao.html` for submission/review configuration
- trim duplicate sections in the client dashboard and link to new page
- inject configuration URL for JavaScript usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557ff870f4832489727fffb289a554