### PR TITLE
Add file type config and xlsx export

### DIFF
--- a/models.py
+++ b/models.py
@@ -586,6 +586,8 @@ class ConfiguracaoCliente(db.Model):
 
     habilitar_submissao_trabalhos = db.Column(db.Boolean, default=False)
 
+    allowed_file_types = db.Column(db.String(100), default="pdf")
+
     # Exibe a taxa de serviço separadamente no preço da inscrição
     mostrar_taxa = db.Column(db.Boolean, default=True)
 

--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -234,7 +234,8 @@ def configuracao_cliente_atual():
         "num_revisores_min": config_cliente.num_revisores_min,
         "num_revisores_max": config_cliente.num_revisores_max,
         "prazo_parecer_dias": config_cliente.prazo_parecer_dias,
-        "habilitar_submissao_trabalhos": config_cliente.habilitar_submissao_trabalhos
+        "habilitar_submissao_trabalhos": config_cliente.habilitar_submissao_trabalhos,
+        "allowed_file_types": config_cliente.allowed_file_types
 
     })
 
@@ -360,6 +361,26 @@ def set_prazo_parecer_dias():
     db.session.commit()
 
     return jsonify({"success": True, "value": config_cliente.prazo_parecer_dias})
+
+
+@config_cliente_routes.route("/set_allowed_file_types", methods=["POST"])
+@login_required
+def set_allowed_file_types():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+
+    data = request.get_json() or {}
+    value = data.get("value", "pdf")
+
+    config_cliente = ConfiguracaoCliente.query.filter_by(cliente_id=current_user.id).first()
+    if not config_cliente:
+        config_cliente = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config_cliente)
+
+    config_cliente.allowed_file_types = value
+    db.session.commit()
+
+    return jsonify({"success": True, "value": config_cliente.allowed_file_types})
 
 @config_cliente_routes.route('/revisao_config/<int:evento_id>', methods=['POST'])
 @login_required

--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -34,6 +34,17 @@ def submeter_trabalho():
             flash("Todos os campos são obrigatórios!", "warning")
             return redirect(url_for("trabalho_routes.submeter_trabalho"))
 
+        allowed = "pdf"
+        if current_user.cliente and current_user.cliente.configuracao:
+            allowed = current_user.cliente.configuracao.allowed_file_types or "pdf"
+        ext_ok = False
+        if allowed:
+            exts = [e.strip().lower() for e in allowed.split(',')]
+            ext_ok = any(arquivo.filename.lower().endswith(f".{ext}") for ext in exts)
+        if not ext_ok:
+            flash("Tipo de arquivo não permitido.", "warning")
+            return redirect(url_for("trabalho_routes.submeter_trabalho"))
+
         # Salva o arquivo
         filename = secure_filename(arquivo.filename)
         uploads_dir = current_app.config.get("UPLOAD_FOLDER", "static/uploads/trabalhos")

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -114,6 +114,8 @@ document.addEventListener('DOMContentLoaded', function() {
         if (btnQrCredenciamento) atualizarBotao(btnQrCredenciamento, data.habilitar_qrcode_evento_credenciamento);
         if (btnMostrarTaxa) atualizarBotao(btnMostrarTaxa, data.mostrar_taxa);
         if (btnSubmissao) atualizarBotao(btnSubmissao, data.habilitar_submissao_trabalhos);
+        const inputAllowed = document.getElementById('inputAllowedFiles');
+        if (inputAllowed && data.allowed_file_types) inputAllowed.value = data.allowed_file_types;
       })
       .catch(err => {
         console.error("Erro ao buscar config do cliente:", err);
@@ -178,6 +180,10 @@ document.addEventListener('DOMContentLoaded', function() {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({ review_model: this.value })
+      })
+      .then(r => r.json())
+      .then(data => {
+        if (data.success) alert('Configuração atualizada!');
       });
     });
   }
@@ -213,6 +219,20 @@ document.addEventListener('DOMContentLoaded', function() {
   const inputPrazo = document.getElementById('inputPrazoParecer');
   if (inputPrazo) {
     inputPrazo.addEventListener('change', function() {
+      const url = this.dataset.updateUrl;
+      if (!url) return;
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ value: this.value })
+      });
+    });
+  }
+
+  const inputAllowed = document.getElementById('inputAllowedFiles');
+  if (inputAllowed) {
+    inputAllowed.addEventListener('change', function() {
       const url = this.dataset.updateUrl;
       if (!url) return;
       fetch(url, {

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -30,6 +30,12 @@
       </div>
       <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
         <div>
+          <h6 class="mb-0 fw-semibold">Tipos de Arquivo Permitidos</h6>
+        </div>
+        <input type="text" id="inputAllowedFiles" class="form-control w-auto" value="{{ config_cliente.allowed_file_types }}" data-update-url="{{ url_for('config_cliente_routes.set_allowed_file_types') }}">
+      </div>
+      <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+        <div>
           <h6 class="mb-0 fw-semibold">Modelo de Revisão</h6>
         </div>
         <select id="selectReviewModel" class="form-select w-auto" data-update-url="{{ url_for('config_cliente_routes.set_review_model') }}">

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -393,23 +393,6 @@
   </div>
 </div>
 
-<!-- Submissões e Revisão -->
-<div class="col-lg-6 col-xl-3">
-  <div class="card h-100 shadow-sm hover-shadow border-0">
-    <div class="card-body">
-      <div class="text-info mb-3">
-        <i class="bi bi-journal-text fs-1"></i>
-      </div>
-      <h5 class="card-title fw-bold">Submissões e Revisão</h5>
-      <p class="card-text text-muted">Acesse as configurações de submissões e revisão</p>
-    </div>
-    <div class="card-footer bg-white border-0 pt-0">
-      <a href="{{ url_for('config_cliente_routes.config_submissao') }}" class="btn btn-info w-100 text-white">
-        <i class="bi bi-journal-text me-2"></i> Abrir Página
-      </a>
-    </div>
-  </div>
-</div>
 
 <!-- Placas das Oficinas -->
 <div class="col-lg-6 col-xl-3">
@@ -956,7 +939,6 @@
               <div class="d-flex align-items-center">
                 <i class="bi bi-journal-text me-2 fs-5"></i>
                 <h5 class="fw-bold mb-0">Submissões e Revisão</h5>
-                <a href="{{ url_for('config_cliente_routes.config_submissao') }}" class="ms-auto small text-decoration-none">Abrir página</a>
               </div>
             </div>
             <div class="card-body">
@@ -975,6 +957,12 @@
                   <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'x-circle-fill' }}"></i>
                   {{ 'Ativo' if config_cliente and config_cliente.habilitar_submissao_trabalhos else 'Desativado' }}
                 </button>
+              </div>
+              <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+                <div>
+                  <h6 class="mb-0 fw-semibold">Tipos de Arquivo Permitidos</h6>
+                </div>
+                <input type="text" id="inputAllowedFiles" class="form-control w-auto" value="{{ config_cliente.allowed_file_types }}" data-update-url="{{ url_for('config_cliente_routes.set_allowed_file_types') }}">
               </div>
               <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
                 <div>

--- a/templates/trabalho/listar_respostas.html
+++ b/templates/trabalho/listar_respostas.html
@@ -48,6 +48,9 @@ body {
                         <a class="dropdown-item" href="{{ url_for('formularios_routes.exportar_csv', formulario_id=formulario.id) }}">
                             <i class="bi bi-file-excel"></i> CSV
                         </a>
+                        <a class="dropdown-item" href="{{ url_for('formularios_routes.exportar_xlsx', formulario_id=formulario.id) }}">
+                            <i class="bi bi-file-earmark-excel"></i> XLSX
+                        </a>
                     </div>
                 </div>
             </div>

--- a/templates/trabalho/submeter_trabalho.html
+++ b/templates/trabalho/submeter_trabalho.html
@@ -16,9 +16,12 @@
       <label for="area_tematica" class="form-label">Área Temática</label>
       <input type="text" class="form-control" name="area_tematica" required>
     </div>
+    {% set tipos = current_user.cliente.configuracao.allowed_file_types if current_user.cliente and current_user.cliente.configuracao else 'pdf' %}
+    {% set accept_str = '.' + tipos.replace(',', ',.').replace(' ', '') %}
     <div class="mb-3">
-      <label for="arquivo_pdf" class="form-label">Arquivo PDF</label>
-      <input type="file" class="form-control" name="arquivo_pdf" accept="application/pdf" required>
+      <label for="arquivo_pdf" class="form-label">Arquivo</label>
+      <input type="file" class="form-control" name="arquivo_pdf" accept="{{ accept_str }}" required>
+      <small class="text-muted">Tipos permitidos: {{ tipos }}</small>
     </div>
     <button type="submit" class="btn btn-success">
       <i class="bi bi-upload me-2"></i>Submeter Trabalho

--- a/tests/test_config_cliente_review.py
+++ b/tests/test_config_cliente_review.py
@@ -49,6 +49,7 @@ def test_update_review_settings(client, app):
         assert config.num_revisores_min == 2
         assert config.num_revisores_max == 3
         assert config.prazo_parecer_dias == 10
+        assert config.allowed_file_types == 'pdf'
 
 
 def test_dashboard_defaults(client, app):
@@ -59,3 +60,4 @@ def test_dashboard_defaults(client, app):
     assert b'id="inputRevisoresMin" value="1"' in resp.data
     assert b'id="inputRevisoresMax" value="2"' in resp.data
     assert b'id="inputPrazoParecer" value="14"' in resp.data
+    assert b'id="inputAllowedFiles"' in resp.data


### PR DESCRIPTION
## Summary
- add `allowed_file_types` column to `ConfiguracaoCliente`
- update submission config routes and dashboard to edit allowed file types
- enforce allowed types on work submission
- support XLSX export of form responses
- show success message when review model changes
- remove card link for submission from dashboard shortcuts

## Testing
- `pytest tests/test_config_cliente_review.py::test_update_review_settings -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6855967c86a8832483def6f4565aef1a