### PR TITLE
Add taxa_diferenciada migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ export RECAPTCHA_PUBLIC_KEY="<sua_chave_publica_recaptcha>"
 export RECAPTCHA_PRIVATE_KEY="<sua_chave_privada_recaptcha>"
 ```
 
+## Banco de Dados
+
+Depois de clonar o repositório ou atualizar o código, aplique as migrações executando:
+
+```bash
+flask db upgrade
+```
+
 `SECRET_KEY` garante que as sessões geradas por uma instância do Flask possam
 ser lidas por outra. Em produção, utilize um valor seguro e idêntico em todas as
 réplicas do aplicativo.

--- a/migrations/versions/edec4bcb5f46_add_taxa_diferenciada_to_configuracao_cliente.py
+++ b/migrations/versions/edec4bcb5f46_add_taxa_diferenciada_to_configuracao_cliente.py
@@ -1,0 +1,25 @@
+"""add taxa_diferenciada column to ConfiguracaoCliente
+
+Revision ID: edec4bcb5f46
+Revises: 5883528bda20
+Create Date: 2025-08-30 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'edec4bcb5f46'
+down_revision = '5883528bda20'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('configuracao_cliente') as batch_op:
+        batch_op.add_column(sa.Column('taxa_diferenciada', sa.Numeric(5, 2), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('configuracao_cliente') as batch_op:
+        batch_op.drop_column('taxa_diferenciada')


### PR DESCRIPTION
## Summary
- add Alembic migration for taxa_diferenciada on configuracao_cliente
- note running `flask db upgrade` in README

## Testing
- `pytest -k '' -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68560836c1748324a6318effa53bd8f0