### PR TITLE
Centralize logging config

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,13 @@ from extensions import db, login_manager, migrate, mail, socketio
 from models import Inscricao
 from utils import brasilia_filter
 import pytz
+import logging
+
+# Configuração centralizada de logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 from services.mp_service import get_sdk
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -30,8 +30,7 @@ from reportlab.lib.pagesizes import letter, landscape
 from reportlab.lib import colors
 from reportlab.lib.utils import ImageReader
 
-# Configuração de logging
-logging.basicConfig(level=logging.DEBUG)
+# Logger do módulo
 logger = logging.getLogger(__name__)
 
 # Escopo necessário para envio de e-mails


### PR DESCRIPTION
## Summary
- centralize logging configuration in `app.py`
- remove inline logging setup from utils

## Testing
- `pytest -q` *(fails: psycopg2 OperationalError, missing `dotenv` module)*


------
https://chatgpt.com/codex/tasks/task_e_6856083792bc8324a3e501bf19351c34