### PR TITLE
Make template path tool configurable

### DIFF
--- a/update_template_paths.py
+++ b/update_template_paths.py
@@ -7,6 +7,8 @@ inserindo o sub-diretório adequado segundo o dicionário `mapping`.
 
 import os
 import re
+import argparse
+from pathlib import Path
 
 # ────────────────────────────────
 # 1) Mapeamento: arquivo → sub-pasta
@@ -112,9 +114,18 @@ mapping: dict[str, str] = {
 pattern = re.compile(r'render_template\(\s*([\'"])([^/\'"]+\.html)\1')
 
 # ────────────────────────────────
-# 3) Pasta base do projeto (ajuste se preciso)
+# 3) Pasta base do projeto
+#    (pode ser passado via --base-path, padrão é o diretório atual)
 # ────────────────────────────────
-base_path = '/mnt/c/Users/Felipe\\ Cabral/Music/system_iafap_two'
+parser = argparse.ArgumentParser(description="Atualiza caminhos de templates")
+parser.add_argument(
+    "--base-path",
+    type=Path,
+    default=Path.cwd(),
+    help="Diretório base para percorrer"
+)
+args = parser.parse_args()
+base_path: Path = args.base_path
 
 # ────────────────────────────────
 # 4) Função de atualização


### PR DESCRIPTION
## Summary
- make `update_template_paths.py` accept `--base-path` instead of a hard-coded path
- ensure the script ends with a newline

## Testing
- `python3 -m py_compile update_template_paths.py`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685608387af88324adacfaa07574fc65