### PR TITLE
Fix SQLite engine options

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,10 @@ from services.mp_service import get_sdk
 def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
+    # Recalcula as opções de conexão caso o URI tenha sido alterado nos testes
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options(
+        app.config['SQLALCHEMY_DATABASE_URI']
+    )
     app.jinja_env.add_extension('jinja2.ext.do')
     app.config["UPLOAD_FOLDER"] = "uploads"
 

--- a/config.py
+++ b/config.py
@@ -27,20 +27,25 @@ class Config:
         except Exception:
             return False
 
+    @staticmethod
+    def build_engine_options(uri):
+        if uri.startswith('sqlite'):
+            return {}
+
+        return {
+            'pool_size': 10,
+            'max_overflow': 20,
+            'pool_timeout': 30,
+            'pool_recycle': 1800,
+            'pool_pre_ping': True,
+            'connect_args': {'connect_timeout': 10},
+        }
+
     # Define qual banco de dados será usado
     SQLALCHEMY_DATABASE_URI = DB_ONLINE if test_db_connection(DB_ONLINE) else DB_LOCAL
 
     # Configurações de pool de conexões
-    SQLALCHEMY_ENGINE_OPTIONS = {
-        'pool_size': 10,  # Número máximo de conexões permanentes
-        'max_overflow': 20,  # Número máximo de conexões temporárias
-        'pool_timeout': 30,  # Tempo máximo de espera por uma conexão
-        'pool_recycle': 1800,  # Recicla conexões após 30 minutos
-        'pool_pre_ping': True,  # Verifica se a conexão está ativa antes de usar
-        'connect_args': {
-            'connect_timeout': 10  # Aumenta o timeout de conexão
-        }
-    }
+    SQLALCHEMY_ENGINE_OPTIONS = build_engine_options(SQLALCHEMY_DATABASE_URI)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/tests/test_binary_routes.py
+++ b/tests/test_binary_routes.py
@@ -2,7 +2,9 @@ import io
 import pytest
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 from app import create_app
 from extensions import db

--- a/tests/test_campo_routes.py
+++ b/tests/test_campo_routes.py
@@ -1,7 +1,9 @@
 import pytest
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 from werkzeug.security import generate_password_hash
 
 from app import create_app

--- a/tests/test_config_cliente_review.py
+++ b/tests/test_config_cliente_review.py
@@ -2,7 +2,9 @@ import pytest
 from werkzeug.security import generate_password_hash
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 from app import create_app
 from extensions import db

--- a/tests/test_dashboard_admin.py
+++ b/tests/test_dashboard_admin.py
@@ -1,7 +1,9 @@
 import pytest
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 from app import create_app
 from extensions import db

--- a/tests/test_inscricao_routes.py
+++ b/tests/test_inscricao_routes.py
@@ -1,7 +1,9 @@
 import pytest
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 from app import create_app
 from extensions import db

--- a/tests/test_register_public_cliente.py
+++ b/tests/test_register_public_cliente.py
@@ -1,7 +1,9 @@
 import pytest
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 from app import create_app
 from extensions import db

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -2,7 +2,9 @@ from flask import session
 from config import Config
 
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-Config.SQLALCHEMY_ENGINE_OPTIONS = {}
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 from app import create_app
 

--- a/tests/test_sqlite_config.py
+++ b/tests/test_sqlite_config.py
@@ -1,0 +1,11 @@
+from config import Config
+from app import create_app
+
+
+def test_create_app_sqlite_no_connect_args():
+    Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+        Config.SQLALCHEMY_DATABASE_URI
+    )
+    app = create_app()
+    assert 'connect_args' not in app.config['SQLALCHEMY_ENGINE_OPTIONS']


### PR DESCRIPTION
## Summary
- skip connection timeout for SQLite connections
- compute engine options dynamically in `create_app`
- test SQLite configuration
- adjust existing tests to rebuild engine options when overriding `SQLALCHEMY_DATABASE_URI`

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68560cc9ef608324a341fe56989d393d