### PR TITLE
Fix populate script registration rules

### DIFF
--- a/populate_script.py
+++ b/populate_script.py
@@ -308,6 +308,7 @@ def criar_tipos_inscricao_evento(evento):
             preco=0.0
         )
         db.session.add(tipo)
+        db.session.flush()
         tipos.append(tipo)
     else:
         # Vários tipos de inscrição com preços diferentes
@@ -327,8 +328,9 @@ def criar_tipos_inscricao_evento(evento):
                 preco=preco
             )
             db.session.add(tipo)
+            db.session.flush()
             tipos.append(tipo)
-            
+
             # Criar regras de inscrição para alguns tipos
             if random.choice([True, False]):
                 regra = RegraInscricaoEvento(
@@ -337,8 +339,7 @@ def criar_tipos_inscricao_evento(evento):
                     limite_oficinas=random.choice([0, 2, 3, 5])
                 )
                 db.session.add(regra)
-    
-    db.session.flush()
+
     return tipos
 
 def criar_lotes_evento(evento):


### PR DESCRIPTION
## Summary
- ensure `EventoInscricaoTipo` records are flushed before creating rules
- remove unnecessary final flush in `criar_tipos_inscricao_evento`

## Testing
- `python - <<'EOF'
from app import app
from extensions import db
from models import Evento
from populate_script import criar_tipos_inscricao_evento

with app.app_context():
    db.drop_all()
    db.create_all()
    evento = Evento(cliente_id=1, nome='Test Event', descricao='desc')
    db.session.add(evento)
    db.session.commit()
    tipos = criar_tipos_inscricao_evento(evento)
    db.session.commit()
    print('Tipos:', [(t.id, t.nome) for t in tipos])
    print('Regras count:', len(evento.regras_inscricao))
EOF

------
https://chatgpt.com/codex/tasks/task_e_6856f8a591548324b86d1b4f99a8ea63