### PR TITLE
Fix logical operator in populate_script

### DIFF
--- a/populate_script.py
+++ b/populate_script.py
@@ -729,7 +729,7 @@ def criar_checkins(inscricoes, oficinas, eventos):
             if inscricao.oficina_id:
                 # Checkin em oficina
                 oficina = next((o for o in oficinas if o.id == inscricao.oficina_id), None)
-                if oficina && oficina.dias:
+                if oficina and oficina.dias:
                     # Pega um dia aleatório da oficina
                     dia = random.choice(oficina.dias)
                     


### PR DESCRIPTION
## Summary
- fix Python logical operator in the `criar_checkins` helper

## Testing
- `python -m py_compile populate_script.py`


------
https://chatgpt.com/codex/tasks/task_e_685803ea684c8324bad05a9bbeb2ba77