### PR TITLE
Add admin impersonation routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ No dashboard do cliente é possível exportar a lista de inscritos de um evento 
 
 Para sinalizar as atividades de um evento, utilize a rota `/gerar_placas/<evento_id>` ou o botão **Baixar Placas** no dashboard do cliente. Um PDF é gerado com uma página por oficina, contendo título e ministrante.
 
+### Impersonação de clientes
+
+Administradores podem acessar o painel de qualquer cliente clicando em **Acessar** na seção de Gestão de Clientes do dashboard. A navegação mostrará um link "Sair do modo cliente" para retornar à conta de administrador.
+
 ## Database maintenance
 
 `add_taxa_coluna.py` adiciona a coluna `taxa_diferenciada` na tabela `configuracao_cliente` caso ela ainda nao exista.

--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -151,6 +151,9 @@
                             </td>
                             <td>
                               <div class="d-flex gap-2">
+                                <a href="{{ url_for('dashboard_routes.login_as_cliente', cliente_id=cliente.id) }}" class="btn btn-sm btn-outline-primary" title="Acessar como cliente">
+                                  <i class="bi bi-box-arrow-in-right"></i>
+                                </a>
                                 <!-- Botão de Editar -->
                                 <button class="btn btn-sm btn-outline-warning"
                                         data-bs-toggle="modal"

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -68,7 +68,15 @@
                     </a>
                 </li>
                 {% endif %}
-                
+
+                {% if session.get('impersonator_id') %}
+                <li class="nav-item">
+                    <a class="nav-link text-warning" href="{{ url_for('dashboard_routes.encerrar_impersonacao') }}">
+                        <i class="bi bi-x-circle"></i> Sair do modo cliente
+                    </a>
+                </li>
+                {% endif %}
+
                 <li class="nav-item">
                     <a class="nav-link text-danger" href="{{ url_for('auth_routes.logout') }}">
                         <i class="bi bi-box-arrow-right"></i> Sair

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -1,0 +1,48 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Usuario, Cliente
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
+        db.session.add(admin)
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456'))
+        db.session.add(cliente)
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_impersonation_flow(client, app):
+    with app.app_context():
+        cid = Cliente.query.first().id
+    login(client, 'admin@test', '123')
+    resp = client.get(f'/login_as_cliente/{cid}', follow_redirects=True)
+    assert resp.status_code in (200, 302)
+    with client.session_transaction() as sess:
+        assert sess.get('user_type') == 'cliente'
+        assert sess.get('impersonator_id') is not None
+    resp = client.get('/encerrar_impersonacao', follow_redirects=True)
+    assert resp.status_code in (200, 302)
+    with client.session_transaction() as sess:
+        assert sess.get('user_type') == 'admin'
+        assert sess.get('impersonator_id') is None


### PR DESCRIPTION
## Summary
- add impersonation routes to dashboard_routes
- link admin dashboard to login as a client
- show end impersonation in navbar
- test admin impersonation flow
- document impersonation feature

## Testing
- `pytest tests/test_impersonation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68593c488a988324a2a91903fdcb628b