### PR TITLE
Fix BuildError for feedback PDF

### DIFF
--- a/routes/pdf_routes.py
+++ b/routes/pdf_routes.py
@@ -4,7 +4,7 @@ import os
 from services.pdf_service import (
     gerar_etiquetas,
     gerar_pdf_checkins_qr as gerar_pdf_checkins_qr_service,
-    gerar_pdf_feedback_route,
+    gerar_pdf_feedback_route as gerar_pdf_feedback_service,
     gerar_pdf_inscritos_pdf,
     gerar_lista_frequencia,
     gerar_certificados,
@@ -56,6 +56,13 @@ def gerar_lista_frequencia_route(oficina_id):
 @login_required
 def gerar_certificados_route(oficina_id):
     return gerar_certificados(oficina_id)
+
+
+@routes.route('/gerar_pdf_feedback/<int:oficina_id>')
+@login_required
+def gerar_pdf_feedback_route(oficina_id):
+    """Gera um PDF com os feedbacks da oficina."""
+    return gerar_pdf_feedback_service(oficina_id)
 
 
 @routes.route('/gerar_certificado_individual_admin', methods=['POST'])


### PR DESCRIPTION
## Summary
- alias service helper for feedback PDF in `routes/pdf_routes`
- expose `/gerar_pdf_feedback/<oficina_id>` route

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6859426ae634832492691344a7dc9970