### PR TITLE
Fix cascading delete of event inscriptions

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -254,6 +254,10 @@ def excluir_cliente(cliente_id):
                 Patrocinador.query.filter_by(evento_id=evento.id).delete()
                 SalaVisitacao.query.filter_by(evento_id=evento.id).delete()  # ✅ NOVO
 
+                # Remover inscrições e check-ins vinculados ao evento
+                Checkin.query.filter_by(evento_id=evento.id).delete()
+                Inscricao.query.filter_by(evento_id=evento.id).delete()
+
                 # Remover dependências de inscrição do evento
                 LoteTipoInscricao.query.filter(
                     LoteTipoInscricao.lote_id.in_(


### PR DESCRIPTION
## Summary
- ensure event-level inscriptions and check-ins are removed when deleting a client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68594cbf915c8324a01eb15d07bd84d1