### PR TITLE
Atualizar lógica de status de eventos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv/
 SELECT
 .vscode/claudesync.json
 token.json
+instance/
 
 # Generated artifacts
 0e765b9c8390,

--- a/populate_script.py
+++ b/populate_script.py
@@ -206,8 +206,6 @@ def criar_eventos(clientes, quantidade_por_cliente=5):
             hoje = datetime.now().date()
             if data_fim < hoje:
                 status = 'encerrado'
-            elif data_inicio > hoje:
-                status = 'agendado'
             else:
                 status = 'ativo'
             
@@ -748,7 +746,7 @@ def criar_checkins(inscricoes, oficinas, eventos):
             if inscricao.oficina_id:
                 # Checkin em oficina
                 oficina = next((o for o in oficinas if o.id == inscricao.oficina_id), None)
-                if oficina  oficina.dias:
+                if oficina and oficina.dias:
                     # Pega um dia aleatório da oficina
                     dia = random.choice(oficina.dias)
                     


### PR DESCRIPTION
## Summary
- ajustar a regra de definição de status no `populate_script.py`
- ignorar diretório `instance/`

## Testing
- `python -m py_compile populate_script.py`
- `python - <<'PY'
from app import create_app, db
from populate_script import popular_banco
app = create_app()
with app.app_context():
    popular_banco()
PY
` *(falhou: `NameError: name 'criar_agendamentos_visita' is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68596bda75e48324993ceff73c55de1f