### PR TITLE
Handle bytes DATABASE_URL

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,8 +4,18 @@ from sqlalchemy.pool import QueuePool
 # ------------------------------------------------------------------ #
 #  Helpers                                                           #
 # ------------------------------------------------------------------ #
-def normalize_pg(uri: str) -> str:
-    """Garante o prefixo aceito pelo SQLAlchemy/psycopg2."""
+def normalize_pg(uri: str | bytes) -> str:
+    """Garante o prefixo aceito pelo SQLAlchemy/psycopg2.
+
+    Aceita `str` ou `bytes` e sempre retorna `str`. Quando `uri` é
+    fornecido como bytes, ele é decodificado usando UTF-8 e, em caso de
+    falha, Latin-1 é utilizado como "fallback".
+    """
+    if isinstance(uri, bytes):
+        try:
+            uri = uri.decode("utf-8")
+        except UnicodeDecodeError:
+            uri = uri.decode("latin-1")
     return uri.replace("postgresql://", "postgresql+psycopg2://", 1)
 
 

--- a/tests/test_config_bytes_database_url.py
+++ b/tests/test_config_bytes_database_url.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+
+from config import Config, normalize_pg
+from app import create_app
+
+
+def test_create_app_with_bytes_database_url(monkeypatch):
+    uri = b'sqlite:///:memory:'
+    monkeypatch.setitem(os.environb, b'DATABASE_URL', uri)
+
+    Config.SQLALCHEMY_DATABASE_URI = normalize_pg(uri)
+    Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+        Config.SQLALCHEMY_DATABASE_URI
+    )
+
+    try:
+        create_app()
+    except UnicodeDecodeError:
+        pytest.fail('create_app raised UnicodeDecodeError')


### PR DESCRIPTION
## Summary
- let `normalize_pg` accept bytes and decode using UTF-8 fallback to Latin-1
- add test ensuring `create_app` works when `DATABASE_URL` is given as bytes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a3c666d88324833debe0f8b167a9