### PR TITLE
Add static normalize_pg method to Config

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,6 +49,10 @@ class Config:
     )
 
     @staticmethod
+    def normalize_pg(uri: str | bytes) -> str:
+        return normalize_pg(uri)
+
+    @staticmethod
     def build_engine_options(uri: str) -> dict:
         """Return engine options for the given database URI."""
         options = dict(


### PR DESCRIPTION
## Summary
- expose module-level `normalize_pg` as a `Config` static method for backward compatibility

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aa8898d8832498c6a39efc56dc24