### PR TITLE
Expose flask app instance for gunicorn

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,7 +99,9 @@ def reconciliar_pendentes():
             db.session.commit()
 
 
+# Instância para servidores WSGI como o gunicorn
+app = create_app()
+
 # Execução da aplicação
 if __name__ == '__main__':
-    app = create_app()
     socketio.run(app, debug=True)


### PR DESCRIPTION
## Summary
- expose a module-level `app` instance so `gunicorn app:app` works
- simplify the `__main__` startup code

## Testing
- `pytest -q`
- `gunicorn app:app --preload --bind 127.0.0.1:5000 --timeout 2`

------
https://chatgpt.com/codex/tasks/task_e_6859ae95822c8324abd2c572b7798d39