### PR TITLE
Add render.yaml and deploy hook instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,8 @@ gunicorn app:app --bind 0.0.0.0:$PORT
 Ensure all configuration variables described earlier are set before starting the
 server.
 
+
+### Render deploy hook
+
+To trigger redeploys automatically when new commits are pushed, open your web service settings on Render. Under **Deploy Hooks**, click **Enable deploy hook** to generate the URL. Call this endpoint from your CI workflow or repository settings whenever you want Render to rebuild the service.
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,20 @@
+services:
+  - type: web
+    name: system-web
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn app:app  # from Procfile
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: system-db
+          property: connectionString
+      - key: SECRET_KEY
+        value: "REPLACE_ME"
+
+# Provision a PostgreSQL database if needed
+# Comment out the database block if you already have one
+# in your Render account and just reference its name above.
+databases:
+  - name: system-db
+    plan: free


### PR DESCRIPTION
## Summary
- add `render.yaml` to configure a Render web service and database
- document enabling Render deploy hooks in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac1b832708324956bffe8f4e47cf1