### PR TITLE
Track review duration and manage codes

### DIFF
--- a/migrations/versions/abcd1234_add_review_timing.py
+++ b/migrations/versions/abcd1234_add_review_timing.py
@@ -1,0 +1,29 @@
+"""add review timing fields"""
+
+Revision ID: abcd1234
+Revises: edec4bcb5f46
+Create Date: 2025-06-30 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'abcd1234'
+down_revision = 'edec4bcb5f46'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('review') as batch_op:
+        batch_op.add_column(sa.Column('started_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('finished_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('duration_seconds', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('review') as batch_op:
+        batch_op.drop_column('duration_seconds')
+        batch_op.drop_column('finished_at')
+        batch_op.drop_column('started_at')

--- a/models.py
+++ b/models.py
@@ -1214,6 +1214,9 @@ class Review(db.Model):
     comments = db.Column(db.Text, nullable=True)
     file_path = db.Column(db.String(255), nullable=True)  # PDF anotado etc.
     decision = db.Column(db.String(50), nullable=True)    # accept | minor | major | reject
+    started_at = db.Column(db.DateTime, nullable=True)
+    finished_at = db.Column(db.DateTime, nullable=True)
+    duration_seconds = db.Column(db.Integer, nullable=True)
     submitted_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     # relationships
@@ -1222,6 +1225,12 @@ class Review(db.Model):
 
     def __repr__(self):
         return f"<Review {self.id} submission={self.submission_id}>"
+
+    @property
+    def duration(self):
+        if self.started_at and self.finished_at:
+            return int((self.finished_at - self.started_at).total_seconds())
+        return None
 
 
 # -----------------------------------------------------------------------------

--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -64,3 +64,22 @@ def add_review(locator):
     db.session.add(review)
     db.session.commit()
     return jsonify({'message': 'Review submitted'})
+
+
+@submission_routes.route('/submissions/<locator>/codes')
+def list_review_codes(locator):
+    submission = Submission.query.filter_by(locator=locator).first_or_404()
+    reviews = Review.query.filter_by(submission_id=submission.id).all()
+    return jsonify({
+        'locator': locator,
+        'reviews': [
+            {
+                'locator': r.locator,
+                'access_code': r.access_code,
+                'started_at': r.started_at.isoformat() if r.started_at else None,
+                'finished_at': r.finished_at.isoformat() if r.finished_at else None,
+                'duration_seconds': r.duration_seconds
+            }
+            for r in reviews
+        ]
+    })

--- a/templates/peer_review/dashboard_reviewer.html
+++ b/templates/peer_review/dashboard_reviewer.html
@@ -6,13 +6,13 @@
   <table class="table table-striped">
     <thead><tr><th>Título</th><th>Status</th><th>Acessar</th></tr></thead>
     <tbody>
-    {% for r in reviews %}
+      {% for r in reviews %}
       <tr>
-        <td>{{ r.trabalho.titulo }}</td>
-        <td>{{ 'Concluída' if r.nota else 'Pendente' }}</td>
+        <td>{{ r.submission.title }}</td>
+        <td>{{ 'Concluída' if r.note else 'Pendente' }}</td>
         <td><a href="{{ url_for('peer_review_routes.review_form', locator=r.locator) }}">Revisar</a></td>
       </tr>
-    {% endfor %}
+      {% endfor %}
     </tbody>
   </table>
 </div>

--- a/templates/peer_review/review_form.html
+++ b/templates/peer_review/review_form.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container mt-5">
   <h3>Revisar Trabalho</h3>
-  <p><strong>{{ review.trabalho.titulo }}</strong></p>
+  <p><strong>{{ review.submission.title }}</strong></p>
   <form method="POST">
     <div class="mb-3">
       <label>Código de Acesso</label>

--- a/tests/test_review_tracking.py
+++ b/tests/test_review_tracking.py
@@ -1,0 +1,51 @@
+import bcrypt
+import pytest
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Submission, Review
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        raw_code = 'secret'
+        sub = Submission(title='T', locator='loc1', code_hash=bcrypt.hashpw(raw_code.encode(), bcrypt.gensalt()).decode())
+        db.session.add(sub)
+        db.session.commit()
+        rev = Review(submission_id=sub.id, locator='revloc', access_code='revcode')
+        db.session.add(rev)
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_review_timing(client, app):
+    # access GET sets start
+    resp = client.get('/review/revloc')
+    assert resp.status_code == 200
+    with app.app_context():
+        rev = Review.query.filter_by(locator='revloc').first()
+        assert rev.started_at is not None
+    # submit POST
+    resp = client.post('/review/revloc', data={'codigo': 'revcode', 'nota': '5'})
+    assert resp.status_code in (200, 302)
+    with app.app_context():
+        rev = Review.query.filter_by(locator='revloc').first()
+        assert rev.finished_at is not None
+        assert rev.duration_seconds is not None
+
+    # list codes
+    resp = client.get('/submissions/loc1/codes')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['locator'] == 'loc1'
+    assert data['reviews'][0]['access_code'] == 'revcode'


### PR DESCRIPTION
## Summary
- support timing fields on reviews
- track review duration when reviewers submit
- list review codes for a submission
- clean up peer review blueprint
- add regression tests for review timing

## Testing
- `pytest tests/test_review_tracking.py::test_review_timing -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abfc329c0832486aaa2cbf2337c2e