### PR TITLE
Add user impersonation listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Para sinalizar as atividades de um evento, utilize a rota `/gerar_placas/<evento
 
 Administradores podem acessar o painel de qualquer cliente clicando em **Acessar** na seção de Gestão de Clientes do dashboard. A navegação mostrará um link "Sair do modo cliente" para retornar à conta de administrador.
 
+### Impersonação de usuários
+
+É possível entrar como qualquer usuário vinculado a um cliente. Utilize o botão **Listar usuários** na tabela de clientes e, em seguida, clique em **Acessar** ao lado do participante desejado. Enquanto estiver nesse modo, a barra superior exibirá "Sair do modo usuário" para retornar ao perfil de administrador.
+
 ## Database maintenance
 
 `add_taxa_coluna.py` adiciona a coluna `taxa_diferenciada` na tabela `configuracao_cliente` caso ela ainda nao exista.

--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -321,3 +321,21 @@ def excluir_cliente(cliente_id):
         flash(f"Erro ao excluir cliente: {str(e)}", "danger")
 
     return redirect(url_for("dashboard_routes.dashboard"))
+
+
+@cliente_routes.route("/listar_usuarios/<int:cliente_id>")
+@login_required
+def listar_usuarios(cliente_id: int):
+    """Exibe os usuários vinculados a um cliente específico."""
+    if current_user.tipo != "admin":
+        flash("Acesso negado!", "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
+
+    from models import Usuario, Cliente
+
+    cliente = Cliente.query.get_or_404(cliente_id)
+    usuarios = Usuario.query.filter_by(cliente_id=cliente.id).all()
+
+    return render_template(
+        "cliente/listar_usuarios.html", cliente=cliente, usuarios=usuarios
+    )

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -192,6 +192,27 @@ def login_as_cliente(cliente_id: int):
     return redirect(url_for('dashboard_routes.dashboard_cliente'))
 
 
+@dashboard_routes.route('/login_as_usuario/<int:usuario_id>')
+@login_required
+def login_as_usuario(usuario_id: int):
+    """Permite que um admin assuma a sessão de um usuário comum."""
+    if current_user.tipo not in {'admin', 'superadmin'}:
+        abort(403)
+
+    from models import Usuario
+
+    admin_id = current_user.get_id()
+    session['impersonator_id'] = admin_id
+    session['impersonator_type'] = current_user.tipo
+
+    usuario = Usuario.query.get_or_404(usuario_id)
+
+    login_user(usuario)
+    session['user_type'] = usuario.tipo
+
+    return redirect(url_for('dashboard_routes.dashboard'))
+
+
 @dashboard_routes.route('/encerrar_impersonacao')
 @login_required
 def encerrar_impersonacao():

--- a/templates/cliente/listar_usuarios.html
+++ b/templates/cliente/listar_usuarios.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}Usuários do Cliente{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <h2>Usuários de {{ cliente.nome }}</h2>
+  {% if usuarios %}
+  <table class="table table-striped">
+    <thead>
+      <tr><th>ID</th><th>Nome</th><th>Email</th><th>Ações</th></tr>
+    </thead>
+    <tbody>
+    {% for u in usuarios %}
+      <tr>
+        <td>{{ u.id }}</td>
+        <td>{{ u.nome }}</td>
+        <td>{{ u.email }}</td>
+        <td>
+          <a href="{{ url_for('dashboard_routes.login_as_usuario', usuario_id=u.id) }}" class="btn btn-sm btn-outline-primary" title="Acessar como usuário">
+            <i class="bi bi-box-arrow-in-right"></i>
+          </a>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Nenhum usuário encontrado.</p>
+  {% endif %}
+  <a href="{{ url_for('dashboard_routes.dashboard_admin') }}" class="btn btn-secondary mt-3">Voltar</a>
+</div>
+{% endblock %}

--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -155,6 +155,9 @@
                                 <a href="{{ url_for('dashboard_routes.login_as_cliente', cliente_id=cliente.id) }}" class="btn btn-sm btn-outline-primary" title="Acessar como cliente">
                                   <i class="bi bi-box-arrow-in-right"></i>
                                 </a>
+                                <a href="{{ url_for('cliente_routes.listar_usuarios', cliente_id=cliente.id) }}" class="btn btn-sm btn-outline-secondary" title="Listar usuários">
+                                  <i class="bi bi-people"></i>
+                                </a>
                                 <!-- Botão de Editar -->
                                 <button class="btn btn-sm btn-outline-warning"
                                         data-bs-toggle="modal"

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -72,7 +72,12 @@
                 {% if session.get('impersonator_id') %}
                 <li class="nav-item">
                     <a class="nav-link text-warning" href="{{ url_for('dashboard_routes.encerrar_impersonacao') }}">
-                        <i class="bi bi-x-circle"></i> Sair do modo cliente
+                        <i class="bi bi-x-circle"></i>
+                        {% if session.get('user_type') == 'cliente' %}
+                        Sair do modo cliente
+                        {% else %}
+                        Sair do modo usuário
+                        {% endif %}
                     </a>
                 </li>
                 {% endif %}


### PR DESCRIPTION
## Summary
- allow admins to list client users via `cliente_routes.listar_usuarios`
- add link on admin dashboard for listing
- implement `/login_as_usuario/<id>` impersonation route
- show end-impersonation link for users in the navbar
- document how to impersonate users

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685acb2bc2b88324a54f313302e071fd