### PR TITLE
Add user blocking functionality

### DIFF
--- a/models.py
+++ b/models.py
@@ -46,6 +46,7 @@ class Usuario(db.Model, UserMixin):
     # MFA
     mfa_enabled = db.Column(db.Boolean, default=False)
     mfa_secret = db.Column(db.String(32), nullable=True)
+    ativo = db.Column(db.Boolean, default=True)
 
     def verificar_senha(self, senha):
         return check_password_hash(self.senha, senha)
@@ -58,6 +59,9 @@ class Usuario(db.Model, UserMixin):
 
     def is_cliente(self):
         return self.tipo == "cliente"
+
+    def is_active(self):
+        return self.ativo
     
     def is_professor(self):
          return self.tipo == 'professor'

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -56,6 +56,11 @@ def login():
             flash('Sua conta está desativada. Contate o administrador.', 'danger')
             return render_template("login.html")
 
+        if isinstance(usuario, Usuario) and not getattr(usuario, 'ativo', True):
+            logout_user()
+            flash('Sua conta está bloqueada. Contate a administração do evento.', 'danger')
+            return render_template("login.html")
+
         if not check_password_hash(usuario.senha, senha):
             flash('E-mail ou senha incorretos!', 'danger')
             return render_template("login.html")

--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -339,3 +339,24 @@ def listar_usuarios(cliente_id: int):
     return render_template(
         "cliente/listar_usuarios.html", cliente=cliente, usuarios=usuarios
     )
+
+
+@cliente_routes.route('/toggle_usuario/<int:usuario_id>')
+@login_required
+def toggle_usuario(usuario_id: int):
+    """Ativa ou bloqueia o acesso de um usuário."""
+    if current_user.tipo != 'admin':
+        flash('Acesso negado!', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    from models import Usuario
+
+    usuario = Usuario.query.get_or_404(usuario_id)
+    usuario.ativo = not usuario.ativo
+    db.session.commit()
+
+    flash(
+        f"Usuário {'bloqueado' if not usuario.ativo else 'ativado'} com sucesso!",
+        'success'
+    )
+    return redirect(url_for('cliente_routes.listar_usuarios', cliente_id=usuario.cliente_id))

--- a/templates/cliente/listar_usuarios.html
+++ b/templates/cliente/listar_usuarios.html
@@ -6,7 +6,7 @@
   {% if usuarios %}
   <table class="table table-striped">
     <thead>
-      <tr><th>ID</th><th>Nome</th><th>Email</th><th>Ações</th></tr>
+      <tr><th>ID</th><th>Nome</th><th>Email</th><th>Status</th><th>Ações</th></tr>
     </thead>
     <tbody>
     {% for u in usuarios %}
@@ -15,8 +15,18 @@
         <td>{{ u.nome }}</td>
         <td>{{ u.email }}</td>
         <td>
+          <span class="badge bg-{{ 'success' if u.ativo else 'secondary' }}">
+            {{ 'Ativo' if u.ativo else 'Bloqueado' }}
+          </span>
+        </td>
+        <td>
           <a href="{{ url_for('dashboard_routes.login_as_usuario', usuario_id=u.id) }}" class="btn btn-sm btn-outline-primary" title="Acessar como usuário">
             <i class="bi bi-box-arrow-in-right"></i>
+          </a>
+          <a href="{{ url_for('cliente_routes.toggle_usuario', usuario_id=u.id) }}"
+             class="btn btn-sm btn-outline-{{ 'danger' if u.ativo else 'success' }}"
+             title="{{ 'Bloquear' if u.ativo else 'Ativar' }}">
+            <i class="bi bi-slash-circle"></i>
           </a>
         </td>
       </tr>

--- a/tests/test_usuario_bloqueio.py
+++ b/tests/test_usuario_bloqueio.py
@@ -1,0 +1,55 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Usuario
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+
+    with app.app_context():
+        db.create_all()
+        admin = Usuario(
+            nome='Admin', cpf='1', email='admin@test',
+            senha=generate_password_hash('123'), formacao='X', tipo='admin'
+        )
+        user = Usuario(
+            nome='User', cpf='2', email='user@test',
+            senha=generate_password_hash('123'), formacao='Y'
+        )
+        db.session.add_all([admin, user])
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_toggle_usuario_block_login(client, app):
+    with app.app_context():
+        user_id = Usuario.query.filter_by(email='user@test').first().id
+
+    login(client, 'admin@test', '123')
+    client.get(f'/toggle_usuario/{user_id}', follow_redirects=True)
+
+    with app.app_context():
+        assert Usuario.query.get(user_id).ativo is False
+
+    resp = login(client, 'user@test', '123')
+    assert b'Sua conta est' in resp.data


### PR DESCRIPTION
## Summary
- add `ativo` flag and `is_active` method for Usuario
- prevent login for blocked Usuario
- support toggling user status via new route
- show status and block/unblock button on admin user list
- test blocking via toggle route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685b0f298fac8324b4a37be7518fe4d7