### PR TITLE
Fix DB transaction error on homepage

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -43,6 +43,7 @@ def home():
                                eventos_destaque=_serializa_eventos(eventos))
     except Exception as e:
         print(f"[ERRO] home(): {e}")
+        db.session.rollback()  # ensure session not left in failed state
         return render_template('index.html', eventos_destaque=[])
 
 @evento_routes.route('/evento/<int:evento_id>/inscricao')


### PR DESCRIPTION
## Summary
- add session rollback in home() to prevent failed transactions from affecting later queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b1128cc488324bbf6e3010cc32241