### PR TITLE
Move populate_script tests

### DIFF
--- a/populate_script.py
+++ b/populate_script.py
@@ -48,8 +48,6 @@ from werkzeug.security import generate_password_hash
 from faker import Faker
 import uuid
 import bcrypt
-import pytest
-from unittest.mock import Mock
 from slugify import slugify  # You may need to pip install python-slugify
 from sqlalchemy.exc import IntegrityError
 
@@ -833,58 +831,6 @@ def criar_feedbacks(inscricoes, oficinas):
     db.session.commit()
 
 
-@pytest.fixture
-def mock_evento():
-    evento = Mock()
-    oficina = Mock()
-    horario = Mock()
-    
-    # Configure mocks
-    horario.vagas_disponiveis = 20
-    horario.id = 1
-    oficina.horarios = [horario]
-    evento.oficinas = [oficina]
-    
-    return evento
-
-@pytest.fixture 
-def mock_usuarios():
-    professor = Mock()
-    professor.tipo = 'professor'
-    professor.id = 1
-    return [professor]
-
-def test_criar_agendamentos_sem_vagas(mock_evento, mock_usuarios):
-    # Arrange
-    mock_evento.oficinas[0].horarios[0].vagas_disponiveis = 0
-    
-    # Act
-    resultado = criar_agendamentos_visita([mock_evento], mock_usuarios)
-    
-    # Assert  
-    assert len(resultado) == 0
-
-def test_criar_agendamentos_com_vagas(mock_evento, mock_usuarios):
-    # Arrange
-    random.seed(42) # For reproducible results
-    mock_evento.oficinas[0].horarios[0].vagas_disponiveis = 20
-    
-    # Act
-    resultado = criar_agendamentos_visita([mock_evento], mock_usuarios)
-    
-    # Assert
-    assert len(resultado) > 0
-    assert resultado[0].quantidade_alunos <= 20
-
-def test_criar_agendamentos_respeita_limite_maximo(mock_evento, mock_usuarios):
-    # Arrange
-    mock_evento.oficinas[0].horarios[0].vagas_disponiveis = 50
-    
-    # Act
-    resultado = criar_agendamentos_visita([mock_evento], mock_usuarios)
-    
-    # Assert
-    assert all(a.quantidade_alunos <= 30 for a in resultado)
 
 def criar_submissoes(eventos, usuarios, quantidade_por_evento=3):
     """Gera trabalhos submetidos (Submission) ligados a participantes."""

--- a/tests/test_populate_script.py
+++ b/tests/test_populate_script.py
@@ -1,0 +1,62 @@
+import random
+import pytest
+from unittest.mock import Mock
+from populate_script import criar_agendamentos_visita
+
+
+@pytest.fixture
+def mock_evento():
+    evento = Mock()
+    oficina = Mock()
+    horario = Mock()
+
+    # Configure mocks
+    horario.vagas_disponiveis = 20
+    horario.id = 1
+    oficina.horarios = [horario]
+    evento.oficinas = [oficina]
+
+    return evento
+
+
+@pytest.fixture
+def mock_usuarios():
+    professor = Mock()
+    professor.tipo = "professor"
+    professor.id = 1
+    return [professor]
+
+
+def test_criar_agendamentos_sem_vagas(mock_evento, mock_usuarios):
+    # Arrange
+    mock_evento.oficinas[0].horarios[0].vagas_disponiveis = 0
+
+    # Act
+    resultado = criar_agendamentos_visita([mock_evento], mock_usuarios)
+
+    # Assert
+    assert len(resultado) == 0
+
+
+def test_criar_agendamentos_com_vagas(mock_evento, mock_usuarios):
+    # Arrange
+    random.seed(42)  # For reproducible results
+    mock_evento.oficinas[0].horarios[0].vagas_disponiveis = 20
+
+    # Act
+    resultado = criar_agendamentos_visita([mock_evento], mock_usuarios)
+
+    # Assert
+    assert len(resultado) > 0
+    assert resultado[0].quantidade_alunos <= 20
+
+
+def test_criar_agendamentos_respeita_limite_maximo(mock_evento, mock_usuarios):
+    # Arrange
+    mock_evento.oficinas[0].horarios[0].vagas_disponiveis = 50
+
+    # Act
+    resultado = criar_agendamentos_visita([mock_evento], mock_usuarios)
+
+    # Assert
+    assert all(a.quantidade_alunos <= 30 for a in resultado)


### PR DESCRIPTION
## Summary
- relocate the agendamento fixtures/tests into `tests/test_populate_script.py`
- drop pytest and Mock imports from `populate_script.py`
- remove inline tests from `populate_script.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685b2b7650b08324886c4729cd7928d4