### PR TITLE
Fix CPF uniqueness in populate script

### DIFF
--- a/populate_script.py
+++ b/populate_script.py
@@ -592,7 +592,7 @@ def criar_usuarios(clientes, quantidade=150):
         # Criar um superadmin apenas se ainda não existir
         superadmin = Usuario(
             nome="Administrador do Sistema",
-            cpf=fake.cpf(),
+            cpf=fake.unique.cpf(),
             email="admin@sistema.com",
             senha=generate_password_hash("admin123"),
             formacao="Administrador de Sistemas",
@@ -620,9 +620,13 @@ def criar_usuarios(clientes, quantidade=150):
         
         cliente = random.choice(clientes)
 
+        cpf = fake.cpf()
+        while Usuario.query.filter_by(cpf=cpf).first():
+            cpf = fake.cpf()
+
         usuario = Usuario(
             nome=fake.name(),
-            cpf=fake.unique.cpf(),
+            cpf=cpf,
             email=fake.unique.email(),
             senha=generate_password_hash(fake.password()),
             formacao=random.choice(TIPOS_FORMACAO),


### PR DESCRIPTION
## Summary
- ensure superadmin CPF uses `fake.unique.cpf`
- generate each user CPF until unique in DB
- confirm CPF uniqueness by calling `criar_usuarios` twice

## Testing
- `python - <<'EOF'
from app import create_app
from populate_script import criar_clientes, criar_usuarios
from extensions import db
from models import Usuario
app = create_app()
with app.app_context():
    db.drop_all()
    db.create_all()
    clientes = criar_clientes(2)
    criar_usuarios(clientes, 5)
    criar_usuarios(clientes, 5)
    cpfs = [u.cpf for u in Usuario.query.all()]
    print('Unique CPF count', len(set(cpfs)), 'Total', len(cpfs))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685b343df13c83249a51f76507e0c567