### PR TITLE
Fix duplicate peer review import

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -51,7 +51,6 @@ def register_routes(app):
     from .util_routes import util_routes
     from .relatorio_pdf_routes import relatorio_pdf_routes
     from .static_page_routes import static_page_routes
-    from .peer_review_routes import peer_review_routes
     # Importa servicos que registram rotas diretamente no blueprint
     from services import lote_service  # noqa: F401
 


### PR DESCRIPTION
## Summary
- clean up duplicated `peer_review_routes` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_685c0b1a2058832482f7d6b6110741a7