### PR TITLE
Allow clients to toggle required custom fields

### DIFF
--- a/routes/campo_routes.py
+++ b/routes/campo_routes.py
@@ -47,6 +47,27 @@ def remover_campo_personalizado(campo_id):
     return redirect(url_for('dashboard_routes.dashboard_cliente'))
 
 
+@campo_routes.route('/toggle_obrigatorio_campo/<int:campo_id>', methods=['POST'])
+@login_required
+def toggle_obrigatorio_campo(campo_id):
+    """Alterna a obrigatoriedade de um campo personalizado de cadastro."""
+    if not (current_user.is_cliente() or getattr(current_user, 'tipo', None) == 'admin'):
+        flash('Acesso negado', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+    campo = CampoPersonalizadoCadastro.query.get_or_404(campo_id)
+
+    if campo.cliente_id != current_user.id and getattr(current_user, 'tipo', None) != 'admin':
+        flash('Você não tem permissão para alterar este campo.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+    campo.obrigatorio = not campo.obrigatorio
+    db.session.commit()
+
+    flash('Campo atualizado com sucesso!', 'success')
+    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+
 
 
 

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1122,7 +1122,12 @@
                           {% endif %}
                         </td>
                         <td class="text-center">
-                          <form method="POST" action="{{ url_for('campo_routes.remover_campo_personalizado', campo_id=campo.id) }}" 
+                          <form method="POST" action="{{ url_for('campo_routes.toggle_obrigatorio_campo', campo_id=campo.id) }}" class="d-inline">
+                            <button class="btn btn-padrao btn-table btn-sm btn-secondary" type="submit">
+                              {% if campo.obrigatorio %}Tornar Opcional{% else %}Tornar Obrigatório{% endif %}
+                            </button>
+                          </form>
+                          <form method="POST" action="{{ url_for('campo_routes.remover_campo_personalizado', campo_id=campo.id) }}"
                                 onsubmit="return confirm('Tem certeza que deseja remover este campo?');">
                             <button class="btn btn-padrao btn-table btn-sm btn-danger" type="submit">
                               <i class="bi bi-trash-fill"></i> Remover


### PR DESCRIPTION
## Summary
- add route `toggle_obrigatorio_campo` to switch required flag
- allow dashboard users to mark custom fields as required or optional

## Testing
- `pytest -k campo_routes -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c0cd2154083248eb039898a48a0a7