### PR TITLE
Add preview cadastro route

### DIFF
--- a/routes/campo_routes.py
+++ b/routes/campo_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, redirect, url_for, flash
+from flask import render_template, Blueprint, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from extensions import db
 from models import CampoPersonalizadoCadastro
@@ -70,4 +70,47 @@ def toggle_obrigatorio_campo(campo_id):
 
 
 
+
+
+@campo_routes.route('/preview_cadastro')
+@login_required
+def preview_cadastro():
+    """Mostra uma prévia do formulário de cadastro de participante."""
+    if not (current_user.is_cliente() or getattr(current_user, 'tipo', None) == 'admin'):
+        flash('Acesso negado', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+    from models import Evento, EventoInscricaoTipo, ConfiguracaoCliente
+    from utils import preco_com_taxa
+
+    evento = Evento.query.filter_by(cliente_id=current_user.id).first()
+
+    campos = CampoPersonalizadoCadastro.query.filter_by(cliente_id=current_user.id).all()
+    tipos_inscricao = []
+    mostrar_taxa = True
+
+    if evento:
+        tipos_inscricao = EventoInscricaoTipo.query.filter_by(evento_id=evento.id).all()
+        config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=current_user.id).first()
+        mostrar_taxa = config_cli.mostrar_taxa if config_cli else True
+
+    return render_template(
+        'auth/cadastro_preview.html',
+        token='preview',
+        evento=evento,
+        sorted_keys=[],
+        grouped_oficinas={},
+        ministrantes=[],
+        patrocinadores=[],
+        campos_personalizados=campos,
+        lote_vigente=None,
+        lote_stats=None,
+        lotes_ativos=[],
+        tipos_inscricao=tipos_inscricao,
+        mostrar_taxa=mostrar_taxa,
+        preco_com_taxa=preco_com_taxa,
+        solicitar_senha=False,
+        cliente_id=current_user.id,
+        disable_submit=True
+    )
 

--- a/templates/auth/cadastro_preview.html
+++ b/templates/auth/cadastro_preview.html
@@ -1,0 +1,20 @@
+{% extends "auth/cadastro_participante.html" %}
+
+{% block title %}Pré-visualização do Cadastro{% endblock %}
+
+{% block content %}
+<div class="alert alert-info text-center mb-3">
+    Esta é uma pré-visualização do formulário de cadastro. O envio está desativado.
+</div>
+{{ super() }}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const form = document.getElementById('registrationForm');
+        if (form) {
+            form.addEventListener('submit', function(e) { e.preventDefault(); });
+            const btn = form.querySelector('button[type="submit"]');
+            if (btn) { btn.disabled = true; }
+        }
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a preview route under `campo_routes`
- show a preview notice and disable the submit button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685da1b0f5cc8324bfbae82def7d6c24