### PR TITLE
Add configurable required fields for participant registration

### DIFF
--- a/migrations/versions/fe25f1583d6c_add_required_flags_to_configuracao_cliente.py
+++ b/migrations/versions/fe25f1583d6c_add_required_flags_to_configuracao_cliente.py
@@ -1,0 +1,33 @@
+"""add required field flags to ConfiguracaoCliente
+
+Revision ID: fe25f1583d6c
+Revises: edec4bcb5f46
+Create Date: 2025-09-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'fe25f1583d6c'
+down_revision = 'edec4bcb5f46'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('configuracao_cliente') as batch_op:
+        batch_op.add_column(sa.Column('obrigatorio_nome', sa.Boolean(), nullable=True, server_default=sa.true()))
+        batch_op.add_column(sa.Column('obrigatorio_cpf', sa.Boolean(), nullable=True, server_default=sa.true()))
+        batch_op.add_column(sa.Column('obrigatorio_email', sa.Boolean(), nullable=True, server_default=sa.true()))
+        batch_op.add_column(sa.Column('obrigatorio_senha', sa.Boolean(), nullable=True, server_default=sa.true()))
+        batch_op.add_column(sa.Column('obrigatorio_formacao', sa.Boolean(), nullable=True, server_default=sa.true()))
+
+
+def downgrade():
+    with op.batch_alter_table('configuracao_cliente') as batch_op:
+        batch_op.drop_column('obrigatorio_formacao')
+        batch_op.drop_column('obrigatorio_senha')
+        batch_op.drop_column('obrigatorio_email')
+        batch_op.drop_column('obrigatorio_cpf')
+        batch_op.drop_column('obrigatorio_nome')

--- a/models.py
+++ b/models.py
@@ -608,6 +608,12 @@ class ConfiguracaoCliente(db.Model):
     num_revisores_max = db.Column(db.Integer, default=2)
     prazo_parecer_dias = db.Column(db.Integer, default=14)
 
+    obrigatorio_nome = db.Column(db.Boolean, default=True)
+    obrigatorio_cpf = db.Column(db.Boolean, default=True)
+    obrigatorio_email = db.Column(db.Boolean, default=True)
+    obrigatorio_senha = db.Column(db.Boolean, default=True)
+    obrigatorio_formacao = db.Column(db.Boolean, default=True)
+
     
     
 class FeedbackCampo(db.Model):

--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -207,6 +207,76 @@ def toggle_mostrar_taxa():
         "message": "Exibição da taxa atualizada!"
     })
 
+@config_cliente_routes.route('/toggle_obrigatorio_nome', methods=['POST'])
+@login_required
+def toggle_obrigatorio_nome():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+    config = current_user.configuracao
+    if not config:
+        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config)
+        db.session.commit()
+    config.obrigatorio_nome = not config.obrigatorio_nome
+    db.session.commit()
+    return jsonify({"success": True, "value": config.obrigatorio_nome})
+
+@config_cliente_routes.route('/toggle_obrigatorio_cpf', methods=['POST'])
+@login_required
+def toggle_obrigatorio_cpf():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+    config = current_user.configuracao
+    if not config:
+        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config)
+        db.session.commit()
+    config.obrigatorio_cpf = not config.obrigatorio_cpf
+    db.session.commit()
+    return jsonify({"success": True, "value": config.obrigatorio_cpf})
+
+@config_cliente_routes.route('/toggle_obrigatorio_email', methods=['POST'])
+@login_required
+def toggle_obrigatorio_email():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+    config = current_user.configuracao
+    if not config:
+        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config)
+        db.session.commit()
+    config.obrigatorio_email = not config.obrigatorio_email
+    db.session.commit()
+    return jsonify({"success": True, "value": config.obrigatorio_email})
+
+@config_cliente_routes.route('/toggle_obrigatorio_senha', methods=['POST'])
+@login_required
+def toggle_obrigatorio_senha():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+    config = current_user.configuracao
+    if not config:
+        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config)
+        db.session.commit()
+    config.obrigatorio_senha = not config.obrigatorio_senha
+    db.session.commit()
+    return jsonify({"success": True, "value": config.obrigatorio_senha})
+
+@config_cliente_routes.route('/toggle_obrigatorio_formacao', methods=['POST'])
+@login_required
+def toggle_obrigatorio_formacao():
+    if current_user.tipo != 'cliente':
+        return jsonify({"success": False, "message": "Acesso negado!"}), 403
+    config = current_user.configuracao
+    if not config:
+        config = ConfiguracaoCliente(cliente_id=current_user.id)
+        db.session.add(config)
+        db.session.commit()
+    config.obrigatorio_formacao = not config.obrigatorio_formacao
+    db.session.commit()
+    return jsonify({"success": True, "value": config.obrigatorio_formacao})
+
 @config_cliente_routes.route("/api/configuracao_cliente_atual", methods=["GET"])
 @login_required
 def configuracao_cliente_atual():
@@ -236,6 +306,11 @@ def configuracao_cliente_atual():
         "num_revisores_max": config_cliente.num_revisores_max,
         "prazo_parecer_dias": config_cliente.prazo_parecer_dias,
         "habilitar_submissao_trabalhos": config_cliente.habilitar_submissao_trabalhos,
+        "obrigatorio_nome": config_cliente.obrigatorio_nome,
+        "obrigatorio_cpf": config_cliente.obrigatorio_cpf,
+        "obrigatorio_email": config_cliente.obrigatorio_email,
+        "obrigatorio_senha": config_cliente.obrigatorio_senha,
+        "obrigatorio_formacao": config_cliente.obrigatorio_formacao,
         "allowed_file_types": config_cliente.allowed_file_types
 
     })

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -101,7 +101,19 @@ def cadastro_participante(identifier: str | None = None):
 
         try:
             solicitar_senha = False
-            if not all([nome, cpf, email, senha, formacao]):
+
+            config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
+
+            def obrig(attr):
+                return getattr(config_cli, attr) if config_cli else True
+
+            if (
+                (obrig("obrigatorio_nome") and not nome) or
+                (obrig("obrigatorio_cpf") and not cpf) or
+                (obrig("obrigatorio_email") and not email) or
+                (obrig("obrigatorio_senha") and not senha) or
+                (obrig("obrigatorio_formacao") and not formacao)
+            ):
                 raise ValueError("Preencha todos os campos obrigatórios.")
 
             duplicado = Usuario.query.filter(
@@ -461,6 +473,11 @@ def _render_form(*, link, evento, lote_vigente, lotes_ativos, cliente_id, solici
 
     config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
     mostrar_taxa = config_cli.mostrar_taxa if config_cli else True
+    obrigatorio_nome = config_cli.obrigatorio_nome if config_cli else True
+    obrigatorio_cpf = config_cli.obrigatorio_cpf if config_cli else True
+    obrigatorio_email = config_cli.obrigatorio_email if config_cli else True
+    obrigatorio_senha = config_cli.obrigatorio_senha if config_cli else True
+    obrigatorio_formacao = config_cli.obrigatorio_formacao if config_cli else True
 
     # Estatísticas do lote vigente
     lote_stats = None
@@ -503,7 +520,12 @@ def _render_form(*, link, evento, lote_vigente, lotes_ativos, cliente_id, solici
         mostrar_taxa=mostrar_taxa,
         preco_com_taxa=preco_com_taxa,
         solicitar_senha=solicitar_senha,
-        cliente_id=cliente_id
+        cliente_id=cliente_id,
+        obrigatorio_nome=obrigatorio_nome,
+        obrigatorio_cpf=obrigatorio_cpf,
+        obrigatorio_email=obrigatorio_email,
+        obrigatorio_senha=obrigatorio_senha,
+        obrigatorio_formacao=obrigatorio_formacao
     )
 
 @inscricao_routes.route('/editar_participante', methods=['GET', 'POST'])

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -107,6 +107,11 @@ document.addEventListener('DOMContentLoaded', function() {
         const btnQrCredenciamento = document.getElementById('btnToggleQrCredenciamento');
         const btnMostrarTaxa = document.getElementById('btnToggleMostrarTaxa');
         const btnSubmissao = document.getElementById('btnToggleSubmissao');
+        const btnObrigNome = document.getElementById('btnToggleObrigatorioNome');
+        const btnObrigCpf = document.getElementById('btnToggleObrigatorioCpf');
+        const btnObrigEmail = document.getElementById('btnToggleObrigatorioEmail');
+        const btnObrigSenha = document.getElementById('btnToggleObrigatorioSenha');
+        const btnObrigFormacao = document.getElementById('btnToggleObrigatorioFormacao');
 
         if (btnCheckin) atualizarBotao(btnCheckin, data.permitir_checkin_global);
         if (btnFeedback) atualizarBotao(btnFeedback, data.habilitar_feedback);
@@ -114,6 +119,11 @@ document.addEventListener('DOMContentLoaded', function() {
         if (btnQrCredenciamento) atualizarBotao(btnQrCredenciamento, data.habilitar_qrcode_evento_credenciamento);
         if (btnMostrarTaxa) atualizarBotao(btnMostrarTaxa, data.mostrar_taxa);
         if (btnSubmissao) atualizarBotao(btnSubmissao, data.habilitar_submissao_trabalhos);
+        if (btnObrigNome) atualizarBotao(btnObrigNome, data.obrigatorio_nome);
+        if (btnObrigCpf) atualizarBotao(btnObrigCpf, data.obrigatorio_cpf);
+        if (btnObrigEmail) atualizarBotao(btnObrigEmail, data.obrigatorio_email);
+        if (btnObrigSenha) atualizarBotao(btnObrigSenha, data.obrigatorio_senha);
+        if (btnObrigFormacao) atualizarBotao(btnObrigFormacao, data.obrigatorio_formacao);
         const inputAllowed = document.getElementById('inputAllowedFiles');
         if (inputAllowed && data.allowed_file_types) inputAllowed.value = data.allowed_file_types;
       })
@@ -131,7 +141,12 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('btnToggleCertificado'),
     document.getElementById('btnToggleQrCredenciamento'),
     document.getElementById('btnToggleMostrarTaxa'),
-    document.getElementById('btnToggleSubmissao')
+    document.getElementById('btnToggleSubmissao'),
+    document.getElementById('btnToggleObrigatorioNome'),
+    document.getElementById('btnToggleObrigatorioCpf'),
+    document.getElementById('btnToggleObrigatorioEmail'),
+    document.getElementById('btnToggleObrigatorioSenha'),
+    document.getElementById('btnToggleObrigatorioFormacao')
   ];
 
   toggleButtons.forEach(button => {

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -246,25 +246,25 @@
                         <!-- Dados Pessoais -->
                         <div class="form-group">
                             <label for="nome">Nome Completo</label>
-                            <input type="text" id="nome" name="nome" value="{{ request.form.get('nome', '') }}" 
-                                   placeholder="Seu nome completo" required>
+                            <input type="text" id="nome" name="nome" value="{{ request.form.get('nome', '') }}"
+                                   placeholder="Seu nome completo" {% if obrigatorio_nome %}required{% endif %}>
                         </div>
                         
                         <div class="form-group">
                             <label for="cpf">CPF</label>
-                            <input type="text" id="cpf" name="cpf" placeholder="000.000.000-00" 
-                                   value="{{ request.form.get('cpf', '') }}" required>
+                            <input type="text" id="cpf" name="cpf" placeholder="000.000.000-00"
+                                   value="{{ request.form.get('cpf', '') }}" {% if obrigatorio_cpf %}required{% endif %}>
                         </div>
                         
                         <div class="form-group">
                             <label for="email">E-mail</label>
-                            <input type="email" id="email" name="email" value="{{ request.form.get('email', '') }}" 
-                                   placeholder="seu@email.com" required>
+                            <input type="email" id="email" name="email" value="{{ request.form.get('email', '') }}"
+                                   placeholder="seu@email.com" {% if obrigatorio_email %}required{% endif %}>
                         </div>
                         
                         <div class="form-group">
                             <label for="senha">Senha</label>
-                            <input type="password" id="senha" name="senha" placeholder="Crie uma senha segura" required>
+                            <input type="password" id="senha" name="senha" placeholder="Crie uma senha segura" {% if obrigatorio_senha %}required{% endif %}>
                             <small class="password-hint">Mínimo de 8 caracteres</small>
                         </div>
 
@@ -277,8 +277,8 @@
                         
                         <div class="form-group full-width">
                             <label for="formacao">Formação Acadêmica</label>
-                            <input type="text" id="formacao" name="formacao" value="{{ request.form.get('formacao', '') }}" 
-                                   placeholder="Ex: Bacharel em Engenharia" required>
+                            <input type="text" id="formacao" name="formacao" value="{{ request.form.get('formacao', '') }}"
+                                   placeholder="Ex: Bacharel em Engenharia" {% if obrigatorio_formacao %}required{% endif %}>
                         </div>
                         
                         <!-- Campos Personalizados -->

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -940,17 +940,34 @@
                     </h6>
                     <p class="text-muted small mb-0">Exibe a taxa de serviço separadamente no valor da inscrição</p>
                   </div>
-                  <button type="button"
-                          id="btnToggleMostrarTaxa"
-                          class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.mostrar_taxa else 'danger' }}"
-                          data-toggle-url="{{ url_for('config_cliente_routes.toggle_mostrar_taxa') }}">
+                <button type="button"
+                        id="btnToggleMostrarTaxa"
+                        class="btn btn-padrao btn-toggle btn-{{ 'success' if config_cliente and config_cliente.mostrar_taxa else 'danger' }}"
+                        data-toggle-url="{{ url_for('config_cliente_routes.toggle_mostrar_taxa') }}">
                     <i class="bi bi-{{ 'check-circle-fill' if config_cliente and config_cliente.mostrar_taxa else 'x-circle-fill' }}"></i>
                     {{ 'Ativo' if config_cliente and config_cliente.mostrar_taxa else 'Desativado' }}
-                  </button>
+                </button>
+              </div>
+
+              <!-- Requisitos de Cadastro -->
+              <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+                <div>
+                  <h6 class="mb-0 fw-semibold d-flex align-items-center">
+                    <i class="bi bi-card-checklist text-primary me-2"></i>
+                    Campos Obrigatórios
+                  </h6>
+                </div>
+                <div class="d-flex gap-2">
+                  <button type="button" id="btnToggleObrigatorioNome" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_nome else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_nome') }}">Nome</button>
+                  <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_cpf else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_cpf') }}">CPF</button>
+                  <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_email else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_email') }}">Email</button>
+                  <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_senha else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_senha') }}">Senha</button>
+                  <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_formacao else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_formacao') }}">Formação</button>
                 </div>
               </div>
             </div>
           </div>
+        </div>
 
 
 


### PR DESCRIPTION
## Summary
- allow clients to specify which participant fields are mandatory
- store booleans on `ConfiguracaoCliente`
- add Alembic migration for new columns
- enforce flags during participant signup
- expose toggles on dashboard preview and update JS logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_685da1b217dc8324b38a2bf90d173f9c