### PR TITLE
Add Campos de Inscrição button

### DIFF
--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -19,6 +19,11 @@
   <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#modalTaxa">
     <i class="bi bi-cash-coin"></i> Taxa do sistema
   </button>
+  {% if current_user.tipo in ['admin', 'superadmin'] %}
+  <a href="/preview_cadastro" class="btn btn-outline-secondary ms-2">
+    <i class="bi bi-ui-checks-grid"></i> Campos de Inscrição
+  </a>
+  {% endif %}
   
   
 


### PR DESCRIPTION
## Summary
- add Campos de Inscrição button in admin dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685da1b476a48324b785afe685f2811a