### PR TITLE
Fix unmatched endif in criar_oficina template

### DIFF
--- a/templates/oficina/criar_oficina.html
+++ b/templates/oficina/criar_oficina.html
@@ -350,7 +350,6 @@
               </div>
             </div>
           </div>
-          {% endif %}
 
           <div class="d-flex justify-content-between mt-4">
             <button type="button" class="btn btn-outline-secondary prev-step px-4" data-prev="4">


### PR DESCRIPTION
## Summary
- fix unmatched `{% endif %}` in `criar_oficina.html`

## Testing
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685f11336d2883249343413b4c472a89