### PR TITLE
Move registration fields preview to client dashboard

### DIFF
--- a/static/css/dashboard_cliente.css
+++ b/static/css/dashboard_cliente.css
@@ -172,10 +172,16 @@
       }
       
       /* Botões de alternância (toggle) */
-      .btn-toggle {
-        min-width: 120px;
-        padding: 0.5rem 1rem;
-      }
+.btn-toggle {
+  min-width: 120px;
+  padding: 0.5rem 1rem;
+}
+
+/* Versão pequena dos botões de alternância */
+.btn-toggle.btn-sm {
+  min-width: 60px;
+  padding: 0.25rem 0.5rem;
+}
       
       /* Grupos de ação para agrupar botões relacionados */
       .action-group {

--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -19,11 +19,6 @@
   <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#modalTaxa">
     <i class="bi bi-cash-coin"></i> Taxa do sistema
   </button>
-  {% if current_user.tipo in ['admin', 'superadmin'] %}
-  <a href="/preview_cadastro" class="btn btn-outline-secondary ms-2">
-    <i class="bi bi-ui-checks-grid"></i> Campos de Inscrição
-  </a>
-  {% endif %}
   
   
 

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -957,13 +957,13 @@
                     Campos Obrigatórios
                   </h6>
                 </div>
-                <div class="d-flex gap-2">
-                  <button type="button" id="btnToggleObrigatorioNome" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_nome else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_nome') }}">Nome</button>
-                  <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_cpf else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_cpf') }}">CPF</button>
-                  <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_email else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_email') }}">Email</button>
-                  <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_senha else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_senha') }}">Senha</button>
-                  <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_formacao else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_formacao') }}">Formação</button>
-                </div>
+                  <div class="d-flex gap-2">
+                    <button type="button" id="btnToggleObrigatorioNome" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_nome else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_nome') }}">Nome</button>
+                    <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_cpf else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_cpf') }}">CPF</button>
+                    <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_email else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_email') }}">Email</button>
+                    <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_senha else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_senha') }}">Senha</button>
+                    <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_formacao else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_formacao') }}">Formação</button>
+                  </div>
               </div>
             </div>
           </div>
@@ -1003,7 +1003,23 @@
                 </div>
               </div>
             </div>
-            
+
+            <!-- Visualizar Campos de Inscrição Card -->
+            <div class="card border-secondary border-top border-4 shadow-sm mb-4">
+              <div class="card-header bg-secondary text-white">
+                <div class="d-flex align-items-center">
+                  <i class="bi bi-ui-checks-grid me-2 fs-5"></i>
+                  <h5 class="fw-bold mb-0">Campos de Inscrição</h5>
+                </div>
+              </div>
+              <div class="card-body">
+                <p class="mb-3">Veja como os campos personalizados aparecem para seus participantes.</p>
+                <a href="{{ url_for('campo_routes.preview_cadastro') }}" class="btn btn-padrao btn-outline-secondary w-100">
+                  <i class="bi bi-eye-fill"></i> Visualizar Formulário
+                </a>
+              </div>
+            </div>
+
             <!-- Manutenção do Sistema Card -->
             <div class="card border-danger border-top border-4 shadow-sm mb-4">
               <div class="card-header bg-danger text-white">


### PR DESCRIPTION
## Summary
- remove "Campos de Inscrição" link from admin dashboard
- add a dedicated card in client dashboard linking to `/preview_cadastro`
- refine toggle button styles and apply `btn-padrao` to small toggles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: sqlalchemy, werkzeug, flask, bcrypt, bleach)*

------
https://chatgpt.com/codex/tasks/task_e_685f12925408832497c45af8f5ae71cf