### PR TITLE
Fix preview template error

### DIFF
--- a/models.py
+++ b/models.py
@@ -328,6 +328,11 @@ class EventoInscricaoTipo(db.Model):
         self.nome = nome
         self.preco = preco
 
+    @property
+    def tipo_inscricao(self):
+        """Alias to self for template compatibility."""
+        return self
+
 
 class RegraInscricaoEvento(db.Model):
     __tablename__ = 'regra_inscricao_evento'


### PR DESCRIPTION
## Summary
- prevent Jinja attribute errors in cadastro preview by adding an alias

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f14b5843883248b88a7c76f12c640