### PR TITLE
Show event dates on participant dashboard

### DIFF
--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -66,6 +66,14 @@
     position: relative;
     overflow: hidden;
   }
+
+  .evento-data {
+    margin-top: -1rem;
+    margin-bottom: 1rem;
+    margin-left: 1.5rem;
+    font-size: 0.9rem;
+    color: var(--gray-text);
+  }
   
   .evento-titulo::after {
     content: '';
@@ -421,7 +429,21 @@
     {% for oficina in oficinas %}
       {% if (oficina.tipo_inscricao == 'com_inscricao_sem_limite' or oficina.tipo_inscricao == 'com_inscricao_com_limite') and oficina.evento_id == usuario.evento_id %}
         {% if oficina.evento_id not in eventos %}
-          {% if eventos.update({oficina.evento_id: {'nome': oficina.evento_nome, 'oficinas': []}}) %}{% endif %}
+          {% set _ = eventos.update({
+            oficina.evento_id: {
+              'nome': oficina.evento_nome,
+              'data_inicio': oficina.evento_data_inicio,
+              'data_fim': oficina.evento_data_fim,
+              'oficinas': []
+            }
+          }) %}
+        {% else %}
+          {% if not eventos[oficina.evento_id].get('data_inicio') and oficina.evento_data_inicio %}
+            {% set _ = eventos[oficina.evento_id].update({'data_inicio': oficina.evento_data_inicio}) %}
+          {% endif %}
+          {% if not eventos[oficina.evento_id].get('data_fim') and oficina.evento_data_fim %}
+            {% set _ = eventos[oficina.evento_id].update({'data_fim': oficina.evento_data_fim}) %}
+          {% endif %}
         {% endif %}
         {% if eventos[oficina.evento_id]['oficinas'].append(oficina) %}{% endif %}
       {% endif %}
@@ -431,7 +453,13 @@
     {% for evento_id, evento_info in eventos.items() %}
       <div class="evento-section">
         <h3 class="evento-titulo">{{ evento_info.nome }}</h3>
-        
+        {% if evento_info.data_inicio %}
+          <p class="evento-data">
+            {{ evento_info.data_inicio.strftime('%d/%m/%Y') }}
+            {% if evento_info.data_fim %}- {{ evento_info.data_fim.strftime('%d/%m/%Y') }}{% endif %}
+          </p>
+        {% endif %}
+
         <div class="row">
           {% for oficina in evento_info.oficinas %}
             <div class="col-md-6 col-lg-4 mb-4">


### PR DESCRIPTION
## Summary
- show event start and end dates when grouping participant dashboard activities
- style event date indicator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861333316dc83249cc61cbb274350f3