### PR TITLE
Fix modal placement outside tables

### DIFF
--- a/templates/formulario/formularios.html
+++ b/templates/formulario/formularios.html
@@ -41,37 +41,13 @@
                                            title="Editar Formulário">
                                             <i class="bi bi-pencil"></i>
                                         </a>
-                                        <button type="button" 
-                                                class="btn btn-outline-danger btn-sm" 
-                                                data-bs-toggle="modal" 
+                                        <button type="button"
+                                                class="btn btn-outline-danger btn-sm"
+                                                data-bs-toggle="modal"
                                                 data-bs-target="#deleteModal{{ formulario.id }}"
                                                 title="Excluir Formulário">
                                             <i class="bi bi-trash"></i>
                                         </button>
-                                    </div>
-                                    
-                                    <!-- Modal de confirmação para exclusão -->
-                                    <div class="modal fade" id="deleteModal{{ formulario.id }}" tabindex="-1" aria-hidden="true">
-                                        <div class="modal-dialog modal-dialog-centered">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title">Confirmar exclusão</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    <p>Tem certeza que deseja excluir o formulário <strong>{{ formulario.nome }}</strong>?</p>
-                                                    <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                                    <form action="{{ url_for('formularios_routes.excluir_formulario', formulario_id=formulario.id) }}" method="POST" class="d-inline">
-                                                        <button type="submit" class="btn btn-danger">
-                                                            Excluir Formulário
-                                                        </button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
                                     </div>
                                 </td>
                             </tr>
@@ -90,9 +66,34 @@
             {% endif %}
         </div>
     </div>
-</div>
+    </div>
 
-<script>
+    {% for formulario in formularios %}
+    <div class="modal fade" id="deleteModal{{ formulario.id }}" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirmar exclusão</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Tem certeza que deseja excluir o formulário <strong>{{ formulario.nome }}</strong>?</p>
+                    <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <form action="{{ url_for('formularios_routes.excluir_formulario', formulario_id=formulario.id) }}" method="POST" class="d-inline">
+                        <button type="submit" class="btn btn-danger">
+                            Excluir Formulário
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+
+    <script>
     // Inicializar tooltips
     document.addEventListener('DOMContentLoaded', function() {
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/templates/formulario/gerenciar_campos.html
+++ b/templates/formulario/gerenciar_campos.html
@@ -46,38 +46,16 @@
                                     <a href="{{ url_for('formularios_routes.editar_campo', campo_id=campo.id) }}" class="btn btn-outline-warning">
                                         <i class="bi bi-pencil"></i>
                                     </a>
-                                    <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteFieldModal{{ campo.id }}">
-                                        <i class="bi bi-trash"></i>
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <!-- Modal para exclusão -->
-                        <div class="modal fade" id="deleteFieldModal{{ campo.id }}" tabindex="-1" aria-hidden="true">
-                            <div class="modal-dialog modal-dialog-centered">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Confirmar exclusão</h5>
-                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                    </div>
-                                    <div class="modal-body">
-                                        <p>Tem certeza que deseja remover o campo <strong>{{ campo.nome }}</strong>?</p>
-                                        <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                        <form action="{{ url_for('formularios_routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
-                                            <button type="submit" class="btn btn-danger">Remover Campo</button>
-                                        </form>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
-                    {% else %}
-                    <div class="text-center p-4">
+                          <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteFieldModal{{ campo.id }}">
+                              <i class="bi bi-trash"></i>
+                          </button>
+                      </div>
+                  </div>
+              </div>
+              {% endfor %}
+          </div>
+          {% else %}
+          <div class="text-center p-4">
                         <i class="bi bi-dash-circle text-muted fs-1"></i>
                         <p class="text-muted mt-2">Nenhum campo adicionado ainda.</p>
                     </div>
@@ -161,9 +139,32 @@
             </div>
         </div>
     </div>
-</div>
+    </div>
 
-<script>
+    {% for campo in formulario.campos %}
+    <div class="modal fade" id="deleteFieldModal{{ campo.id }}" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirmar exclusão</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Tem certeza que deseja remover o campo <strong>{{ campo.nome }}</strong>?</p>
+                    <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <form action="{{ url_for('formularios_routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
+                        <button type="submit" class="btn btn-danger">Remover Campo</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+
+    <script>
     // Controle de exibição do campo opções
     document.addEventListener('DOMContentLoaded', function() {
         const tipoSelect = document.getElementById('tipo');

--- a/templates/formulario/gerenciar_campos_template.html
+++ b/templates/formulario/gerenciar_campos_template.html
@@ -60,39 +60,17 @@
                                             <a href="#" class="btn btn-outline-warning" data-bs-toggle="tooltip" title="Editar Campo">
                                                 <i class="bi bi-pencil"></i>
                                             </a>
-                                            <button type="button" class="btn btn-outline-danger" 
-                                                    data-bs-toggle="modal" data-bs-target="#deleteFieldModal{{ campo.id }}"
-                                                    title="Remover Campo">
-                                                <i class="bi bi-trash"></i>
-                                            </button>
-                                        </div>
-                                        
-                                        <!-- Modal para exclusão -->
-                                        <div class="modal fade" id="deleteFieldModal{{ campo.id }}" tabindex="-1" aria-hidden="true">
-                                            <div class="modal-dialog modal-dialog-centered">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title">Confirmar exclusão</h5>
-                                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                    </div>
-                                                    <div class="modal-body">
-                                                        <p>Tem certeza que deseja remover o campo <strong>{{ campo.nome }}</strong>?</p>
-                                                        <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                                        <form action="#" method="POST" class="d-inline">
-                                                            <button type="submit" class="btn btn-danger">Remover Campo</button>
-                                                        </form>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                              <button type="button" class="btn btn-outline-danger"
+                                                      data-bs-toggle="modal" data-bs-target="#deleteFieldModal{{ campo.id }}"
+                                                      title="Remover Campo">
+                                                  <i class="bi bi-trash"></i>
+                                              </button>
+                                          </div>
+                                      </td>
+                                  </tr>
+                                  {% endfor %}
+                              </tbody>
+                          </table>
                     </div>
                     {% else %}
                     <div class="text-center p-4">
@@ -170,9 +148,32 @@
             </div>
         </div>
     </div>
-</div>
+    </div>
 
-<script>
+    {% for campo in template.campos|sort(attribute='ordem') %}
+    <div class="modal fade" id="deleteFieldModal{{ campo.id }}" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirmar exclusão</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Tem certeza que deseja remover o campo <strong>{{ campo.nome }}</strong>?</p>
+                    <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <form action="#" method="POST" class="d-inline">
+                        <button type="submit" class="btn btn-danger">Remover Campo</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+
+    <script>
     // Controle de exibição do campo opções
     document.addEventListener('DOMContentLoaded', function() {
         const tipoSelect = document.getElementById('tipo');

--- a/templates/ministrante/gerenciar_ministrantes.html
+++ b/templates/ministrante/gerenciar_ministrantes.html
@@ -97,45 +97,13 @@
                     <i class="bi bi-pencil"></i>
                   </a>
                   
-                  <button type="button" 
-                          class="btn btn-outline-danger btn-sm" 
-                          data-bs-toggle="modal" 
+                  <button type="button"
+                          class="btn btn-outline-danger btn-sm"
+                          data-bs-toggle="modal"
                           data-bs-target="#deleteModal{{ ministrante.id }}"
                           title="Excluir Ministrante">
                     <i class="bi bi-trash"></i>
                   </button>
-                </div>
-                
-                <!-- Modal de confirmação para exclusão -->
-                <div class="modal fade" id="deleteModal{{ ministrante.id }}" tabindex="-1" aria-hidden="true">
-                  <div class="modal-dialog modal-dialog-centered">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <h5 class="modal-title">Confirmar exclusão</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                      </div>
-                      <div class="modal-body">
-                        <div class="d-flex align-items-center mb-3">
-                          <div class="avatar-circle bg-danger text-white me-3 d-flex align-items-center justify-content-center" style="width: 48px; height: 48px; font-size: 20px;">
-                            {{ ministrante.nome[:1].upper() }}
-                          </div>
-                          <div>
-                            <p class="mb-0">Tem certeza que deseja excluir o ministrante:</p>
-                            <h5 class="mt-1 mb-0">{{ ministrante.nome }}</h5>
-                          </div>
-                        </div>
-                        <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                        <form action="{{ url_for('ministrante_routes.excluir_ministrante', ministrante_id=ministrante.id) }}" method="POST" class="d-inline">
-                          <button type="submit" class="btn btn-danger">
-                            <i class="bi bi-trash me-1"></i> Excluir Ministrante
-                          </button>
-                        </form>
-                      </div>
-                    </div>
-                  </div>
                 </div>
               </td>
             </tr>
@@ -162,6 +130,39 @@
     {% endif %}
   </div>
 </div>
+
+{% for ministrante in ministrantes %}
+<div class="modal fade" id="deleteModal{{ ministrante.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmar exclusão</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex align-items-center mb-3">
+          <div class="avatar-circle bg-danger text-white me-3 d-flex align-items-center justify-content-center" style="width: 48px; height: 48px; font-size: 20px;">
+            {{ ministrante.nome[:1].upper() }}
+          </div>
+          <div>
+            <p class="mb-0">Tem certeza que deseja excluir o ministrante:</p>
+            <h5 class="mt-1 mb-0">{{ ministrante.nome }}</h5>
+          </div>
+        </div>
+        <p class="text-danger"><small>Esta ação não pode ser desfeita.</small></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <form action="{{ url_for('ministrante_routes.excluir_ministrante', ministrante_id=ministrante.id) }}" method="POST" class="d-inline">
+          <button type="submit" class="btn btn-danger">
+            <i class="bi bi-trash me-1"></i> Excluir Ministrante
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endfor %}
 
 <script>
   // Inicializar tooltips


### PR DESCRIPTION
## Summary
- move modal definitions below tables for forms, fields and instructors
- keep unique modal ids referenced by buttons

## Testing
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68613335e33083249bfebc7f88df512d