### PR TITLE
Validate oficina date and time fields

### DIFF
--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -149,6 +149,8 @@ def criar_oficina():
             horarios_fim = request.form.getlist('horario_fim[]')
             if not datas or len(datas) != len(horarios_inicio) or len(datas) != len(horarios_fim):
                 raise ValueError("Datas e horários inconsistentes.")
+            if any(d == '' for d in datas) or any(h == '' for h in horarios_inicio) or any(f == '' for f in horarios_fim):
+                raise ValueError("Todos os campos de data e horário devem ser preenchidos.")
             for i in range(len(datas)):
                 novo_dia = OficinaDia(
                     oficina_id=nova_oficina.id,

--- a/templates/oficina/criar_oficina.html
+++ b/templates/oficina/criar_oficina.html
@@ -640,11 +640,23 @@
         case 3:
           const dataItems = document.querySelectorAll('.data-item');
           const cargaHoraria = document.getElementById('carga_horaria').value;
-          
+
           if (dataItems.length === 0 || !cargaHoraria) {
             alert("Por favor, defina pelo menos uma data e a carga horária.");
             return false;
           }
+
+          for (const item of dataItems) {
+            const dataInput = item.querySelector('input[name="data[]"]');
+            const inicioInput = item.querySelector('input[name="horario_inicio[]"]');
+            const fimInput = item.querySelector('input[name="horario_fim[]"]');
+
+            if (!dataInput.value || !inicioInput.value || !fimInput.value) {
+              alert('Por favor, preencha todas as datas e horários antes de continuar.');
+              return false;
+            }
+          }
+
           return true;
           
         case 4:


### PR DESCRIPTION
## Summary
- enhance step 3 validation in `criar_oficina.html` to ensure every date and time input is filled
- add server-side check in `criar_oficina` route for empty date/time values

## Testing
- `pytest tests/test_oficina_model.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861332fec94832497893d71966fe34a