### PR TITLE
Add event archiving feature

### DIFF
--- a/templates/evento/meus_eventos.html
+++ b/templates/evento/meus_eventos.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% block title %}Meus Eventos{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h2 class="mb-0"><i class="bi bi-calendar-event me-2"></i>Meus Eventos</h2>
+    <a href="{{ url_for('evento_routes.criar_evento') }}" class="btn btn-primary">
+      <i class="bi bi-plus-circle me-1"></i> Novo Evento
+    </a>
+  </div>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+          {{ message }}
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
+        </div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card shadow-sm border-0">
+    <div class="card-body p-0">
+      {% if eventos %}
+      <div class="table-responsive">
+        <table class="table table-hover align-middle mb-0">
+          <thead class="table-dark">
+            <tr>
+              <th>Nome</th>
+              <th>Período</th>
+              <th>Status</th>
+              <th class="text-center">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for ev in eventos %}
+            <tr>
+              <td>{{ ev.nome }}</td>
+              <td>
+                {% if ev.data_inicio %}
+                  {{ ev.data_inicio.strftime('%d/%m/%Y') }}
+                  {% if ev.data_fim %}- {{ ev.data_fim.strftime('%d/%m/%Y') }}{% endif %}
+                {% else %}
+                  <span class="text-muted">A definir</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if ev.status == 'arquivado' %}
+                  <span class="badge bg-secondary">Arquivado</span>
+                {% else %}
+                  <span class="badge bg-success">Ativo</span>
+                {% endif %}
+              </td>
+              <td class="text-center">
+                <div class="btn-group">
+                  {% if ev.status == 'ativo' %}
+                  <a href="{{ url_for('evento_routes.configurar_evento', evento_id=ev.id) }}" class="btn btn-outline-primary btn-sm" title="Editar">
+                    <i class="bi bi-pencil"></i>
+                  </a>
+                  {% endif %}
+                  <form action="{{ url_for('evento_routes.toggle_arquivamento', evento_id=ev.id) }}" method="POST" class="d-inline">
+                    <button type="submit" class="btn btn-outline-danger btn-sm" title="{{ 'Arquivar' if ev.status=='ativo' else 'Reativar' }}">
+                      {% if ev.status == 'ativo' %}<i class="bi bi-archive"></i>{% else %}<i class="bi bi-arrow-counterclockwise"></i>{% endif %}
+                    </button>
+                  </form>
+                </div>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <div class="text-center py-5">
+        <h4 class="text-muted">Nenhum evento cadastrado</h4>
+        <a href="{{ url_for('evento_routes.criar_evento') }}" class="btn btn-primary mt-3">
+          <i class="bi bi-plus-circle me-1"></i> Criar Evento
+        </a>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -55,6 +55,11 @@
                         <i class="bi bi-speedometer2"></i> Dashboard
                     </a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('evento_routes.meus_eventos') }}">
+                        <i class="bi bi-calendar-event"></i> Meus Eventos
+                    </a>
+                </li>
                 {% elif current_user.tipo == 'ministrante' %}
                 <li class="nav-item">
                     <a class="nav-link" href="{{ url_for('dashboard_ministrante_routes.dashboard_ministrante') }}">

--- a/tests/test_evento_arquivar.py
+++ b/tests/test_evento_arquivar.py
@@ -1,0 +1,50 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Usuario, Cliente, Evento
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+        evento = Evento(cliente_id=cliente.id, nome='EV')
+        db.session.add(evento)
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_toggle_arquivamento(client, app):
+    with app.app_context():
+        cliente = Cliente.query.first()
+        evento = Evento.query.first()
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/toggle_arquivamento/{evento.id}', follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Evento.query.get(evento.id).status == 'arquivado'
+    resp = client.post(f'/toggle_arquivamento/{evento.id}', follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Evento.query.get(evento.id).status == 'ativo'


### PR DESCRIPTION
## Summary
- filter archived events from configuration page
- allow archiving/unarchiving events
- link "Meus Eventos" for clients
- display customer events with archive control
- test event archiving toggle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_68612f23c200832482236c39a7e607e0