### PR TITLE
Add locator to trabalhos and review creation helper

### DIFF
--- a/migrations/versions/7715d38d1175_add_locator_to_trabalho_cientifico.py
+++ b/migrations/versions/7715d38d1175_add_locator_to_trabalho_cientifico.py
@@ -1,0 +1,27 @@
+"""add locator column to TrabalhoCientifico
+
+Revision ID: 7715d38d1175
+Revises: fe25f1583d6c
+Create Date: 2025-09-10 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7715d38d1175'
+down_revision = 'fe25f1583d6c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('trabalhos_cientificos') as batch_op:
+        batch_op.add_column(sa.Column('locator', sa.String(length=36), nullable=True))
+        batch_op.create_unique_constraint('uq_trabalhos_cientificos_locator', ['locator'])
+
+
+def downgrade():
+    with op.batch_alter_table('trabalhos_cientificos') as batch_op:
+        batch_op.drop_constraint('uq_trabalhos_cientificos_locator', type_='unique')
+        batch_op.drop_column('locator')

--- a/models.py
+++ b/models.py
@@ -961,6 +961,7 @@ class TrabalhoCientifico(db.Model):
     resumo = db.Column(db.Text, nullable=True)
     arquivo_pdf = db.Column(db.String(255), nullable=True)
     area_tematica = db.Column(db.String(100), nullable=True)
+    locator = db.Column(db.String(36), unique=True, default=lambda: str(uuid.uuid4()))
     status = db.Column(db.String(50), default="submetido")  # Ex: submetido, em avaliação, aceito, rejeitado, revisando
     usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
     evento_id = db.Column(db.Integer, db.ForeignKey('evento.id'), nullable=False)

--- a/routes/dashboard_participante.py
+++ b/routes/dashboard_participante.py
@@ -13,7 +13,7 @@ from models import (
     Usuario, Formulario, RegraInscricaoEvento
 )
 
-dashboard_participante_routes = Bluelogger.debug('dashboard_participante_routes', __name__)
+dashboard_participante_routes = Blueprint('dashboard_participante_routes', __name__)
 
 
 @dashboard_participante_routes.route('/dashboard_participante')

--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -5,6 +5,7 @@ from utils.mfa import mfa_required
 from extensions import db
 from sqlalchemy import or_
 from models import TrabalhoCientifico, AvaliacaoTrabalho, AuditLog, Evento
+import uuid
 import os
 
 trabalho_routes = Blueprint(
@@ -72,6 +73,7 @@ def submeter_trabalho():
             arquivo_pdf=caminho_pdf,
             usuario_id=current_user.id,
             evento_id=evento_id,
+            locator=str(uuid.uuid4()),
         )
         db.session.add(trabalho)
         db.session.commit()

--- a/templates/peer_review/dashboard_editor.html
+++ b/templates/peer_review/dashboard_editor.html
@@ -3,13 +3,21 @@
 <div class="container mt-5">
   <h3>Gestão de Revisões</h3>
   <table class="table table-striped">
-    <thead><tr><th>Título</th><th>Área</th><th>Revisões</th></tr></thead>
+    <thead><tr><th>Título</th><th>Área</th><th>Locator</th><th>Revisões</th><th>Nova Revisão</th></tr></thead>
     <tbody>
     {% for t in trabalhos %}
       <tr>
         <td>{{ t.titulo }}</td>
         <td>{{ t.area_tematica }}</td>
+        <td><code>{{ t.locator }}</code></td>
         <td>{{ t.reviews|length }}</td>
+        <td>
+          <form method="post" action="{{ url_for('peer_review_routes.create_review') }}" class="d-flex">
+            <input type="hidden" name="trabalho_id" value="{{ t.id }}">
+            <input name="reviewer_id" class="form-control form-control-sm me-1" placeholder="ID do revisor" required>
+            <button type="submit" class="btn btn-sm btn-primary">Gerar</button>
+          </form>
+        </td>
       </tr>
     {% endfor %}
     </tbody>

--- a/templates/trabalho/avaliar_trabalhos.html
+++ b/templates/trabalho/avaliar_trabalhos.html
@@ -9,6 +9,7 @@
         <th>Área Temática</th>
         <th>Autor</th>
         <th>Status</th>
+        <th>Locator</th>
         <th>Ação</th>
       </tr>
     </thead>
@@ -19,6 +20,7 @@
         <td>{{ trabalho.area_tematica }}</td>
         <td>{{ trabalho.usuario.nome }}</td>
         <td>{{ trabalho.status }}</td>
+        <td><code>{{ trabalho.locator }}</code></td>
         <td>
           <a href="{{ url_for('trabalho_routes.avaliar_trabalho', trabalho_id=trabalho.id) }}" class="btn btn-primary btn-sm">Avaliar</a>
         </td>

--- a/templates/trabalho/meus_trabalhos.html
+++ b/templates/trabalho/meus_trabalhos.html
@@ -8,6 +8,7 @@
         <th>Título</th>
         <th>Área</th>
         <th>Status</th>
+        <th>Locator</th>
         <th>PDF</th>
       </tr>
     </thead>
@@ -17,6 +18,7 @@
         <td>{{ trabalho.titulo }}</td>
         <td>{{ trabalho.area_tematica }}</td>
         <td>{{ trabalho.status }}</td>
+        <td><code>{{ trabalho.locator }}</code></td>
         <td><a href="{{ url_for('static', filename=trabalho.arquivo_pdf.split('static/')[-1]) }}" target="_blank">Abrir</a></td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- allow assigning unique locators to `TrabalhoCientifico`
- expose single-review creation route in `peer_review_routes`
- store locator when a submission is created
- show locator in participant and admin pages
- add Alembic migration for the new column
- fix blueprint name in `dashboard_participante`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6861944a42848324bdda39ccdb52fc62