### PR TITLE
Add submission control and reviewer login validation

### DIFF
--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -106,7 +106,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <form method="get" action="{{ url_for('peer_review_routes.reviewer_dashboard') }}">
+        <form method="post" action="{{ url_for('peer_review_routes.reviewer_dashboard') }}">
           <div class="mb-3">
             <label for="locatorInput" class="form-label">Localizador</label>
             <input type="text" class="form-control" id="locatorInput" name="locator">

--- a/templates/peer_review/submission_control.html
+++ b/templates/peer_review/submission_control.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block title %}Controle de Submissões{% endblock %}
+{% block content %}
+<div class="container mt-5">
+  <h3 class="mb-4">Controle de Submissões</h3>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Título</th>
+        <th>Localizador</th>
+        <th>Revisores</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sub in submissions %}
+      <tr>
+        <td>{{ sub.title }}</td>
+        <td>{{ sub.locator }}</td>
+        <td>
+          <ul class="mb-0">
+            {% for rev in sub.reviews %}
+            <li>{{ rev.reviewer.nome if rev.reviewer else 'N/A' }} - {{ rev.access_code }}</li>
+            {% else %}
+            <li>Nenhum revisor atribuído</li>
+            {% endfor %}
+          </ul>
+          <button class="btn btn-sm btn-secondary mt-1 gerar-codigos" data-locator="{{ sub.locator }}">Gerar Códigos</button>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('.gerar-codigos').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        const loc = this.dataset.locator;
+        fetch(`/submissions/${loc}/codes`).then(r=>r.json()).then(data=>{
+          if(data.reviews){
+            alert(data.reviews.map(r=>r.access_code).join('\n'));
+          }
+        });
+      });
+    });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- list submissions with reviewer codes
- secure reviewer dashboard with code/locator login
- allow reviewer login from navbar modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861944e21848324836c9a20b0b2f841