### PR TITLE
Display locator after trabalho submission

### DIFF
--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -77,6 +77,7 @@ def submeter_trabalho():
         )
         db.session.add(trabalho)
         db.session.commit()
+        locator = trabalho.locator
 
         # Audit log
         db.session.add(
@@ -88,7 +89,10 @@ def submeter_trabalho():
         )
         db.session.commit()
 
-        flash("Trabalho submetido com sucesso!", "success")
+        flash(
+            f"Trabalho submetido com sucesso! Localizador: {locator}",
+            "success",
+        )
         return redirect(url_for("trabalho_routes.meus_trabalhos"))
 
     return render_template("submeter_trabalho.html", eventos=eventos)

--- a/templates/trabalho/submeter_trabalho.html
+++ b/templates/trabalho/submeter_trabalho.html
@@ -32,6 +32,7 @@
       <input type="file" class="form-control" name="arquivo_pdf" accept="{{ accept_str }}" required>
       <small class="text-muted">Tipos permitidos: {{ tipos }}</small>
     </div>
+    <p class="text-muted small">Após a submissão, um localizador único será exibido para que você consulte seu trabalho.</p>
     <button type="submit" class="btn btn-success">
       <i class="bi bi-upload me-2"></i>Submeter Trabalho
     </button>


### PR DESCRIPTION
## Summary
- keep the locator from new TrabalhoCientifico submissions
- show the generated locator in a flash message
- mention locator information on submission form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68632a0dc6ac8324a504b0b6c0f1ef62