### PR TITLE
Add reviewer application workflow

### DIFF
--- a/models.py
+++ b/models.py
@@ -1269,3 +1269,61 @@ class Assignment(db.Model):
     def __repr__(self):
         return f"<Assignment submission={self.submission_id} reviewer={self.reviewer_id}>"
 
+
+# -----------------------------------------------------------------------------
+# PROCESSO PARA SELEÇÃO DE REVISORES
+# -----------------------------------------------------------------------------
+class RevisorProcess(db.Model):
+    """Configura um processo seletivo de revisores."""
+
+    __tablename__ = "revisor_process"
+
+    id = db.Column(db.Integer, primary_key=True)
+    cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)
+    formulario_id = db.Column(db.Integer, db.ForeignKey("formularios.id"), nullable=True)
+    num_etapas = db.Column(db.Integer, default=1)
+
+    cliente = db.relationship("Cliente", backref=db.backref("revisor_processes", lazy=True))
+    formulario = db.relationship("Formulario")
+
+
+class RevisorEtapa(db.Model):
+    __tablename__ = "revisor_etapa"
+
+    id = db.Column(db.Integer, primary_key=True)
+    process_id = db.Column(db.Integer, db.ForeignKey("revisor_process.id"), nullable=False)
+    numero = db.Column(db.Integer, nullable=False)
+    nome = db.Column(db.String(255), nullable=False)
+    descricao = db.Column(db.Text, nullable=True)
+
+    process = db.relationship("RevisorProcess", backref=db.backref("etapas", lazy=True))
+
+
+class RevisorCandidatura(db.Model):
+    __tablename__ = "revisor_candidatura"
+
+    id = db.Column(db.Integer, primary_key=True)
+    process_id = db.Column(db.Integer, db.ForeignKey("revisor_process.id"), nullable=False)
+    respostas = db.Column(db.JSON, nullable=True)
+    nome = db.Column(db.String(255), nullable=True)
+    email = db.Column(db.String(255), nullable=True)
+    codigo = db.Column(db.String(8), unique=True, default=lambda: str(uuid.uuid4())[:8])
+    etapa_atual = db.Column(db.Integer, default=1)
+    status = db.Column(db.String(50), default="pendente")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    process = db.relationship("RevisorProcess", backref=db.backref("candidaturas", lazy=True))
+
+
+class RevisorCandidaturaEtapa(db.Model):
+    __tablename__ = "revisor_candidatura_etapa"
+
+    id = db.Column(db.Integer, primary_key=True)
+    candidatura_id = db.Column(db.Integer, db.ForeignKey("revisor_candidatura.id"), nullable=False)
+    etapa_id = db.Column(db.Integer, db.ForeignKey("revisor_etapa.id"), nullable=False)
+    status = db.Column(db.String(50), default="pendente")
+    observacoes = db.Column(db.Text, nullable=True)
+
+    candidatura = db.relationship("RevisorCandidatura", backref=db.backref("etapas_status", lazy=True))
+    etapa = db.relationship("RevisorEtapa")
+

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -50,6 +50,7 @@ def register_routes(app):
     from .api_cidades import api_cidades
     from .mercadopago_routes import mercadopago_routes
     from .binary_routes import binary_routes
+    from .revisor_routes import revisor_routes
     from .peer_review_routes import peer_review_routes
     from .submission_routes import submission_routes
     from .util_routes import util_routes
@@ -91,6 +92,7 @@ def register_routes(app):
     app.register_blueprint(api_cidades)
     app.register_blueprint(mercadopago_routes)
     app.register_blueprint(binary_routes)
+    app.register_blueprint(revisor_routes)
     app.register_blueprint(submission_routes)
     app.register_blueprint(util_routes)
     app.register_blueprint(relatorio_pdf_routes)

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -1,0 +1,131 @@
+from flask import Blueprint, request, render_template, redirect, url_for, flash, jsonify
+from flask_login import login_required, current_user
+from werkzeug.security import generate_password_hash
+from werkzeug.utils import secure_filename
+from extensions import db
+from models import (Formulario, CampoFormulario, RevisorProcess, RevisorEtapa,
+                    RevisorCandidatura, RevisorCandidaturaEtapa, Usuario, Assignment, Submission)
+import os
+import uuid
+
+revisor_routes = Blueprint('revisor_routes', __name__, template_folder="../templates/revisor")
+
+
+@revisor_routes.route('/config_revisor', methods=['GET', 'POST'])
+@login_required
+def config_revisor():
+    if current_user.tipo != 'cliente':
+        flash('Acesso negado!', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    processo = RevisorProcess.query.filter_by(cliente_id=current_user.id).first()
+    formularios = Formulario.query.filter_by(cliente_id=current_user.id).all()
+
+    if request.method == 'POST':
+        formulario_id = request.form.get('formulario_id', type=int)
+        num_etapas = request.form.get('num_etapas', type=int, default=1)
+        stage_names = request.form.getlist('stage_name')
+        if not processo:
+            processo = RevisorProcess(cliente_id=current_user.id)
+            db.session.add(processo)
+        processo.formulario_id = formulario_id
+        processo.num_etapas = num_etapas
+        db.session.commit()
+        RevisorEtapa.query.filter_by(process_id=processo.id).delete()
+        for idx, nome in enumerate(stage_names, start=1):
+            if nome:
+                db.session.add(RevisorEtapa(process_id=processo.id, numero=idx, nome=nome))
+        db.session.commit()
+        flash('Processo atualizado', 'success')
+        return redirect(url_for('revisor_routes.config_revisor'))
+
+    etapas = processo.etapas if processo else []
+    return render_template('revisor/config.html', processo=processo, formularios=formularios, etapas=etapas)
+
+
+@revisor_routes.route('/revisor/apply/<int:process_id>', methods=['GET', 'POST'])
+def submit_application(process_id):
+    processo = RevisorProcess.query.get_or_404(process_id)
+    formulario = processo.formulario
+    if not formulario:
+        flash('Formulário não configurado.', 'danger')
+        return redirect(url_for('evento_routes.home'))
+
+    if request.method == 'POST':
+        respostas = {}
+        nome = None
+        email = None
+        for campo in formulario.campos:
+            valor = request.form.get(str(campo.id))
+            if campo.tipo == 'file' and 'file_' + str(campo.id) in request.files:
+                arquivo = request.files['file_' + str(campo.id)]
+                if arquivo.filename:
+                    filename = secure_filename(arquivo.filename)
+                    path = os.path.join('uploads', 'candidaturas', filename)
+                    os.makedirs(os.path.dirname(path), exist_ok=True)
+                    arquivo.save(path)
+                    valor = path
+            respostas[campo.nome] = valor
+            low = campo.nome.lower()
+            if low == 'nome':
+                nome = valor
+            if low == 'email':
+                email = valor
+        candidatura = RevisorCandidatura(
+            process_id=process_id,
+            respostas=respostas,
+            nome=nome,
+            email=email,
+        )
+        db.session.add(candidatura)
+        db.session.commit()
+        flash(f'Seu código: {candidatura.codigo}', 'success')
+        return redirect(url_for('revisor_routes.progress', codigo=candidatura.codigo))
+
+    return render_template('revisor/candidatura_form.html', formulario=formulario)
+
+
+@revisor_routes.route('/revisor/progress/<codigo>')
+def progress(codigo):
+    cand = RevisorCandidatura.query.filter_by(codigo=codigo).first_or_404()
+    return render_template('revisor/progress.html', candidatura=cand)
+
+
+@revisor_routes.route('/revisor/progress')
+def progress_query():
+    codigo = request.args.get('codigo')
+    if codigo:
+        return redirect(url_for('revisor_routes.progress', codigo=codigo))
+    return redirect(url_for('evento_routes.home'))
+
+
+@revisor_routes.route('/revisor/approve/<int:cand_id>', methods=['POST'])
+@login_required
+def approve(cand_id):
+    if current_user.tipo not in ('cliente', 'admin', 'superadmin'):
+        return jsonify({'success': False}), 403
+    cand = RevisorCandidatura.query.get_or_404(cand_id)
+    cand.status = 'aprovado'
+    cand.etapa_atual = cand.process.num_etapas
+    reviewer = Usuario.query.filter_by(email=cand.email).first()
+    if not reviewer:
+        reviewer = Usuario(
+            nome=cand.nome or cand.email,
+            cpf=str(uuid.uuid4()),
+            email=cand.email,
+            senha=generate_password_hash('temp123'),
+            formacao='',
+            tipo='revisor'
+        )
+        db.session.add(reviewer)
+    else:
+        reviewer.tipo = 'revisor'
+    submission_id = None
+    if request.is_json:
+        submission_id = request.json.get('submission_id')
+    else:
+        submission_id = request.form.get('submission_id', type=int)
+    if submission_id:
+        db.session.add(Assignment(submission_id=submission_id, reviewer_id=reviewer.id))
+    db.session.commit()
+    return jsonify({'success': True, 'reviewer_id': reviewer.id})

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -117,6 +117,15 @@
           </div>
           <button type="submit" class="btn btn-primary">Entrar</button>
         </form>
+        <hr class="my-3">
+        <a class="btn btn-outline-success w-100 mb-2" href="{{ url_for('revisor_routes.submit_application', process_id=1) }}">Quero ser revisor</a>
+        <form method="get" action="{{ url_for('revisor_routes.progress_query') }}">
+          <div class="mb-3">
+            <label for="codigoAcomp" class="form-label">Código da Candidatura</label>
+            <input type="text" class="form-control" id="codigoAcomp" name="codigo">
+          </div>
+          <button type="submit" class="btn btn-secondary">Acompanhar</button>
+        </form>
       </div>
     </div>
   </div>

--- a/templates/revisor/candidatura_form.html
+++ b/templates/revisor/candidatura_form.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container py-5">
+    <div class="card shadow-sm border-0 rounded-lg">
+        <div class="card-header bg-primary text-white">
+            <h2 class="mb-0 fs-4">{{ formulario.nome }}</h2>
+        </div>
+        <div class="card-body">
+            <div class="alert alert-info mb-4">
+                <i class="bi bi-info-circle me-2"></i>{{ formulario.descricao }}
+            </div>
+            <form method="POST" enctype="multipart/form-data">
+                {% for campo in formulario.campos %}
+                <div class="mb-4">
+                    <label class="form-label fw-bold" for="campo-{{ campo.id }}">
+                        {{ campo.nome }}{% if campo.obrigatorio %}<span class="text-danger">*</span>{% endif %}
+                    </label>
+                    <div class="form-field-container">
+                        {% if campo.tipo == 'text' %}
+                        <input type="text" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+                        {% elif campo.tipo == 'textarea' %}
+                        <textarea id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" rows="4" {% if campo.obrigatorio %}required{% endif %}></textarea>
+                        {% elif campo.tipo == 'number' %}
+                        <input type="number" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+                        {% elif campo.tipo == 'file' %}
+                        <input type="file" id="campo-{{ campo.id }}" name="file_{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+                        {% elif campo.tipo == 'date' %}
+                        <input type="date" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
+                        {% elif campo.tipo == 'dropdown' %}
+                        <select id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-select" {% if campo.obrigatorio %}required{% endif %}>
+                            <option value="" disabled selected>Selecione uma opção</option>
+                            {% for opcao in campo.opcoes.split(',') %}
+                            <option value="{{ opcao.strip() }}">{{ opcao.strip() }}</option>
+                            {% endfor %}
+                        </select>
+                        {% endif %}
+                    </div>
+                </div>
+                {% endfor %}
+                <div class="d-grid gap-2 d-md-flex mt-5">
+                    <a href="{{ url_for('evento_routes.home') }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-left me-1"></i>Voltar
+                    </a>
+                    <button type="submit" class="btn btn-primary ms-auto">
+                        <i class="bi bi-check-circle me-1"></i>Enviar Formulário
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Processo de Revisores{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h3 mb-4">Configurar Processo de Revisores</h1>
+  <form method="post">
+    <div class="mb-3">
+      <label class="form-label">Formulário</label>
+      <select class="form-select" name="formulario_id">
+        {% for f in formularios %}
+        <option value="{{ f.id }}" {% if processo and f.id == processo.formulario_id %}selected{% endif %}>{{ f.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Número de Etapas</label>
+      <input type="number" class="form-control" name="num_etapas" value="{{ processo.num_etapas if processo else 1 }}">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Nomes das Etapas</label>
+      {% set total = processo.num_etapas if processo else 1 %}
+      {% for i in range(total) %}
+      <input type="text" class="form-control mb-2" name="stage_name" value="{{ etapas[i].nome if etapas|length > i else '' }}">
+      {% endfor %}
+    </div>
+    <button type="submit" class="btn btn-primary">Salvar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/revisor/progress.html
+++ b/templates/revisor/progress.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Acompanhamento{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Acompanhamento da Candidatura</h1>
+  <p><strong>Status geral:</strong> {{ candidatura.status }}</p>
+  <table class="table table-striped">
+    <thead>
+      <tr><th>Etapa</th><th>Status</th></tr>
+    </thead>
+    <tbody>
+      {% for est in candidatura.etapas_status %}
+      <tr><td>{{ est.etapa.nome }}</td><td>{{ est.status }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -1,0 +1,89 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from flask import Flask
+from extensions import db, login_manager
+
+from models import (Cliente, Formulario, CampoFormulario, RevisorProcess,
+                    RevisorCandidatura, Usuario, Submission, Assignment)
+from routes.auth_routes import auth_routes
+from routes.revisor_routes import revisor_routes
+from routes.submission_routes import submission_routes
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options('sqlite://')
+    login_manager.init_app(app)
+    db.init_app(app)
+
+    app.register_blueprint(auth_routes)
+    app.register_blueprint(revisor_routes)
+    app.register_blueprint(submission_routes)
+
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+        form = Formulario(nome='Cand', cliente_id=cliente.id)
+        db.session.add(form)
+        db.session.commit()
+        campo_email = CampoFormulario(formulario_id=form.id, nome='email', tipo='text')
+        campo_nome = CampoFormulario(formulario_id=form.id, nome='nome', tipo='text')
+        db.session.add_all([campo_email, campo_nome])
+        db.session.commit()
+        proc = RevisorProcess(cliente_id=cliente.id, formulario_id=form.id, num_etapas=1)
+        db.session.add(proc)
+        db.session.commit()
+        sub = Submission(title='T', locator='loc', code_hash='x')
+        db.session.add(sub)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_application_and_approval_flow(client, app):
+    with app.app_context():
+        proc = RevisorProcess.query.first()
+        campos = {c.nome: c.id for c in proc.formulario.campos}
+        sub = Submission.query.first()
+
+    resp = client.post(f'/revisor/apply/{proc.id}', data={str(campos['email']): 'rev@test', str(campos['nome']): 'Rev'})
+    assert resp.status_code in (302, 200)
+
+    with app.app_context():
+        cand = RevisorCandidatura.query.first()
+        assert cand.email == 'rev@test'
+        cand_id = cand.id
+        code = cand.codigo
+
+    resp = client.get(f'/revisor/progress/{code}')
+    assert resp.status_code == 200
+
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/revisor/approve/{cand_id}', json={'submission_id': sub.id})
+    assert resp.status_code == 200
+    assert resp.get_json()['success']
+
+    with app.app_context():
+        cand = RevisorCandidatura.query.get(cand_id)
+        assert cand.status == 'aprovado'
+        user = Usuario.query.filter_by(email='rev@test').first()
+        assert user and user.tipo == 'revisor'
+        ass = Assignment.query.filter_by(submission_id=sub.id, reviewer_id=user.id).first()
+        assert ass is not None


### PR DESCRIPTION
## Summary
- define models to manage reviewer selection processes
- implement revisor_routes blueprint
- update navbar with reviewer application links
- add templates for configuring process, applying and progress tracking
- cover reviewer application and approval in tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement cloud-init==24.4)*
- `pytest -q` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68632e4341cc8324b7f55b66d7cab4bd