### PR TITLE
Add reviewer application dashboard

### DIFF
--- a/migrations/versions/f123456789ab_add_reviewer_application_table.py
+++ b/migrations/versions/f123456789ab_add_reviewer_application_table.py
@@ -1,0 +1,28 @@
+"""add reviewer application table
+
+Revision ID: f123456789ab
+Revises: fe25f1583d6c
+Create Date: 2025-10-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'f123456789ab'
+down_revision = 'fe25f1583d6c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'reviewer_application',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('usuario_id', sa.Integer(), nullable=False),
+        sa.Column('stage', sa.String(length=50), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('reviewer_application')

--- a/models.py
+++ b/models.py
@@ -1269,3 +1269,21 @@ class Assignment(db.Model):
     def __repr__(self):
         return f"<Assignment submission={self.submission_id} reviewer={self.reviewer_id}>"
 
+
+# -----------------------------------------------------------------------------
+# REVIEWER APPLICATION
+# -----------------------------------------------------------------------------
+class ReviewerApplication(db.Model):
+    """Candidatura de usuário para atuar como revisor."""
+
+    __tablename__ = 'reviewer_application'
+
+    id = db.Column(db.Integer, primary_key=True)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    stage = db.Column(db.String(50), default='novo')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    usuario = db.relationship('Usuario', backref=db.backref('reviewer_applications', lazy=True))
+
+    def __repr__(self):
+        return f"<ReviewerApplication usuario={self.usuario_id} stage={self.stage}>"

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -82,6 +82,12 @@
             <i class="bi bi-cash-coin me-1"></i> Financeiro
           </button>
         </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="revisores-tab" data-bs-toggle="tab"
+                  data-bs-target="#revisores" type="button">
+            <i class="bi bi-people-fill me-1"></i> Revisores
+          </button>
+        </li>
       </ul>
 
       <!-- Conteúdo das Abas -->
@@ -1419,6 +1425,40 @@
     {% include 'partials/dashboard_financeiro_aba.html' %}
   </div>
   <!-- /ABA 5: FINANCEIRO -->
+  <!-- ABA 6: REVISORES -->
+  <div class="tab-pane fade" id="revisores" role="tabpanel">
+    <h5 class="fw-bold mb-3">Candidaturas de Revisores</h5>
+    <table class="table table-sm">
+      <thead>
+        <tr><th>Usuário</th><th>Status</th><th>Ações</th></tr>
+      </thead>
+      <tbody>
+        {% for app in reviewer_apps %}
+        <tr>
+          <td>{{ app.usuario.nome }}</td>
+          <td>{{ app.stage }}</td>
+          <td>
+            <form method="post" action="{{ url_for('dashboard_routes.update_reviewer_application', app_id=app.id) }}" class="d-inline">
+              <input type="hidden" name="action" value="advance">
+              <button class="btn btn-sm btn-primary">Avançar</button>
+            </form>
+            <form method="post" action="{{ url_for('dashboard_routes.update_reviewer_application', app_id=app.id) }}" class="d-inline ms-1">
+              <input type="hidden" name="action" value="approve">
+              <button class="btn btn-sm btn-success">Aprovar</button>
+            </form>
+            <form method="post" action="{{ url_for('dashboard_routes.update_reviewer_application', app_id=app.id) }}" class="d-inline ms-1">
+              <input type="hidden" name="action" value="reject">
+              <button class="btn btn-sm btn-danger">Rejeitar</button>
+            </form>
+          </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">Nenhuma candidatura.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <!-- /ABA 6: REVISORES -->
 <!-- Mantendo a integração com o script original sem modificações -->
 <!-- Javascript com ícones e labels melhorados -->
 

--- a/tests/test_reviewer_applications.py
+++ b/tests/test_reviewer_applications.py
@@ -1,0 +1,72 @@
+import sys
+import types
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+# Stubs to avoid optional deps
+mercadopago_stub = types.ModuleType('mercadopago')
+mercadopago_stub.SDK = lambda *a, **k: None
+sys.modules.setdefault('mercadopago', mercadopago_stub)
+utils_stub = types.ModuleType('utils')
+taxa_service = types.ModuleType('utils.taxa_service')
+taxa_service.calcular_taxa_cliente = lambda *a, **k: {'taxa_aplicada': 0, 'usando_taxa_diferenciada': False}
+taxa_service.calcular_taxas_clientes = lambda *a, **k: []
+utils_stub.taxa_service = taxa_service
+sys.modules.setdefault('utils', utils_stub)
+sys.modules.setdefault('utils.taxa_service', taxa_service)
+
+from app import create_app
+from extensions import db, login_manager
+from models import Usuario, Cliente, ReviewerApplication
+from routes.auth_routes import auth_routes
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
+        user = Usuario(nome='User', cpf='2', email='user@test', senha=generate_password_hash('123'), formacao='x')
+        db.session.add_all([cliente, admin, user])
+        db.session.commit()
+        db.session.add(ReviewerApplication(usuario_id=user.id))
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_dashboard_applications_visible_for_cliente(client, app):
+    login(client, 'cli@test', '123')
+    resp = client.get('/dashboard_cliente')
+    assert resp.status_code == 200
+    assert b'User' in resp.data
+
+
+def test_update_application_requires_permission(client, app):
+    with app.app_context():
+        rid = ReviewerApplication.query.first().id
+
+    login(client, 'user@test', '123')
+    resp = client.post(f'/reviewer_applications/{rid}', data={'action': 'advance'}, follow_redirects=True)
+    assert b'dashboard' in resp.data
+    with app.app_context():
+        assert ReviewerApplication.query.get(rid).stage == 'novo'
+
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/reviewer_applications/{rid}', data={'action': 'advance'}, follow_redirects=True)
+    assert resp.status_code in (200, 302)
+    with app.app_context():
+        assert ReviewerApplication.query.get(rid).stage == 'triagem'


### PR DESCRIPTION
## Summary
- model reviewer applications
- list reviewer applications in client dashboard
- add route to update reviewer application stage
- migration for reviewer_application table
- tests for reviewer application permissions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68632e4641d883249f0ce346f2ebcc22