### PR TITLE
Add RevisorProcess scheduling fields

### DIFF
--- a/models.py
+++ b/models.py
@@ -1283,6 +1283,11 @@ class RevisorProcess(db.Model):
     formulario_id = db.Column(db.Integer, db.ForeignKey("formularios.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
 
+    titulo = db.Column(db.String(255), nullable=True)
+    data_inicio = db.Column(db.DateTime, nullable=True)
+    data_fim = db.Column(db.DateTime, nullable=True)
+    exibir_participantes = db.Column(db.Boolean, default=False)
+
     cliente = db.relationship("Cliente", backref=db.backref("revisor_processes", lazy=True))
     formulario = db.relationship("Formulario")
 

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -3,6 +3,7 @@ from flask_login import login_required, current_user
 from werkzeug.security import generate_password_hash
 from werkzeug.utils import secure_filename
 from extensions import db
+from datetime import datetime
 from models import (Formulario, CampoFormulario, RevisorProcess, RevisorEtapa,
                     RevisorCandidatura, RevisorCandidaturaEtapa, Usuario, Assignment, Submission)
 import os
@@ -32,11 +33,34 @@ def config_revisor():
         formulario_id = request.form.get('formulario_id', type=int)
         num_etapas = request.form.get('num_etapas', type=int, default=1)
         stage_names = request.form.getlist('stage_name')
+        titulo = request.form.get('titulo')
+        data_inicio_raw = request.form.get('data_inicio')
+        data_fim_raw = request.form.get('data_fim')
+        exibir_val = request.form.get('exibir_participantes')
+        exibir_participantes = exibir_val in ['on', '1', 'true']
+
+        data_inicio = None
+        if data_inicio_raw:
+            try:
+                data_inicio = datetime.strptime(data_inicio_raw, '%Y-%m-%d')
+            except ValueError:
+                data_inicio = None
+
+        data_fim = None
+        if data_fim_raw:
+            try:
+                data_fim = datetime.strptime(data_fim_raw, '%Y-%m-%d')
+            except ValueError:
+                data_fim = None
         if not processo:
             processo = RevisorProcess(cliente_id=current_user.id)
             db.session.add(processo)
         processo.formulario_id = formulario_id
         processo.num_etapas = num_etapas
+        processo.titulo = titulo
+        processo.data_inicio = data_inicio
+        processo.data_fim = data_fim
+        processo.exibir_participantes = exibir_participantes
         db.session.commit()
         RevisorEtapa.query.filter_by(process_id=processo.id).delete()
         for idx, nome in enumerate(stage_names, start=1):

--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -5,6 +5,24 @@
   <h1 class="h3 mb-4">Configurar Processo de Revisores</h1>
   <form method="post">
     <div class="mb-3">
+      <label class="form-label">Título</label>
+      <input type="text" class="form-control" name="titulo" value="{{ processo.titulo if processo else '' }}">
+    </div>
+    <div class="row">
+      <div class="col-md-6 mb-3">
+        <label class="form-label">Data de Início</label>
+        <input type="date" class="form-control" name="data_inicio" value="{{ processo.data_inicio.strftime('%Y-%m-%d') if processo and processo.data_inicio else '' }}">
+      </div>
+      <div class="col-md-6 mb-3">
+        <label class="form-label">Data de Término</label>
+        <input type="date" class="form-control" name="data_fim" value="{{ processo.data_fim.strftime('%Y-%m-%d') if processo and processo.data_fim else '' }}">
+      </div>
+    </div>
+    <div class="form-check form-switch mb-3">
+      <input type="checkbox" class="form-check-input" id="exibir_participantes" name="exibir_participantes" {% if processo and processo.exibir_participantes %}checked{% endif %}>
+      <label class="form-check-label" for="exibir_participantes">Exibir para participantes?</label>
+    </div>
+    <div class="mb-3">
       <label class="form-label">Formulário</label>
       <select class="form-select" name="formulario_id">
         {% for f in formularios %}


### PR DESCRIPTION
## Summary
- allow configuring reviewer process title, dates and visibility
- save the new fields when submitting the config form

## Testing
- `python -m py_compile models.py routes/revisor_routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6863429be6d483248b59c4871ed9f3f1