### PR TITLE
Add availability fields to RevisorProcess

### DIFF
--- a/migrations/versions/28df0170395a_extend_revisor_process.py
+++ b/migrations/versions/28df0170395a_extend_revisor_process.py
@@ -1,0 +1,40 @@
+"""extend RevisorProcess with new columns
+
+Revision ID: 28df0170395a
+Revises: 26243c055ce7, f123456789ab
+Create Date: 2025-10-10 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "28df0170395a"
+down_revision = ("26243c055ce7", "f123456789ab")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("revisor_process", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("titulo", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("inicio_disponibilidade", sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column("fim_disponibilidade", sa.DateTime(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "exibir_para_participantes",
+                sa.Boolean(),
+                nullable=True,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("revisor_process", schema=None) as batch_op:
+        batch_op.drop_column("exibir_para_participantes")
+        batch_op.drop_column("fim_disponibilidade")
+        batch_op.drop_column("inicio_disponibilidade")
+        batch_op.drop_column("titulo")
+

--- a/models.py
+++ b/models.py
@@ -1282,9 +1282,16 @@ class RevisorProcess(db.Model):
     cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)
     formulario_id = db.Column(db.Integer, db.ForeignKey("formularios.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
+    titulo = db.Column(db.String(255), nullable=True)
+    inicio_disponibilidade = db.Column(db.DateTime, nullable=True)
+    fim_disponibilidade = db.Column(db.DateTime, nullable=True)
+    exibir_para_participantes = db.Column(db.Boolean, default=False)
 
     cliente = db.relationship("Cliente", backref=db.backref("revisor_processes", lazy=True))
     formulario = db.relationship("Formulario")
+
+    def __repr__(self):
+        return f"<RevisorProcess id={self.id} titulo={self.titulo}>"
 
 
 class RevisorEtapa(db.Model):


### PR DESCRIPTION
## Summary
- extend `RevisorProcess` with title, availability and visibility fields
- add `__repr__` for the model
- create Alembic migration for the new columns

## Testing
- `pytest -q` *(fails: werkzeug routing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863429a277c8324bb413f9864dc693d