### PR TITLE
Implement reviewer process selection page

### DIFF
--- a/migrations/versions/0cefe1a160c4_add_window_to_revisor_process.py
+++ b/migrations/versions/0cefe1a160c4_add_window_to_revisor_process.py
@@ -1,0 +1,26 @@
+"""add availability window to RevisorProcess
+
+Revision ID: 0cefe1a160c4
+Revises: f123456789ab
+Create Date: 2025-10-05 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0cefe1a160c4'
+down_revision = 'f123456789ab'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('revisor_process') as batch_op:
+        batch_op.add_column(sa.Column('data_inicio', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('data_fim', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('revisor_process') as batch_op:
+        batch_op.drop_column('data_fim')
+        batch_op.drop_column('data_inicio')

--- a/models.py
+++ b/models.py
@@ -1282,9 +1282,19 @@ class RevisorProcess(db.Model):
     cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)
     formulario_id = db.Column(db.Integer, db.ForeignKey("formularios.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
+    data_inicio = db.Column(db.DateTime, nullable=True)
+    data_fim = db.Column(db.DateTime, nullable=True)
 
     cliente = db.relationship("Cliente", backref=db.backref("revisor_processes", lazy=True))
     formulario = db.relationship("Formulario")
+
+    def is_available(self):
+        now = datetime.utcnow()
+        if self.data_inicio and now < self.data_inicio:
+            return False
+        if self.data_fim and now > self.data_fim:
+            return False
+        return True
 
 
 class RevisorEtapa(db.Model):

--- a/templates/revisor/select_event.html
+++ b/templates/revisor/select_event.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}Processo Seletivo{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h3 mb-4">Processo Seletivo de Revisores</h1>
+  {% if eventos %}
+  <div class="row g-4">
+    {% for item in eventos %}
+    <div class="col-md-6">
+      <div class="card h-100 shadow-sm">
+        <div class="card-header bg-primary text-white">
+          {{ item.evento.nome }}
+        </div>
+        <div class="card-body">
+          <p class="mb-1"><strong>Período:</strong>
+            {% if item.evento.data_inicio %}{{ item.evento.data_inicio.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %}
+            a
+            {% if item.evento.data_fim %}{{ item.evento.data_fim.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %}
+          </p>
+          <p class="mb-1"><strong>Status do processo:</strong> {{ item.status }}</p>
+        </div>
+        <div class="card-footer bg-white border-0">
+          <a href="{{ url_for('revisor_routes.submit_application', process_id=item.processo.id) }}" class="btn btn-success w-100">Participar do processo seletivo</a>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="alert alert-info">
+    Nenhum evento com seleção de revisores disponível no momento.
+    <a href="{{ url_for('evento_routes.home') }}" class="alert-link">Voltar para a página inicial</a>.
+  </div>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow reviewer process to have availability window
- show selectable events with open reviewer processes
- expose `/processo_seletivo` route for reviewers to pick an event

## Testing
- `pytest tests/test_revisor_process.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6863429f4b84832497fdb71305414e0e