### PR TITLE
Update revisor process availability checks

### DIFF
--- a/models.py
+++ b/models.py
@@ -1282,6 +1282,10 @@ class RevisorProcess(db.Model):
     cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)
     formulario_id = db.Column(db.Integer, db.ForeignKey("formularios.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
+    # Novos campos para controlar disponibilidade do processo
+    availability_start = db.Column(db.DateTime, nullable=True)
+    availability_end = db.Column(db.DateTime, nullable=True)
+    exibir_para_participantes = db.Column(db.Boolean, default=False)
 
     cliente = db.relationship("Cliente", backref=db.backref("revisor_processes", lazy=True))
     formulario = db.relationship("Formulario")

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -166,11 +166,7 @@
             Quero ser revisor
           </a>
         {% else %}
-          {# Fallback para process_id=1 caso a variável não exista #}
-          <a class="btn btn-outline-success w-100 mb-2"
-             href="{{ url_for('revisor_routes.submit_application', process_id=1) }}">
-            Quero ser revisor
-          </a>
+          <p class="text-muted text-center">Processo indisponível</p>
         {% endif %}
 
         <form method="get" action="{{ url_for('revisor_routes.progress_query') }}">


### PR DESCRIPTION
## Summary
- add availability and visibility fields to `RevisorProcess`
- filter revisor process in context processor based on current date
- hide revisor registration when process is unavailable
- test navbar behaviour for unavailable processes

## Testing
- `pytest tests/test_revisor_process.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686342a043288324b357dbbc24dcaa0e