### PR TITLE
Remove obsolete title field from revisor process

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -80,7 +80,6 @@ def config_revisor():
         formulario_id = request.form.get("formulario_id", type=int)
         num_etapas = request.form.get("num_etapas", type=int, default=1)
         stage_names: List[str] = request.form.getlist("stage_name")
-        titulo = request.form.get("titulo")
         start_raw = request.form.get("availability_start")
         end_raw = request.form.get("availability_end")
         exibir_val = request.form.get("exibir_participantes")
@@ -103,7 +102,6 @@ def config_revisor():
 
         processo.formulario_id = formulario_id
         processo.num_etapas = num_etapas
-        processo.titulo = titulo
         processo.availability_start = start_dt
         processo.availability_end = end_dt
         processo.exibir_para_participantes = exibir_para_participantes

--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -4,10 +4,6 @@
 <div class="container py-4">
   <h1 class="h3 mb-4">Configurar Processo de Revisores</h1>
   <form method="post">
-    <div class="mb-3">
-      <label class="form-label">Título</label>
-      <input type="text" class="form-control" name="titulo" value="{{ processo.titulo if processo else '' }}">
-    </div>
     <div class="row">
       <div class="col-md-6 mb-3">
         <label class="form-label">Data de Início</label>

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -117,7 +117,6 @@ def test_config_route_saves_availability(client, app):
                     'formulario_id': formulario.id,
                     'num_etapas': 1,
                     'stage_name': ['Etapa 1'],
-                    'titulo': 'Proc',
                     'availability_start': start.strftime('%Y-%m-%d'),
                     'availability_end': end.strftime('%Y-%m-%d'),
                     'exibir_participantes': 'on',


### PR DESCRIPTION
## Summary
- remove 'Título' field from reviewer config form
- drop unused title field handling in `revisor_routes`
- update tests accordingly

## Testing
- `pytest -q` *(fails: 17 failed, 39 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6863ef4b25a08324b20ed5ec3b03e4bc