### PR TITLE
Add data labels to campos obrigatorios toggles

### DIFF
--- a/static/css/dashboard_cliente.css
+++ b/static/css/dashboard_cliente.css
@@ -173,13 +173,13 @@
       
       /* Botões de alternância (toggle) */
 .btn-toggle {
-  min-width: 120px;
+  min-width: 150px;
   padding: 0.5rem 1rem;
 }
 
 /* Versão pequena dos botões de alternância */
 .btn-toggle.btn-sm {
-  min-width: 60px;
+  min-width: 120px;
   padding: 0.25rem 0.5rem;
 }
       

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -263,14 +263,15 @@ document.addEventListener('DOMContentLoaded', function() {
 // Funções auxiliares
 function atualizarBotao(btn, valorAtivo) {
   if (!btn) return;
+  const label = btn.dataset.label;
   if (valorAtivo) {
     btn.classList.remove("btn-danger", "btn-outline-danger");
     btn.classList.add("btn-success");
-    btn.textContent = "Ativo";
+    btn.textContent = label ? `${label} - Ativo` : "Ativo";
   } else {
     btn.classList.remove("btn-success", "btn-outline-success");
     btn.classList.add("btn-danger");
-    btn.textContent = "Desativado";
+    btn.textContent = label ? `${label} - Desativado` : "Desativado";
   }
 }
 

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -982,11 +982,11 @@
                   </h6>
                 </div>
                   <div class="d-flex gap-2">
-                    <button type="button" id="btnToggleObrigatorioNome" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_nome else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_nome') }}">Nome</button>
-                    <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_cpf else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_cpf') }}">CPF</button>
-                    <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_email else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_email') }}">Email</button>
-                    <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_senha else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_senha') }}">Senha</button>
-                    <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_formacao else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_formacao') }}">Formação</button>
+                    <button type="button" id="btnToggleObrigatorioNome" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_nome else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_nome') }}" data-label="Nome">Nome</button>
+                    <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_cpf else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_cpf') }}" data-label="CPF">CPF</button>
+                    <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_email else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_email') }}" data-label="Email">Email</button>
+                    <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_senha else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_senha') }}" data-label="Senha">Senha</button>
+                    <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-padrao btn-sm btn-toggle btn-{{ 'success' if config_cliente and config_cliente.obrigatorio_formacao else 'danger' }}" data-toggle-url="{{ url_for('config_cliente_routes.toggle_obrigatorio_formacao') }}" data-label="Formação">Formação</button>
                   </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- enhance Campos Obrigatórios buttons with `data-label` attributes
- update button toggling to show label and state
- widen toggle buttons for longer text

## Testing
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6863f831b5c8832499250af26e083d5f