### PR TITLE
Show reviewer code in progress page

### DIFF
--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -148,14 +148,6 @@
           <button type="submit" class="btn btn-primary">Entrar</button>
         </form>
 
-        <!-- Registro opcional de novos revisores -->
-        {% if show_reviewer_registration %}
-          <div class="mt-3">
-            <a class="btn btn-outline-secondary w-100" href="{{ url_for('peer_review_routes.reviewer_registration') }}">
-              Inscrever-se como revisor
-            </a>
-          </div>
-        {% endif %}
 
         <!-- Candidatura ou acompanhamento -->
         <hr class="my-4">

--- a/templates/revisor/progress.html
+++ b/templates/revisor/progress.html
@@ -3,6 +3,7 @@
 {% block content %}
 <div class="container py-5">
   <h1 class="mb-4">Acompanhamento da Candidatura</h1>
+  <p><strong>Código da candidatura:</strong> {{ candidatura.codigo }}</p>
   <p><strong>Status geral:</strong> {{ candidatura.status }}</p>
   <table class="table table-striped">
     <thead>

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -130,6 +130,7 @@ def test_application_and_approval_flow(client, app):
 
     resp = client.get(f"/revisor/progress/{code}")
     assert resp.status_code == 200
+    assert code in resp.get_data(as_text=True)
 
     login(client, "cli@test", "123")
     resp = client.post(f"/revisor/approve/{cand_id}", json={})
@@ -149,6 +150,12 @@ def test_navbar_shows_correct_process_id(app):
     with app.test_request_context("/"):
         html = render_template("partials/navbar.html")
     assert "/processo_seletivo" in html
+
+
+def test_navbar_without_reviewer_registration_link(app):
+    with app.test_request_context("/"):
+        html = render_template("partials/navbar.html")
+    assert "Inscrever-se como revisor" not in html
 
 
 def test_navbar_shows_link_when_unavailable(app):


### PR DESCRIPTION
## Summary
- remove reviewer registration link from navbar
- show candidacy code on progress page
- cover navbar changes in tests

## Testing
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6864107a76dc8324ab48b3ebc7b06099