### PR TITLE
Display client name in reviewer events

### DIFF
--- a/templates/revisor/select_event.html
+++ b/templates/revisor/select_event.html
@@ -12,6 +12,7 @@
           {{ item.evento.nome }}
         </div>
         <div class="card-body">
+          <p class="mb-1"><strong>Cliente:</strong> {{ item.evento.cliente.nome }}</p>
           <p class="mb-1"><strong>Período:</strong>
             {% if item.evento.data_inicio %}{{ item.evento.data_inicio.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %}
             a


### PR DESCRIPTION
## Summary
- show the client's name alongside each event option in the reviewer sign‑up page

## Testing
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686412367ad48324ada6683bdb8c89b1