### PR TITLE
Mark free registrations as paid

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -178,6 +178,7 @@ def cadastro_participante(identifier: str | None = None):
                 db.session.commit()
                 return redirect(url_pagamento)
 
+            inscricao.status_pagamento = "approved"
             db.session.commit()
             flash("Inscrição realizada com sucesso!", "success")
             return redirect(url_for("auth_routes.login"))
@@ -719,6 +720,7 @@ def inscrever(oficina_id):
                     })
             
         # Se chegou aqui, é porque a inscrição é gratuita ou não precisa de pagamento
+        inscricao.status_pagamento = "approved"
         db.session.commit()
 
         # Gera o comprovante


### PR DESCRIPTION
## Summary
- auto-approve payment status for free participant registrations
- auto-approve payment status for free workshop signups

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 17 failed, 40 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686421c6b7f083248dfca19875a80037