### PR TITLE
Add message for empty schedule

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -76,6 +76,12 @@
             </h2>
 
             <div class="schedule-container">
+                {% if not sorted_keys %}
+                <div class="empty-message">
+                    <i class="fas fa-info-circle"></i>
+                    <p>Nenhuma atividade cadastrada.</p>
+                </div>
+                {% else %}
                 {% for data_str in sorted_keys %}
                 <div class="day-schedule">
                     <h3 class="day-title">{{ data_str }}</h3>
@@ -125,6 +131,7 @@
                     </div>
                 </div>
                 {% endfor %}
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- show an empty message when no activities exist in event schedule

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: BuildError: Could not build url for endpoint 'routes.gerar_folder_evento' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68644249b2488324b09a040b24e62277