### PR TITLE
Fix default profile image references

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -99,8 +99,8 @@
                                 {% if item.ministrante or (item.oficina and item.oficina.ministrantes_associados) %}
                                 <div class="speakers-container">
                                     {% if item.ministrante %}
-                                    <div class="speaker-card" onclick="openSpeakerModal('{{ item.ministrante.nome }}', '{{ item.ministrante.formacao }}', '{{ url_for('static', filename=item.ministrante.foto or 'uploads/ministrantes/default-profile.png') }}')">
-                                        <img src="{{ url_for('static', filename=item.ministrante.foto or 'uploads/ministrantes/default-profile.png') }}" 
+                                    <div class="speaker-card" onclick="openSpeakerModal('{{ item.ministrante.nome }}', '{{ item.ministrante.formacao }}', '{{ url_for('static', filename=item.ministrante.foto or 'default-profile.png') }}')">
+                                        <img src="{{ url_for('static', filename=item.ministrante.foto or 'default-profile.png') }}"
                                              alt="{{ item.ministrante.nome }}" 
                                              class="speaker-photo">
                                         <span class="speaker-name">{{ item.ministrante.nome }}</span>


### PR DESCRIPTION
## Summary
- update templates to consistently reference `static/default-profile.png`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68644239bc5c832499c7e280c2515955