### PR TITLE
Improve address field fallback

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -469,6 +469,7 @@
     let currentLoteId = {% if lote_vigente %}{{ lote_vigente.id }}{% else %}null{% endif %};
     let loteCheckInterval = null;
     let estadosBrasil = [];
+    let statesFailed = false;
       // Controle de Modais
     function abrirModal() {
         const modal = document.getElementById('cadastroModal');
@@ -488,7 +489,7 @@
         
         // Inicializar campos de endereço
         if (document.getElementById('address-fields-container').children.length === 0) {
-            addAddressField();
+            addAddressField(statesFailed);
         }
     }
       function fecharModal() {
@@ -584,15 +585,18 @@
             const response = await fetch('https://servicodados.ibge.gov.br/api/v1/localidades/estados');
             estadosBrasil = await response.json();
             estadosBrasil.sort((a, b) => a.nome.localeCompare(b.nome));
-            
+
             // Adiciona o primeiro campo de endereço após carregar os estados
             addAddressField();
         } catch (error) {
             console.error('Erro ao carregar estados:', error);
+            statesFailed = true;
+            addAddressField(true);
+            showAlert('Não foi possível carregar os estados. Informe o endereço manualmente.', 'warning');
         }
     }
     
-    function addAddressField() {
+    function addAddressField(useTextFields = false) {
         const container = document.getElementById('address-fields-container');
         const addressId = Date.now();
         
@@ -609,19 +613,21 @@
             <div class="form-row">
                 <div class="form-group">
                     <label for="estado_${addressId}">Estado</label>
-                    <select id="estado_${addressId}" name="estados[]" class="state-select" required
-                            onchange="loadCities(this, 'cidade_${addressId}')">
-                        <option value="">Selecione...</option>
-                        ${estadosBrasil.map(estado => 
-                            `<option value="${estado.sigla}">${estado.nome}</option>`).join('')}
-                    </select>
+                    ${useTextFields ?
+                        `<input type="text" id="estado_${addressId}" name="estados[]" placeholder="Estado">` :
+                        `<select id="estado_${addressId}" name="estados[]" class="state-select" required onchange="loadCities(this, 'cidade_${addressId}')">
+                            <option value="">Selecione...</option>
+                            ${estadosBrasil.map(estado => `<option value="${estado.sigla}">${estado.nome}</option>`).join('')}
+                        </select>`}
                 </div>
-                
+
                 <div class="form-group">
                     <label for="cidade_${addressId}">Cidade</label>
-                    <select id="cidade_${addressId}" name="cidades[]" class="city-select" disabled required>
-                        <option value="">Selecione o estado primeiro</option>
-                    </select>
+                    ${useTextFields ?
+                        `<input type="text" id="cidade_${addressId}" name="cidades[]" placeholder="Cidade">` :
+                        `<select id="cidade_${addressId}" name="cidades[]" class="city-select" disabled required>
+                            <option value="">Selecione o estado primeiro</option>
+                        </select>`}
                 </div>
             </div>
         `;


### PR DESCRIPTION
## Summary
- allow manual address entry if IBGE API fails
- ensure modal adds text-based address fields when needed

## Testing
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686599deb7bc8324984ac591d6827967