### PR TITLE
Ensure address field added after states load

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -487,10 +487,10 @@
             loteCheckInterval = setInterval(() => checkCurrentLote(false), 30000);
         }
         
-        // Inicializar campos de endereço
-        if (document.getElementById('address-fields-container').children.length === 0) {
-            addAddressField(statesFailed);
-        }
+        // Campos de endereço agora são inicializados em loadBrazilianStates()
+        // if (document.getElementById('address-fields-container').children.length === 0) {
+        //     addAddressField(statesFailed);
+        // }
     }
       function fecharModal() {
         document.getElementById('cadastroModal').style.display = 'none';


### PR DESCRIPTION
## Summary
- defer initial address field creation until `loadBrazilianStates()` completes
- document new behavior inside `abrirModal`

## Testing
- `node test_modal.js` (custom test)
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68683803a2a88324bb42540c6d9320d9