### PR TITLE
Handle missing CSRF token in templates

### DIFF
--- a/templates/config/config_system.html
+++ b/templates/config/config_system.html
@@ -6,7 +6,9 @@
   <h1 class="h3 mb-4"><i class="bi bi-gear me-2"></i>Configurações do Sistema</h1>
 
   <form method="POST" class="card p-4 shadow-sm" style="max-width: 440px;">
-    {{ csrf_token() }} {# se CSRF estiver habilitado #}
+    {% if csrf_token is defined %}
+      {{ csrf_token() }}
+    {% endif %} {# se CSRF estiver habilitado #}
     <div class="mb-3">
       <label class="form-label fw-bold">Taxa fixa por inscrição (R$)</label>
       <input type="number"

--- a/templates/trabalho/submeter_trabalho.html
+++ b/templates/trabalho/submeter_trabalho.html
@@ -3,7 +3,9 @@
 <div class="container mt-5">
   <h3 class="mb-4">Submissão de Trabalho Científico</h3>
   <form method="POST" enctype="multipart/form-data">
-    {{ csrf_token() }}
+    {% if csrf_token is defined %}
+      {{ csrf_token() }}
+    {% endif %}
     <div class="mb-3">
       <label for="titulo" class="form-label">Título</label>
       <input type="text" class="form-control" name="titulo" required>


### PR DESCRIPTION
## Summary
- guard CSRF token calls with a defined check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6868a00df548832481b0a90d15eef6e3