### PR TITLE
Add evento_formulario association table

### DIFF
--- a/migrations/versions/d33e6d59d2e3_add_evento_formulario_association.py
+++ b/migrations/versions/d33e6d59d2e3_add_evento_formulario_association.py
@@ -1,0 +1,28 @@
+"""add evento_formulario association
+
+Revision ID: d33e6d59d2e3
+Revises: 7d9bf72dc081
+Create Date: 2025-07-05 04:08:30.657683
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd33e6d59d2e3'
+down_revision = '7d9bf72dc081'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'evento_formulario',
+        sa.Column('evento_id', sa.Integer(), sa.ForeignKey('evento.id'), primary_key=True),
+        sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formularios.id'), primary_key=True),
+    )
+
+
+def downgrade():
+    op.drop_table('evento_formulario')

--- a/models.py
+++ b/models.py
@@ -517,6 +517,13 @@ class LinkCadastro(db.Model):
 
 from extensions import db
 
+# Associação entre eventos e formulários (N:N)
+evento_formulario = db.Table(
+    'evento_formulario',
+    db.Column('evento_id', db.Integer, db.ForeignKey('evento.id'), primary_key=True),
+    db.Column('formulario_id', db.Integer, db.ForeignKey('formularios.id'), primary_key=True)
+)
+
 class Formulario(db.Model):
     __tablename__ = 'formularios'
     
@@ -529,6 +536,8 @@ class Formulario(db.Model):
     campos = db.relationship('CampoFormulario', backref='formulario', lazy=True, cascade="all, delete-orphan")
     # Relacionamento com respostas do formulário.
     respostas = db.relationship('RespostaFormulario', back_populates='formulario', cascade="all, delete-orphan")
+    # Eventos associados a este formulário
+    eventos = db.relationship('Evento', secondary=evento_formulario, backref='formularios')
 
 
     def __repr__(self):


### PR DESCRIPTION
## Summary
- add `evento_formulario` association table
- relate `Formulario` to `Evento` via new table
- generate alembic migration for the table

## Testing
- `pytest -q`
- `flask db upgrade`

------
https://chatgpt.com/codex/tasks/task_e_6868a40987dc8324bdebc5a99ce586d3