### PR TITLE
Enable associating events to forms

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -32,6 +32,7 @@ from models import (
     Oficina,
     Ministrante,
     AuditLog,
+    Evento,
 )
 from services.pdf_service import gerar_pdf_respostas
 
@@ -82,21 +83,33 @@ def listar_formularios():
 @formularios_routes.route('/formularios/novo', methods=['GET', 'POST'])
 @login_required
 def criar_formulario():
+    eventos_disponiveis = (
+        Evento.query.filter_by(cliente_id=current_user.id).all()
+        if current_user.tipo == 'cliente'
+        else Evento.query.all()
+    )
+
     if request.method == 'POST':
         nome = request.form.get('nome')
         descricao = request.form.get('descricao')
-        
+        evento_ids = request.form.getlist('eventos')
+
         novo_formulario = Formulario(
             nome=nome,
             descricao=descricao,
             cliente_id=current_user.id  # Relaciona com o cliente logado
         )
+
+        if evento_ids:
+            eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
+            novo_formulario.eventos = eventos_sel
+
         db.session.add(novo_formulario)
         db.session.commit()
         flash('Formulário criado com sucesso!', 'success')
         return redirect(url_for('formularios_routes.listar_formularios'))
-    
-    return render_template("criar_formulario.html")
+
+    return render_template("criar_formulario.html", eventos=eventos_disponiveis)
 
 @formularios_routes.route('/formularios/<int:formulario_id>/editar', methods=['GET', 'POST'])
 @login_required

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -22,9 +22,19 @@
                 
                 <div class="mb-4">
                     <label for="descricao" class="form-label fw-medium">Descrição</label>
-                    <textarea id="descricao" name="descricao" class="form-control" 
+                    <textarea id="descricao" name="descricao" class="form-control"
                               rows="4" placeholder="Adicione uma descrição (opcional)"></textarea>
                     <div class="form-text">Uma breve descrição sobre o propósito deste formulário.</div>
+                </div>
+
+                <div class="mb-4">
+                    <label for="eventos" class="form-label fw-medium">Eventos Relacionados</label>
+                    <select id="eventos" name="eventos" class="form-select" multiple>
+                        {% for ev in eventos %}
+                            <option value="{{ ev.id }}">{{ ev.nome }}</option>
+                        {% endfor %}
+                    </select>
+                    <div class="form-text">Segure Ctrl para selecionar vários eventos</div>
                 </div>
                 
                 <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">


### PR DESCRIPTION
## Summary
- query events for the logged in client when creating a form
- store selected events on POST
- allow picking multiple events in the create form template

## Testing
- `pytest -q` *(fails: BuildError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6868a40a61448324b380849ba28f5b60