### PR TITLE
Update participant form list filtering

### DIFF
--- a/models.py
+++ b/models.py
@@ -108,6 +108,13 @@ oficina_ministrantes_association = db.Table(
     db.Column('ministrante_id', db.Integer, db.ForeignKey('ministrante.id'), primary_key=True)
 )
 
+# Association table linking formulários to eventos
+evento_formulario_association = db.Table(
+    'evento_formulario_association',
+    db.Column('evento_id', db.Integer, db.ForeignKey('evento.id'), primary_key=True),
+    db.Column('formulario_id', db.Integer, db.ForeignKey('formularios.id'), primary_key=True)
+)
+
 
 class Ministrante(db.Model, UserMixin):
     __tablename__ = 'ministrante'
@@ -529,6 +536,12 @@ class Formulario(db.Model):
     campos = db.relationship('CampoFormulario', backref='formulario', lazy=True, cascade="all, delete-orphan")
     # Relacionamento com respostas do formulário.
     respostas = db.relationship('RespostaFormulario', back_populates='formulario', cascade="all, delete-orphan")
+    # Eventos associados a este formulário
+    eventos = db.relationship(
+        'Evento',
+        secondary='evento_formulario_association',
+        backref=db.backref('formularios', lazy='dynamic')
+    )
 
 
     def __repr__(self):

--- a/routes/dashboard_participante.py
+++ b/routes/dashboard_participante.py
@@ -55,7 +55,11 @@ def dashboard_participante():
     formularios_disponiveis = False
     if current_user.cliente_id:
         logger.debug(f"DEBUG [9] -> Verificando formulários disponíveis para cliente_id = {current_user.cliente_id}")
-        form_count = Formulario.query.filter_by(cliente_id=current_user.cliente_id).count()
+        form_query = Formulario.query.filter_by(cliente_id=current_user.cliente_id)
+        evento_ref = evento.id if evento else current_user.evento_id
+        if evento_ref:
+            form_query = form_query.join(Formulario.eventos).filter(Evento.id == evento_ref)
+        form_count = form_query.count()
         formularios_disponiveis = form_count > 0
         logger.debug(f"DEBUG [10] -> Formulários disponíveis: {formularios_disponiveis} (total: {form_count})")
     

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -32,6 +32,7 @@ from models import (
     Oficina,
     Ministrante,
     AuditLog,
+    Evento,
 )
 from services.pdf_service import gerar_pdf_respostas
 
@@ -231,13 +232,17 @@ def listar_formularios_participante():
     # Busca apenas formulários disponíveis para o participante
     # Filtra formulários criados pelo mesmo cliente ao qual o participante está associado
     cliente_id = current_user.cliente_id
+    evento_id = request.args.get('evento_id', type=int) or current_user.evento_id
     
     if not cliente_id:
         flash("Você não está associado a nenhum cliente.", "warning")
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
         
-    # Busca formulários criados pelo cliente do participante
-    formularios = Formulario.query.filter_by(cliente_id=cliente_id).all()
+    # Base query: formulários criados pelo cliente do participante
+    query = Formulario.query.filter_by(cliente_id=cliente_id)
+    if evento_id:
+        query = query.join(Formulario.eventos).filter(Evento.id == evento_id)
+    formularios = query.all()
     
     # Não há relação direta entre formulários e ministrantes no modelo atual,
     # então estamos filtrando apenas pelo cliente_id do participante

--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -395,7 +395,7 @@
   {% if formularios_disponiveis %}
     <div class="formularios-card">
       <strong>Formulários Disponíveis</strong>
-      <a href="{{ url_for('formularios_routes.listar_formularios_participante') }}" class="btn btn-primary">
+      <a href="{{ url_for('formularios_routes.listar_formularios_participante', evento_id=evento.id if evento else None) }}" class="btn btn-primary">
         <i class="fas fa-clipboard-list"></i> Acessar Formulários
       </a>
     </div>


### PR DESCRIPTION
## Summary
- add association table `evento_formulario_association`
- relate `Formulario` with events
- filter forms by selected event in participant dashboard and form listing
- include event id in dashboard link

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: 19 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6868a40d348c832483839820f2307d6d