### PR TITLE
Add event registration type limits for scheduling

### DIFF
--- a/migrations/versions/3c3a378fdd_add_tipos_inscricao_permitidos_to_configuracao_agendamento.py
+++ b/migrations/versions/3c3a378fdd_add_tipos_inscricao_permitidos_to_configuracao_agendamento.py
@@ -1,0 +1,24 @@
+"""add tipos_inscricao_permitidos column
+
+Revision ID: 3c3a378fdd
+Revises: 7d9bf72dc081
+Create Date: 2025-10-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '3c3a378fdd'
+down_revision = '7d9bf72dc081'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('configuracao_agendamento', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('tipos_inscricao_permitidos', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('configuracao_agendamento', schema=None) as batch_op:
+        batch_op.drop_column('tipos_inscricao_permitidos')

--- a/models.py
+++ b/models.py
@@ -769,6 +769,8 @@ class ConfiguracaoAgendamento(db.Model):
     tempo_bloqueio = db.Column(db.Integer, nullable=False, default=7)  # Dias de bloqueio por violação
     capacidade_padrao = db.Column(db.Integer, nullable=False, default=30)  # Quantidade padrão de alunos por horário
     intervalo_minutos = db.Column(db.Integer, nullable=False, default=60)  # Minutos entre agendamentos
+
+    tipos_inscricao_permitidos = db.Column(db.Text, nullable=True)
     
     # Horários de disponibilidade
     horario_inicio = db.Column(db.Time, nullable=False)
@@ -778,6 +780,11 @@ class ConfiguracaoAgendamento(db.Model):
     # Relações
     cliente = db.relationship('Cliente', backref=db.backref('configuracoes_agendamento', lazy=True))
     evento = db.relationship('Evento', backref=db.backref('configuracoes_agendamento', lazy=True))
+
+    def get_tipos_inscricao_list(self):
+        if not self.tipos_inscricao_permitidos:
+            return []
+        return [int(t) for t in self.tipos_inscricao_permitidos.split(',') if t]
     
     def __repr__(self):
         return f"<ConfiguracaoAgendamento {self.id} - Evento {self.evento_id}>"

--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -799,6 +799,7 @@ def configurar_agendamentos(evento_id):
         return redirect(url_for('dashboard_routes.dashboard'))
     
     evento = Evento.query.get_or_404(evento_id)
+    tipos_inscricao = EventoInscricaoTipo.query.filter_by(evento_id=evento_id).all()
     
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
@@ -828,6 +829,8 @@ def configurar_agendamentos(evento_id):
             # Dias da semana selecionados
             dias_semana = request.form.getlist('dias_semana')
             config.dias_semana = ','.join(dias_semana)
+            selecionados = request.form.getlist('tipos_inscricao_permitidos')
+            config.tipos_inscricao_permitidos = ','.join(selecionados) if selecionados else None
         else:
             # Criar nova configuração
             hora_inicio = request.form.get('horario_inicio')
@@ -842,7 +845,8 @@ def configurar_agendamentos(evento_id):
                 intervalo_minutos=request.form.get('intervalo_minutos', type=int),
                 horario_inicio=datetime.strptime(hora_inicio, '%H:%M').time(),
                 horario_fim=datetime.strptime(hora_fim, '%H:%M').time(),
-                dias_semana=','.join(request.form.getlist('dias_semana'))
+                dias_semana=','.join(request.form.getlist('dias_semana')),
+                tipos_inscricao_permitidos=','.join(request.form.getlist('tipos_inscricao_permitidos')) or None
             )
             db.session.add(config)
         
@@ -857,7 +861,8 @@ def configurar_agendamentos(evento_id):
     return render_template(
         'configurar_agendamentos.html',
         evento=evento,
-        config=config
+        config=config,
+        tipos_inscricao=tipos_inscricao
     )
 
 

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -12,7 +12,7 @@ from PIL import Image
 from extensions import db
 from models import (
     Evento, ProfessorBloqueado, SalaVisitacao, HorarioVisitacao,
-    AgendamentoVisita, AlunoVisitante,
+    AgendamentoVisita, AlunoVisitante, ConfiguracaoAgendamento
 )
 from services.pdf_service import gerar_pdf_comprovante_agendamento
 from . import routes
@@ -135,6 +135,13 @@ def criar_agendamento_professor(horario_id):
     
     horario = HorarioVisitacao.query.get_or_404(horario_id)
     evento = horario.evento
+
+    config = ConfiguracaoAgendamento.query.filter_by(evento_id=evento.id).first()
+    if config:
+        permitidos = config.get_tipos_inscricao_list()
+        if permitidos and current_user.tipo_inscricao_id not in permitidos:
+            flash('Seu tipo de inscrição não permite agendar visitas neste evento.', 'danger')
+            return redirect(url_for('routes.horarios_disponiveis_professor', evento_id=evento.id))
     
     # Verificar se o professor está bloqueado
     bloqueio = ProfessorBloqueado.query.filter_by(

--- a/templates/agendamento/configurar_agendamentos.html
+++ b/templates/agendamento/configurar_agendamentos.html
@@ -130,8 +130,24 @@
                   </div>
                 </div>
               </div>
-              <div class="form-text">Selecione os dias da semana em que o evento estará aberto para visitação.</div>
+            <div class="form-text">Selecione os dias da semana em que o evento estará aberto para visitação.</div>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">Tipos de Inscrição Permitidos</label>
+            <div class="card">
+              <div class="card-body">
+                {% set tipos_sel = config.get_tipos_inscricao_list() if config else [] %}
+                {% for tipo in tipos_inscricao %}
+                <div class="form-check mb-2">
+                  <input class="form-check-input" type="checkbox" name="tipos_inscricao_permitidos" value="{{ tipo.id }}" id="tipo-{{ tipo.id }}" {% if tipo.id in tipos_sel %}checked{% endif %}>
+                  <label class="form-check-label" for="tipo-{{ tipo.id }}">{{ tipo.nome }}</label>
+                </div>
+                {% endfor %}
+              </div>
             </div>
+            <div class="form-text">Marque para restringir o agendamento apenas a estes tipos de inscrição. Deixe vazio para liberar para todos.</div>
+          </div>
             
             <div class="alert alert-info">
               <i class="bi bi-info-circle"></i> Após salvar as configurações, você será redirecionado para gerar os horários de visitação.


### PR DESCRIPTION
## Summary
- extend `ConfiguracaoAgendamento` with `tipos_inscricao_permitidos`
- allow configuring which registration types can schedule
- save/read these types when configuring an event
- show multiselect in agendamento configuration UI
- block schedule creation when user registration type is not allowed
- add Alembic migration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6868aa3334788324bc2bf140441bf2f9