### PR TITLE
Add participant agendamento routes

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3469,6 +3469,36 @@ def meus_agendamentos():
     )
 
 
+@agendamento_routes.route('/participante/meus_agendamentos')
+@login_required
+def meus_agendamentos_participante():
+    """Lista agendamentos do participante logado."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    status = request.args.get('status')
+
+    query = AgendamentoVisita.query.filter_by(professor_id=current_user.id)
+    if status:
+        query = query.filter(AgendamentoVisita.status == status)
+
+    agendamentos = query.join(
+        HorarioVisitacao, AgendamentoVisita.horario_id == HorarioVisitacao.id
+    ).order_by(
+        HorarioVisitacao.data,
+        HorarioVisitacao.horario_inicio
+    ).all()
+
+    return render_template(
+        'participante/meus_agendamentos.html',
+        agendamentos=agendamentos,
+        status_filtro=status,
+        today=date.today,
+        hoje=date.today()
+    )
+
+
 @agendamento_routes.route('/professor/cancelar_agendamento/<int:agendamento_id>', methods=['GET', 'POST'])
 @login_required
 def cancelar_agendamento_professor(agendamento_id):
@@ -3542,6 +3572,45 @@ def cancelar_agendamento_professor(agendamento_id):
         agendamento=agendamento,
         horario=horario,
         prazo_limite=prazo_limite
+    )
+
+
+@agendamento_routes.route('/participante/cancelar_agendamento/<int:agendamento_id>', methods=['GET', 'POST'])
+@login_required
+def cancelar_agendamento_participante(agendamento_id):
+    """Permite que o participante cancele seu agendamento."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
+
+    if agendamento.professor_id != current_user.id:
+        flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    if agendamento.status == 'cancelado':
+        flash('Este agendamento já foi cancelado!', 'warning')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    horario = agendamento.horario
+
+    if request.method == 'POST':
+        horario.vagas_disponiveis += agendamento.quantidade_alunos
+        agendamento.status = 'cancelado'
+        agendamento.data_cancelamento = datetime.utcnow()
+        try:
+            db.session.commit()
+            flash('Agendamento cancelado com sucesso!', 'success')
+            return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Erro ao cancelar agendamento: {str(e)}', 'danger')
+
+    return render_template(
+        'participante/cancelar_agendamento.html',
+        agendamento=agendamento,
+        horario=horario
     )
 
 

--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -387,6 +387,14 @@
 
   {% endif %}
 
+  <div class="container-fluid px-4 mt-2">
+    <div class="d-flex justify-content-end mb-4">
+      <a href="{{ url_for('agendamento_routes.meus_agendamentos_participante') }}" class="btn btn-info btn-lg">
+        <i class="fas fa-calendar-alt me-2"></i> AGENDAMENTOS
+      </a>
+    </div>
+  </div>
+
   {% if current_user.tem_pagamento_pendente() %}
 
 {% endif %}

--- a/templates/participante/cancelar_agendamento.html
+++ b/templates/participante/cancelar_agendamento.html
@@ -1,0 +1,36 @@
+<!-- Template: participante/cancelar_agendamento.html -->
+{% extends 'base.html' %}
+
+{% block title %}Cancelar Agendamento{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Cancelar Agendamento</h2>
+    <div class="card mb-4">
+        <div class="card-header bg-primary text-white">Detalhes do Agendamento</div>
+        <div class="card-body">
+            <p><strong>Evento:</strong> {{ horario.evento.nome }}</p>
+            <p><strong>Data:</strong> {{ horario.data.strftime('%d/%m/%Y') }}</p>
+            <p><strong>Horário:</strong> {{ horario.horario_inicio.strftime('%H:%M') }} às {{ horario.horario_fim.strftime('%H:%M') }}</p>
+        </div>
+    </div>
+    <div class="card mb-4">
+        <div class="card-header bg-danger text-white">
+            <i class="fas fa-exclamation-triangle"></i> Confirmação de Cancelamento
+        </div>
+        <div class="card-body">
+            <p>Tem certeza que deseja cancelar este agendamento? Esta ação não pode ser desfeita.</p>
+            <form method="POST" action="{{ url_for('agendamento_routes.cancelar_agendamento_participante', agendamento_id=agendamento.id) }}">
+                <div class="mt-4 d-flex gap-2">
+                    <button type="submit" class="btn btn-danger">
+                        <i class="fas fa-times"></i> Confirmar Cancelamento
+                    </button>
+                    <a href="{{ url_for('agendamento_routes.meus_agendamentos_participante') }}" class="btn btn-secondary">
+                        <i class="fas fa-chevron-left"></i> Voltar
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/participante/criar_agendamento.html
+++ b/templates/participante/criar_agendamento.html
@@ -1,0 +1,33 @@
+<!-- Template: participante/criar_agendamento.html -->
+{% extends 'base.html' %}
+
+{% block title %}Criar Agendamento{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Confirmar Agendamento</h2>
+    <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
+            Detalhes do Horário Selecionado
+        </div>
+        <div class="card-body">
+            <p><strong>Evento:</strong> {{ evento.nome }}</p>
+            <p><strong>Data:</strong> {{ horario.data.strftime('%d/%m/%Y') }}</p>
+            <p><strong>Horário:</strong> {{ horario.horario_inicio.strftime('%H:%M') }} às {{ horario.horario_fim.strftime('%H:%M') }}</p>
+            <p><strong>Vagas disponíveis:</strong> {{ horario.vagas_disponiveis }}</p>
+        </div>
+    </div>
+
+    <form method="POST" action="{{ url_for('routes.criar_agendamento_participante', horario_id=horario.id) }}">
+        <div class="alert alert-info">Confirme para reservar este horário para você.</div>
+        <div class="d-grid gap-2 d-md-flex">
+            <button type="submit" class="btn btn-success">
+                <i class="fas fa-save"></i> Confirmar Agendamento
+            </button>
+            <a href="{{ url_for('routes.horarios_disponiveis_participante', evento_id=evento.id) }}" class="btn btn-secondary">
+                <i class="fas fa-times"></i> Cancelar
+            </a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/participante/horarios_disponiveis.html
+++ b/templates/participante/horarios_disponiveis.html
@@ -1,0 +1,85 @@
+<!-- Template: participante/horarios_disponiveis.html -->
+{% extends 'base.html' %}
+
+{% block title %}Horários Disponíveis{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Horários Disponíveis - {{ evento.nome }}</h2>
+
+    <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
+            Filtrar Horários
+        </div>
+        <div class="card-body">
+            <form method="GET" action="{{ url_for('routes.horarios_disponiveis_participante', evento_id=evento.id) }}">
+                <div class="form-group">
+                    <label for="data">Selecione uma data específica:</label>
+                    <input type="date" class="form-control" id="data" name="data" value="{{ data_filtro }}">
+                </div>
+                <button type="submit" class="btn btn-primary mt-2">
+                    <i class="fas fa-filter"></i> Filtrar
+                </button>
+                {% if data_filtro %}
+                    <a href="{{ url_for('routes.horarios_disponiveis_participante', evento_id=evento.id) }}" class="btn btn-outline-secondary mt-2">
+                        <i class="fas fa-times"></i> Limpar Filtro
+                    </a>
+                {% endif %}
+            </form>
+        </div>
+    </div>
+
+    {% if horarios_por_data %}
+        {% for data_str, horarios in horarios_por_data.items() %}
+            {% set data = horarios[0].data %}
+            <div class="card mb-4">
+                <div class="card-header bg-success text-white">
+                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data.strftime('%A')|capitalize }})
+                </div>
+                <div class="card-body">
+                    <table class="table table-striped table-hover">
+                        <thead>
+                            <tr>
+                                <th>Horário</th>
+                                <th class="text-center">Vagas Disponíveis</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for horario in horarios %}
+                                <tr>
+                                    <td>{{ horario.horario_inicio.strftime('%H:%M') }} às {{ horario.horario_fim.strftime('%H:%M') }}</td>
+                                    <td class="text-center">
+                                        {% if horario.vagas_disponiveis > 10 %}
+                                            <span class="badge bg-success">{{ horario.vagas_disponiveis }} vagas</span>
+                                        {% elif horario.vagas_disponiveis > 5 %}
+                                            <span class="badge bg-warning text-dark">{{ horario.vagas_disponiveis }} vagas</span>
+                                        {% else %}
+                                            <span class="badge bg-danger">{{ horario.vagas_disponiveis }} vagas</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-end">
+                                        <a href="{{ url_for('routes.criar_agendamento_participante', horario_id=horario.id) }}" class="btn btn-sm btn-primary">
+                                            <i class="fas fa-calendar-plus"></i> Agendar
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        {% endfor %}
+    {% else %}
+        <div class="alert alert-warning">
+            <i class="fas fa-exclamation-triangle"></i> Não há horários disponíveis para os critérios selecionados.
+        </div>
+    {% endif %}
+
+    <div class="mt-4">
+        <a href="{{ url_for('dashboard_participante_routes.dashboard_participante') }}" class="btn btn-secondary">
+            <i class="fas fa-chevron-left"></i> Voltar
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/participante/meus_agendamentos.html
+++ b/templates/participante/meus_agendamentos.html
@@ -1,0 +1,96 @@
+<!-- Template: participante/meus_agendamentos.html -->
+{% extends 'base.html' %}
+
+{% block title %}Meus Agendamentos{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row mb-4">
+        <div class="col">
+            <h2 class="mb-4 border-bottom pb-2">Meus Agendamentos</h2>
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-primary text-white">
+                    <i class="fas fa-filter me-2"></i>Filtrar
+                </div>
+                <div class="card-body">
+                    <form method="GET" action="{{ url_for('agendamento_routes.meus_agendamentos_participante') }}" class="row g-2 align-items-center">
+                        <div class="col-md-4">
+                            <select name="status" class="form-select">
+                                <option value="">Todos os status</option>
+                                <option value="confirmado" {% if status_filtro == 'confirmado' %}selected{% endif %}>Confirmados</option>
+                                <option value="cancelado" {% if status_filtro == 'cancelado' %}selected{% endif %}>Cancelados</option>
+                                <option value="realizado" {% if status_filtro == 'realizado' %}selected{% endif %}>Realizados</option>
+                            </select>
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-search me-1"></i>Filtrar
+                            </button>
+                        </div>
+                        {% if status_filtro %}
+                        <div class="col-auto">
+                            <a href="{{ url_for('agendamento_routes.meus_agendamentos_participante') }}" class="btn btn-outline-secondary">
+                                <i class="fas fa-times me-1"></i>Limpar
+                            </a>
+                        </div>
+                        {% endif %}
+                    </form>
+                </div>
+            </div>
+
+            {% if agendamentos %}
+                <div class="card shadow-sm">
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <th>Evento</th>
+                                        <th>Data</th>
+                                        <th>Horário</th>
+                                        <th>Status</th>
+                                        <th>Ações</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for agendamento in agendamentos %}
+                                        {% set horario = agendamento.horario %}
+                                        {% set hoje = hoje or today %}
+                                        <tr class="{% if agendamento.status == 'cancelado' %}table-danger{% endif %}{% if agendamento.status == 'realizado' %} table-success{% endif %}{% if horario.data and horario.data < hoje and agendamento.status == 'confirmado' %} table-warning{% endif %}">
+                                            <td>{{ horario.evento.nome }}</td>
+                                            <td>{{ horario.data.strftime('%d/%m/%Y') }}</td>
+                                            <td>{{ horario.horario_inicio.strftime('%H:%M') }}</td>
+                                            <td>
+                                                {% if agendamento.status == 'confirmado' %}
+                                                    <span class="badge rounded-pill bg-primary">Confirmado</span>
+                                                {% elif agendamento.status == 'cancelado' %}
+                                                    <span class="badge rounded-pill bg-danger">Cancelado</span>
+                                                {% elif agendamento.status == 'realizado' %}
+                                                    <span class="badge rounded-pill bg-success">Realizado</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                <div class="d-flex flex-wrap justify-content-center gap-1">
+                                                    {% if agendamento.status == 'confirmado' %}
+                                                        <a href="{{ url_for('agendamento_routes.cancelar_agendamento_participante', agendamento_id=agendamento.id) }}" class="btn btn-sm btn-outline-danger" title="Cancelar">
+                                                            <i class="fas fa-times me-1"></i>Cancelar
+                                                        </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            {% else %}
+                <div class="alert alert-warning shadow-sm">
+                    <i class="fas fa-exclamation-triangle me-2"></i>Não há agendamentos para exibir.
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement participant-facing agendamento endpoints
- list participant horarios and creation page
- allow participants to view or cancel their own agendamentos
- link from dashboard to participant agendamentos page

## Testing
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868aa3688f083249d99a82f5e322f39