### PR TITLE
Unify event-form association table

### DIFF
--- a/migrations/versions/123456789abc_unify_evento_formulario_association.py
+++ b/migrations/versions/123456789abc_unify_evento_formulario_association.py
@@ -1,0 +1,39 @@
+"""unify evento_formulario association
+
+Revision ID: 123456789abc
+Revises: ffbc68259c84
+Create Date: 2025-07-07 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '123456789abc'
+down_revision = 'ffbc68259c84'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table('evento_formulario')
+    op.drop_table('formulario_evento_association')
+    op.create_table(
+        'evento_formulario_association',
+        sa.Column('evento_id', sa.Integer(), sa.ForeignKey('evento.id'), primary_key=True),
+        sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formularios.id'), primary_key=True),
+    )
+
+
+def downgrade():
+    op.drop_table('evento_formulario_association')
+    op.create_table(
+        'formulario_evento_association',
+        sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formularios.id'), primary_key=True),
+        sa.Column('evento_id', sa.Integer(), sa.ForeignKey('evento.id'), primary_key=True),
+    )
+    op.create_table(
+        'evento_formulario',
+        sa.Column('evento_id', sa.Integer(), sa.ForeignKey('evento.id'), primary_key=True),
+        sa.Column('formulario_id', sa.Integer(), sa.ForeignKey('formularios.id'), primary_key=True),
+    )

--- a/models.py
+++ b/models.py
@@ -526,22 +526,6 @@ class LinkCadastro(db.Model):
 
 from extensions import db
 
-# -------------------------------------------------
-#  Associacao Formulario <-> Evento (Many-to-Many)
-# -------------------------------------------------
-formulario_evento_association = db.Table(
-    'formulario_evento_association',
-    db.Column('formulario_id', db.Integer, db.ForeignKey('formularios.id'), primary_key=True),
-    db.Column('evento_id', db.Integer, db.ForeignKey('evento.id'), primary_key=True)
-)
-
-# Associação entre eventos e formulários (N:N)
-evento_formulario = db.Table(
-    'evento_formulario',
-    db.Column('evento_id', db.Integer, db.ForeignKey('evento.id'), primary_key=True),
-    db.Column('formulario_id', db.Integer, db.ForeignKey('formularios.id'), primary_key=True)
-)
-
 class Formulario(db.Model):
     __tablename__ = 'formularios'
     


### PR DESCRIPTION
## Summary
- remove duplicate `evento_formulario` and `formulario_evento_association` tables
- keep single `evento_formulario_association` in `models.py`
- add Alembic migration to drop old tables and create the unified one

## Testing
- `pytest -q` *(fails: 21 failed, 40 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6868b8ee14888324b73779a04e90b1e8