### PR TITLE
Add event submission toggle

### DIFF
--- a/migrations/versions/e4cb3d4630b1_add_submissao_aberta_to_evento.py
+++ b/migrations/versions/e4cb3d4630b1_add_submissao_aberta_to_evento.py
@@ -1,0 +1,24 @@
+"""add submissao_aberta to Evento
+
+Revision ID: e4cb3d4630b1
+Revises: ffbc68259c84
+Create Date: 2025-12-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'e4cb3d4630b1'
+down_revision = 'ffbc68259c84'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('evento') as batch_op:
+        batch_op.add_column(sa.Column('submissao_aberta', sa.Boolean(), nullable=True, server_default=sa.false()))
+
+
+def downgrade():
+    with op.batch_alter_table('evento') as batch_op:
+        batch_op.drop_column('submissao_aberta')

--- a/models.py
+++ b/models.py
@@ -724,6 +724,8 @@ class Evento(db.Model):
 
         habilitar_lotes = db.Column(db.Boolean, default=False)
 
+        submissao_aberta = db.Column(db.Boolean, default=False)
+
         cliente = db.relationship('Cliente', backref=db.backref('eventos', lazy=True))
         # Modificando o relacionamento para evitar conflito de backref
         tipos_inscricao = db.relationship(

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -43,8 +43,8 @@
           <option value="double" {% if config_cliente.review_model == 'double' %}selected{% endif %}>Double-blind</option>
         </select>
       </div>
-      <div class="config-item p-3">
-        <div class="row g-2 align-items-end">
+        <div class="config-item p-3">
+          <div class="row g-2 align-items-end">
           <div class="col">
             <label class="form-label mb-0">Mínimo Revisores</label>
             <input type="number" min="1" class="form-control" id="inputRevisoresMin" value="{{ config_cliente.num_revisores_min }}" data-update-url="{{ url_for('config_cliente_routes.set_num_revisores_min') }}">
@@ -58,6 +58,22 @@
             <input type="number" min="1" class="form-control" id="inputPrazoParecer" value="{{ config_cliente.prazo_parecer_dias }}" data-update-url="{{ url_for('config_cliente_routes.set_prazo_parecer_dias') }}">
           </div>
         </div>
+        {% if eventos %}
+        <div class="mt-3">
+          <h6 class="mb-2 fw-semibold">Submissão por Evento</h6>
+          {% for evento in eventos %}
+          <div class="config-item d-flex justify-content-between align-items-center p-2 border-bottom">
+            <span>{{ evento.nome }}</span>
+            <button type="button"
+                    class="btn btn-padrao btn-toggle btn-{{ 'success' if evento.submissao_aberta else 'danger' }}"
+                    data-toggle-url="{{ url_for('config_cliente_routes.toggle_submissao_evento', evento_id=evento.id) }}"
+                    data-label="{{ evento.nome }}">
+              {{ 'Ativo' if evento.submissao_aberta else 'Desativado' }}
+            </button>
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/trabalho/submeter_trabalho.html
+++ b/templates/trabalho/submeter_trabalho.html
@@ -18,15 +18,6 @@
       <label for="area_tematica" class="form-label">Área Temática</label>
       <input type="text" class="form-control" name="area_tematica" required>
     </div>
-    <div class="mb-3">
-      <label for="evento_id" class="form-label">Evento</label>
-      <select class="form-select" name="evento_id">
-        <option value="">-- Selecione um Evento --</option>
-        {% for evento in eventos %}
-          <option value="{{ evento.id }}" {% if current_user.evento_id == evento.id %}selected{% endif %}>{{ evento.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
     {% set tipos = current_user.cliente.configuracao.allowed_file_types if current_user.cliente and current_user.cliente.configuracao else 'pdf' %}
     {% set accept_str = '.' + tipos.replace(',', ',.').replace(' ', '') %}
     <div class="mb-3">

--- a/tests/test_evento_submissao.py
+++ b/tests/test_evento_submissao.py
@@ -1,0 +1,55 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Cliente, Evento, Usuario
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+        evento = Evento(cliente_id=cliente.id, nome='EV', submissao_aberta=False)
+        db.session.add(evento)
+        db.session.commit()
+        usuario = Usuario(nome='Part', cpf='1', email='part@test', senha=generate_password_hash('123'), formacao='x', tipo='participante', cliente_id=cliente.id, evento_id=evento.id)
+        db.session.add(usuario)
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_toggle_submissao_evento(client, app):
+    with app.app_context():
+        evento = Evento.query.first()
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/toggle_submissao_evento/{evento.id}')
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Evento.query.get(evento.id).submissao_aberta is True
+    client.post(f'/toggle_submissao_evento/{evento.id}')
+    with app.app_context():
+        assert Evento.query.get(evento.id).submissao_aberta is False
+
+
+def test_form_without_event_field(client, app):
+    login(client, 'part@test', '123')
+    resp = client.get('/submeter_trabalho')
+    assert resp.status_code == 200
+    assert b'name="evento_id"' not in resp.data


### PR DESCRIPTION
## Summary
- add `submissao_aberta` column to `Evento`
- allow clients to toggle submission per event
- list events in submission config page with per-event toggle
- rely on `current_user.evento_id` when submitting works and validate if event open
- remove event selection field from participant form
- add tests for enabling/disabling submissions and for participant form

## Testing
- `pytest tests/test_evento_submissao.py::test_toggle_submissao_evento -q`
- `pytest tests/test_evento_submissao.py::test_form_without_event_field -q`
- `pytest -q` *(fails: 22 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6868b8ece33c832493d531c27fefc9aa