### PR TITLE
Fix revisor approval flow

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -236,7 +236,7 @@ def approve(cand_id: int):
     if not reviewer:
         reviewer = Usuario(
             nome=cand.nome or cand.email,
-            cpf=str(uuid.uuid4()),
+            cpf=str(uuid.uuid4().int)[:11],
             email=cand.email,
             senha=generate_password_hash("temp123"),
             formacao="",
@@ -255,7 +255,9 @@ def approve(cand_id: int):
         db.session.add(Assignment(submission_id=submission_id, reviewer_id=reviewer.id))
 
     db.session.commit()
-    return jsonify({"success": True, "reviewer_id": reviewer.id})
+    if request.is_json:
+        return jsonify({"success": True, "reviewer_id": reviewer.id})
+    return redirect(url_for("dashboard_routes.dashboard_cliente"))
 
 
 @revisor_routes.route("/revisor/reject/<int:cand_id>", methods=["POST"])
@@ -268,7 +270,9 @@ def reject(cand_id: int):
     cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
     cand.status = "rejeitado"
     db.session.commit()
-    return jsonify({"success": True})
+    if request.is_json:
+        return jsonify({"success": True})
+    return redirect(url_for("dashboard_routes.dashboard_cliente"))
 
 
 @revisor_routes.route("/revisor/advance/<int:cand_id>", methods=["POST"])
@@ -282,7 +286,9 @@ def advance(cand_id: int):
     if cand.etapa_atual < cand.process.num_etapas:
         cand.etapa_atual += 1
     db.session.commit()
-    return jsonify({"success": True, "etapa_atual": cand.etapa_atual})
+    if request.is_json:
+        return jsonify({"success": True, "etapa_atual": cand.etapa_atual})
+    return redirect(url_for("dashboard_routes.dashboard_cliente"))
 
 
 # -----------------------------------------------------------------------------

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1445,36 +1445,6 @@
   <!-- /ABA 5: FINANCEIRO -->
   <!-- ABA 6: REVISORES -->
   <div class="tab-pane fade" id="revisores" role="tabpanel">
-    <h5 class="fw-bold mb-3">Candidaturas de Revisores</h5>
-    <table class="table table-sm">
-      <thead>
-        <tr><th>Usuário</th><th>Status</th><th>Ações</th></tr>
-      </thead>
-      <tbody>
-        {% for app in reviewer_apps %}
-        <tr>
-          <td>{{ app.usuario.nome }}</td>
-          <td>{{ app.stage }}</td>
-          <td>
-            <form method="post" action="{{ url_for('dashboard_routes.update_reviewer_application', app_id=app.id) }}" class="d-inline">
-              <input type="hidden" name="action" value="advance">
-              <button class="btn btn-sm btn-primary">Avançar</button>
-            </form>
-            <form method="post" action="{{ url_for('dashboard_routes.update_reviewer_application', app_id=app.id) }}" class="d-inline ms-1">
-              <input type="hidden" name="action" value="approve">
-              <button class="btn btn-sm btn-success">Aprovar</button>
-            </form>
-            <form method="post" action="{{ url_for('dashboard_routes.update_reviewer_application', app_id=app.id) }}" class="d-inline ms-1">
-              <input type="hidden" name="action" value="reject">
-              <button class="btn btn-sm btn-danger">Rejeitar</button>
-            </form>
-          </td>
-        </tr>
-        {% else %}
-        <tr><td colspan="3">Nenhuma candidatura.</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
     <h5 class="fw-bold mt-4">Candidaturas via Formulário</h5>
     <table class="table table-sm">
       <thead>


### PR DESCRIPTION
## Summary
- generate a numeric placeholder for `cpf` when approving new reviewer candidate
- redirect to dashboard after approving, rejecting or advancing non-json requests
- remove old "Candidaturas de Revisores" table from the client dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6868c2e0856c8324961a89270ad8fb7d