### PR TITLE
Fix QR check‑in list and display

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -375,7 +375,12 @@ def lista_checkins_qr():
         .outerjoin(Checkin.oficina)
         .outerjoin(Checkin.usuario)
         .filter(
-            Checkin.palavra_chave.in_(['QR-AUTO', 'QR-EVENTO']),
+            Checkin.palavra_chave.in_([
+                'QR-AUTO',
+                'QR-EVENTO',
+                'QR-OFICINA',
+                'QR‑OFICINA'
+            ]),
             or_(
                 Usuario.cliente_id == current_user.id,
                 Oficina.cliente_id == current_user.id,

--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -62,7 +62,12 @@ def dashboard_cliente():
         .outerjoin(Checkin.oficina)
         .outerjoin(Checkin.usuario)
         .filter(
-            Checkin.palavra_chave.in_(['QR-AUTO', 'QR-EVENTO']),
+            Checkin.palavra_chave.in_([
+                'QR-AUTO',
+                'QR-EVENTO',
+                'QR-OFICINA',
+                'QR‑OFICINA'
+            ]),
             or_(
                 Usuario.cliente_id == current_user.id,
                 Oficina.cliente_id == current_user.id,

--- a/templates/checkin/scan_qr.html
+++ b/templates/checkin/scan_qr.html
@@ -183,7 +183,8 @@
                         <div>${data.message}</div>
                     </div>
                 </div>`;
-                addScannedItem(data.participante, data.oficina, data.turno, data.data_hora);
+                const atividade = data.oficina || data.evento || 'Credenciamento';
+                addScannedItem(data.participante, atividade, data.turno, data.data_hora);
             } else if (data.status === "warning") {
                 // ex.: "Check-in já realizado!"
                 resultElement.innerHTML = `<div class="alert alert-warning">
@@ -246,7 +247,8 @@
             const data = await resp.json();
             if (data.status === 'success' && Array.isArray(data.checkins)) {
                 data.checkins.forEach(chk => {
-                    addScannedItem(chk.participante, chk.oficina, chk.turno, chk.data_hora);
+                    const atividade = chk.oficina || chk.evento || 'Credenciamento';
+                    addScannedItem(chk.participante, atividade, chk.turno, chk.data_hora);
                 });
             }
         } catch (err) {
@@ -310,13 +312,7 @@
 
   // Receber apenas os check-ins do cliente logado
   socket.on("novo_checkin", function (data) {
-    const tabela = document.getElementById("tabelaCheckins");
-    const novaLinha = tabela.insertRow(1);
-    novaLinha.innerHTML = `
-      <td>${data.nome}</td>
-      <td>${data.oficina}</td>
-      <td>${data.hora}</td>
-    `;
+    const atividade = data.oficina || data.evento || 'Credenciamento';
+    addScannedItem(data.participante, atividade, data.turno, data.data_hora);
   });
-</script>
-{% endblock %}
+</script>{% endblock %}


### PR DESCRIPTION
## Summary
- show QR check-ins from workshops on listing pages
- display event check-ins as "Credenciamento" in scanner UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686d5c4097c48324ac6806f3093a9ea5