### PR TITLE
Update duplicate user logic in participant registration

### DIFF
--- a/routes/campo_routes.py
+++ b/routes/campo_routes.py
@@ -109,7 +109,6 @@ def preview_cadastro():
         tipos_inscricao=tipos_inscricao,
         mostrar_taxa=mostrar_taxa,
         preco_com_taxa=preco_com_taxa,
-        solicitar_senha=False,
         cliente_id=current_user.id,
         disable_submit=True
     )

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -275,12 +275,6 @@
                             <small class="password-hint">Mínimo de 8 caracteres</small>
                         </div>
 
-                        {% if solicitar_senha %}
-                        <div class="form-group">
-                            <label for="senha_existente">Confirme sua senha cadastrada</label>
-                            <input type="password" id="senha_existente" name="senha_existente" placeholder="Senha já cadastrada" required>
-                        </div>
-                        {% endif %}
                         
                         <div class="form-group full-width">
                             <label for="formacao">Formação Acadêmica</label>


### PR DESCRIPTION
## Summary
- streamline duplicate user handling in participant registration
- drop password confirmation requirement
- remove `solicitar_senha` from form rendering and template

## Testing
- `pytest -q` *(fails: BuildError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_686d602618448324be34e853723cee00