### PR TITLE
Add reviewer PDF download

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -42,6 +42,7 @@ from models import (
     Submission,
     Usuario,
 )
+from services.pdf_service import gerar_revisor_details_pdf
 
 # -----------------------------------------------------------------------------
 # Blueprint
@@ -177,7 +178,14 @@ def submit_application(process_id: int):
 @revisor_routes.route("/revisor/progress/<codigo>")
 def progress(codigo: str):
     cand: RevisorCandidatura = RevisorCandidatura.query.filter_by(codigo=codigo).first_or_404()
-    return render_template("revisor/progress.html", candidatura=cand)
+    pdf_url = url_for("revisor_routes.progress_pdf", codigo=codigo)
+    return render_template("revisor/progress.html", candidatura=cand, pdf_url=pdf_url)
+
+
+@revisor_routes.route("/revisor/progress/<codigo>/pdf")
+def progress_pdf(codigo: str):
+    cand: RevisorCandidatura = RevisorCandidatura.query.filter_by(codigo=codigo).first_or_404()
+    return gerar_revisor_details_pdf(cand)
 
 
 @revisor_routes.route("/revisor/progress")

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1,6 +1,32 @@
 from flask_login import login_required
 from utils import external_url, determinar_turno
 
+
+def gerar_revisor_details_pdf(cand, pdf_path=None):
+    """Gera um PDF simples com dados do revisor."""
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+    import tempfile
+    import os
+    from flask import send_file
+
+    if pdf_path is None:
+        pdf_filename = f"revisor_{cand.codigo}.pdf"
+        pdf_path = os.path.join(tempfile.gettempdir(), pdf_filename)
+
+    c = canvas.Canvas(pdf_path, pagesize=letter)
+    width, height = letter
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(72, height - 72, "Dados do Revisor")
+    c.setFont("Helvetica", 12)
+    c.drawString(72, height - 100, f"Nome: {cand.nome}")
+    c.drawString(72, height - 120, f"E-mail: {cand.email}")
+    c.drawString(72, height - 140, f"Código: {cand.codigo}")
+    c.showPage()
+    c.save()
+
+    return send_file(pdf_path, as_attachment=True, download_name=os.path.basename(pdf_path))
+
 def gerar_lista_frequencia_pdf(oficina, pdf_path):
     """
     Generates a modern and professional attendance list PDF for a workshop.

--- a/templates/revisor/progress.html
+++ b/templates/revisor/progress.html
@@ -16,4 +16,11 @@
     </tbody>
   </table>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    {% if pdf_url %}
+    window.location.href = '{{ pdf_url }}';
+    {% endif %}
+  });
+</script>
 {% endblock %}

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -128,6 +128,25 @@ def test_application_and_approval_flow(client, app):
         assert ass is None
 
 
+def test_progress_pdf_download(client, app):
+    with app.app_context():
+        proc = RevisorProcess.query.first()
+        campos = {c.nome: c.id for c in proc.formulario.campos}
+
+    client.post(
+        f"/revisor/apply/{proc.id}",
+        data={str(campos["email"]): "pdf@test", str(campos["nome"]): "Pdf"},
+    )
+
+    with app.app_context():
+        cand = RevisorCandidatura.query.filter_by(email="pdf@test").first()
+        code = cand.codigo
+
+    resp = client.get(f"/revisor/progress/{code}/pdf")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/pdf"
+
+
 def test_navbar_shows_correct_process_id(app):
     with app.test_request_context("/"):
         html = render_template("partials/navbar.html")


### PR DESCRIPTION
## Summary
- add `gerar_revisor_details_pdf` in `pdf_service`
- expose `/revisor/progress/<codigo>/pdf` route
- include PDF URL on progress page and auto-download via JS
- test PDF route

## Testing
- `pytest tests/test_revisor_process.py tests/test_revisor_process_extra.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6603ad58832485c396ef209e0233