### PR TITLE
Enable CSRF globally

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask_socketio import join_room
 from apscheduler.schedulers.background import BackgroundScheduler
 from datetime import datetime, timedelta
 from config import Config
-from extensions import db, login_manager, migrate, mail, socketio
+from extensions import db, login_manager, migrate, mail, socketio, csrf
 from models import Inscricao
 import pytz
 import logging
@@ -37,6 +37,7 @@ def create_app():
     login_manager.init_app(app)
     migrate.init_app(app, db)
     mail.init_app(app)
+    csrf.init_app(app)
     CORS(app)
 
     login_manager.login_view = "auth_routes.login"

--- a/extensions.py
+++ b/extensions.py
@@ -3,6 +3,7 @@ from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_mail import Mail
 from flask_socketio import SocketIO
+from flask_wtf.csrf import CSRFProtect
 from sqlalchemy import MetaData
 
 socketio = SocketIO()
@@ -20,3 +21,4 @@ db = SQLAlchemy(metadata=MetaData(naming_convention=naming_convention))
 login_manager = LoginManager()
 migrate = Migrate()
 mail = Mail()
+csrf = CSRFProtect()

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1458,12 +1458,15 @@
           <td>{{ cand.status }}</td>
           <td>
             <form method="post" action="{{ url_for('revisor_routes.advance', cand_id=cand.id) }}" class="d-inline">
+              {{ csrf_token() }}
               <button class="btn btn-sm btn-primary">Avançar</button>
             </form>
             <form method="post" action="{{ url_for('revisor_routes.approve', cand_id=cand.id) }}" class="d-inline ms-1">
+              {{ csrf_token() }}
               <button class="btn btn-sm btn-success">Aprovar</button>
             </form>
             <form method="post" action="{{ url_for('revisor_routes.reject', cand_id=cand.id) }}" class="d-inline ms-1">
+              {{ csrf_token() }}
               <button class="btn btn-sm btn-danger">Rejeitar</button>
             </form>
           </td>

--- a/tests/test_binary_routes.py
+++ b/tests/test_binary_routes.py
@@ -13,6 +13,7 @@ from extensions import db
 def app():
     app = create_app()
     app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
     app.config['LOGIN_DISABLED'] = True
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     with app.app_context():

--- a/tests/test_inscricao_routes.py
+++ b/tests/test_inscricao_routes.py
@@ -13,6 +13,7 @@ from models import Cliente, Evento, EventoInscricaoTipo, LoteInscricao, LoteTipo
 def app():
     app = create_app()
     app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
 
     with app.app_context():


### PR DESCRIPTION
## Summary
- initialize CSRFProtect in `extensions` and set up in `create_app`
- include CSRF tokens in reviewer action forms
- disable CSRF in binary and inscricao route tests

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q` *(fails: BuildError: Could not build url for endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_686d66070f6883248a49ad3e601c7851