### PR TITLE
Add missing CSRF tokens

### DIFF
--- a/templates/peer_review/review_form.html
+++ b/templates/peer_review/review_form.html
@@ -4,6 +4,7 @@
   <h3>Revisar Trabalho</h3>
   <p><strong>{{ review.submission.title }}</strong></p>
   <form method="POST">
+    {{ csrf_token() }}
     <div class="mb-3">
       <label>Código de Acesso</label>
       <input type="text" name="codigo" class="form-control" required>

--- a/templates/peer_review/reviewer_registration.html
+++ b/templates/peer_review/reviewer_registration.html
@@ -8,6 +8,7 @@
     </div>
     <div class="card-body">
       <form method="POST">
+        {{ csrf_token() }}
         <div class="mb-3">
           <label for="nome" class="form-label">Nome</label>
           <input type="text" class="form-control" id="nome" name="nome" required>

--- a/templates/revisor/candidatura_form.html
+++ b/templates/revisor/candidatura_form.html
@@ -10,6 +10,7 @@
                 <i class="bi bi-info-circle me-2"></i>{{ formulario.descricao }}
             </div>
             <form method="POST" enctype="multipart/form-data">
+                {{ csrf_token() }}
                 {% for campo in formulario.campos %}
                 <div class="mb-4">
                     <label class="form-label fw-bold" for="campo-{{ campo.id }}">


### PR DESCRIPTION
## Summary
- insert `{{ csrf_token() }}` in reviewer registration form
- include token in the review form
- add token to the revisor candidatura form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686d6b546da88324b452cc305ae4a96c