### PR TITLE
Consolidate arquivo_permitido utility

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from werkzeug.security import generate_password_hash
 from extensions import db, mail
 import logging
+from utils.arquivo_utils import arquivo_permitido
 
 logger = logging.getLogger(__name__)
 from models import (
@@ -3716,11 +3717,7 @@ def importar_oficinas():
         return redirect(url_for('dashboard_routes.dashboard_cliente'))
 
     # Verifica se a extensão é permitida (.xlsx)
-    ALLOWED_EXTENSIONS = {"xlsx"}
-    def arquivo_permitido(filename):
-        return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
-
-    if not arquivo_permitido(arquivo.filename):
+    if not (arquivo_permitido(arquivo.filename) and arquivo.filename.rsplit('.', 1)[1].lower() == "xlsx"):
         flash("Formato de arquivo inválido. Envie um arquivo Excel (.xlsx)", "danger")
         return redirect(url_for('dashboard_routes.dashboard_cliente'))
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,5 +1,0 @@
-# utils.py
-
-def arquivo_permitido(filename):
-    extensoes_permitidas = {'xls', 'xlsx', 'csv'}
-    return '.' in filename and filename.rsplit('.', 1)[1].lower() in extensoes_permitidas


### PR DESCRIPTION
## Summary
- remove old `utils.utils` helper module
- centralize `arquivo_permitido` in `utils/arquivo_utils`
- use the shared helper in `agendamento_routes` and drop the inline implementation

## Testing
- `pytest -q tests/test_utils.py`
- `pytest -q` *(fails: ImportError: cannot import name 'gerar_revisor_details_pdf')*

------
https://chatgpt.com/codex/tasks/task_e_686d6e23ade88324b4da2b7e946e9445