### PR TITLE
Fix CSRF token inclusion

### DIFF
--- a/templates/config/config_system.html
+++ b/templates/config/config_system.html
@@ -7,7 +7,7 @@
 
   <form method="POST" class="card p-4 shadow-sm" style="max-width: 440px;">
     {% if csrf_token is defined %}
-      {{ csrf_token() }}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% endif %} {# se CSRF estiver habilitado #}
     <div class="mb-3">
       <label class="form-label fw-bold">Taxa fixa por inscrição (R$)</label>

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1460,16 +1460,16 @@
           <td>{{ cand.status }}</td>
           <td>
             <form method="post" action="{{ url_for('revisor_routes.advance', cand_id=cand.id) }}" class="d-inline">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button class="btn btn-sm btn-primary">Avançar</button>
             </form>
 
             <form method="post" action="{{ url_for('revisor_routes.approve', cand_id=cand.id) }}" class="d-inline ms-1">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button class="btn btn-sm btn-success">Aprovar</button>
             </form>
             <form method="post" action="{{ url_for('revisor_routes.reject', cand_id=cand.id) }}" class="d-inline ms-1">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button class="btn btn-sm btn-danger">Rejeitar</button>
             </form>
           </td>

--- a/templates/peer_review/review_form.html
+++ b/templates/peer_review/review_form.html
@@ -4,7 +4,7 @@
   <h3>Revisar Trabalho</h3>
   <p><strong>{{ review.submission.title }}</strong></p>
   <form method="POST">
-    {{ csrf_token() }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="mb-3">
       <label>Código de Acesso</label>
       <input type="text" name="codigo" class="form-control" required>

--- a/templates/peer_review/reviewer_registration.html
+++ b/templates/peer_review/reviewer_registration.html
@@ -8,7 +8,7 @@
     </div>
     <div class="card-body">
       <form method="POST">
-        {{ csrf_token() }}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-3">
           <label for="nome" class="form-label">Nome</label>
           <input type="text" class="form-control" id="nome" name="nome" required>

--- a/templates/revisor/candidatura_form.html
+++ b/templates/revisor/candidatura_form.html
@@ -10,7 +10,7 @@
                 <i class="bi bi-info-circle me-2"></i>{{ formulario.descricao }}
             </div>
             <form method="POST" enctype="multipart/form-data">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 {% for campo in formulario.campos %}
                 <div class="mb-4">
                     <label class="form-label fw-bold" for="campo-{{ campo.id }}">

--- a/templates/trabalho/dar_feedback_resposta.html
+++ b/templates/trabalho/dar_feedback_resposta.html
@@ -19,7 +19,7 @@
 
   <form method="POST" class="feedback-form">
     {% if form is defined %}
-      {{ form.csrf_token() }}
+      <input type="hidden" name="csrf_token" value="{{ form.csrf_token() }}">
     {% endif %}
     
     <div class="feedback-items">

--- a/templates/trabalho/definir_status_resposta.html
+++ b/templates/trabalho/definir_status_resposta.html
@@ -8,7 +8,7 @@
 
   <form method="POST">
     <!-- Se estiver usando Flask-WTF, inclua o CSRF -->
-    <!-- {{ form.csrf_token() }} -->
+    <input type="hidden" name="csrf_token" value="{{ form.csrf_token() if form is defined }}">
 
     <div class="mb-3">
       <label for="status_avaliacao" class="form-label">Status da Resposta</label>

--- a/templates/trabalho/submeter_trabalho.html
+++ b/templates/trabalho/submeter_trabalho.html
@@ -4,7 +4,7 @@
   <h3 class="mb-4">Submissão de Trabalho Científico</h3>
   <form method="POST" enctype="multipart/form-data">
     {% if csrf_token is defined %}
-      {{ csrf_token() }}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% endif %}
     <div class="mb-3">
       <label for="titulo" class="form-label">Título</label>


### PR DESCRIPTION
## Summary
- ensure CSRF token is sent as hidden input on several forms

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686d71e98a188324a1f9a6c680c0ec01