### PR TITLE
Fix CSRF token handling on login and forms

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -293,6 +293,7 @@
                 </div>
                 
                 <form action="{{ url_for('auth_routes.login') }}" method="POST" class="login-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="form-group">
                         <label for="email">E-mail</label>
                         <div class="input-wrapper">

--- a/templates/base.html
+++ b/templates/base.html
@@ -352,6 +352,21 @@
     <!-- Theme Switcher Aprimorado -->
     <script>
         document.addEventListener("DOMContentLoaded", () => {
+            // Insere token CSRF automaticamente em formulários POST
+            const csrfTokenMeta = document.querySelector('meta[name="csrf-token"]');
+            if (csrfTokenMeta) {
+                const token = csrfTokenMeta.getAttribute('content');
+                document.querySelectorAll('form[method="POST"]').forEach(form => {
+                    if (!form.querySelector('input[name="csrf_token"]')) {
+                        const input = document.createElement('input');
+                        input.type = 'hidden';
+                        input.name = 'csrf_token';
+                        input.value = token;
+                        form.appendChild(input);
+                    }
+                });
+            }
+
             // Theme Switcher
             const themeSwitcher = {
                 init() {


### PR DESCRIPTION
## Summary
- embed CSRF token in login form
- auto-insert CSRF token in every POST form on page load

## Testing
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d752cef548324a43766dbeffc6a46