### PR TITLE
Fix reviewer approval without email

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -236,6 +236,13 @@ def approve(cand_id: int):
         return jsonify({"success": False}), 403
 
     cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
+    if not cand.email:
+        msg = "Candidatura sem email"
+        if request.is_json:
+            return jsonify({"success": False, "message": msg}), 400
+        flash(msg, "danger")
+        return redirect(url_for("dashboard_routes.dashboard_cliente"))
+
     cand.status = "aprovado"
     cand.etapa_atual = cand.process.num_etapas  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary
- prevent IntegrityError when approving a reviewer without an email
- test approving candidatura without email

## Testing
- `pytest -q tests/test_revisor_process.py`

------
https://chatgpt.com/codex/tasks/task_e_686d76f01ee88324998419fa529a9065