### PR TITLE
Fix usuario evento_id updates

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -158,7 +158,7 @@ def cadastro_participante(identifier: str | None = None):
                 db.session.add(usuario)
                 db.session.flush()
             else:
-                if usuario.evento_id != evento.id:
+                if usuario.evento_id is None:
                     usuario.evento_id = evento.id
 
             inscricao = Inscricao(
@@ -1092,7 +1092,7 @@ def inscricoes_lote():
         for uid in usuarios_afetados:
             usuario = Usuario.query.get(uid)
             # se o sistema admite apenas 1 evento corrente por usuário:
-            if usuario and usuario.evento_id != oficina_destino.evento_id:
+            if usuario and usuario.evento_id is None:
                 usuario.evento_id = oficina_destino.evento_id
 
         db.session.commit()


### PR DESCRIPTION
## Summary
- set `usuario.evento_id` only when not set during inscrição creation
- ensure bulk move sets `usuario.evento_id` only if currently None

## Testing
- `pip install -q -r requirements.txt` *(fails: ImportError in tests)*
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686db03400808324bfbac4014da3b8c1