### PR TITLE
Add option for participants to schedule visits

### DIFF
--- a/routes/dashboard_participante.py
+++ b/routes/dashboard_participante.py
@@ -269,6 +269,16 @@ def dashboard_participante():
     ).all()
     logger.debug(f"DEBUG [53] -> Encontrados {len(horarios_disponiveis)} horários disponíveis")
 
+    # Verificar se o evento atual possui horários disponíveis e configuração de
+    # agendamento habilitada
+    tem_horarios_agendamento = False
+    if evento:
+        horarios_evento = [h for h in horarios_disponiveis if h.evento_id == evento.id]
+        tem_horarios_agendamento = bool(horarios_evento) and bool(evento.configuracoes_agendamento)
+    logger.debug(
+        f"DEBUG [53A] -> Evento possui horários para agendamento? {tem_horarios_agendamento}"
+    )
+
     # Carregar regras de inscrição para o tipo de inscrição do usuário por evento
     logger.debug(f"DEBUG [54] -> Carregando regras de inscrição para tipo_inscricao_id = {current_user.tipo_inscricao_id}")
     regras_inscricao = {}
@@ -473,6 +483,7 @@ def dashboard_participante():
         habilitar_certificado_individual=habilitar_certificado,
         formularios_disponiveis=formularios_disponiveis,
         horarios_disponiveis=horarios_disponiveis,
+        tem_horarios_agendamento=tem_horarios_agendamento,
         # Variáveis para diagnóstico
         debug_total_oficinas=len(oficinas_formatadas),
         debug_oficinas_encerradas=len([o for o in oficinas_formatadas if o['evento_encerrado']]),

--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -389,9 +389,14 @@
 
   <div class="container-fluid px-4 mt-2">
     <div class="d-flex justify-content-end mb-4">
-      <a href="{{ url_for('agendamento_routes.meus_agendamentos_participante') }}" class="btn btn-info btn-lg">
+      <a href="{{ url_for('agendamento_routes.meus_agendamentos_participante') }}" class="btn btn-info btn-lg me-2">
         <i class="fas fa-calendar-alt me-2"></i> AGENDAMENTOS
       </a>
+      {% if tem_horarios_agendamento %}
+      <a href="{{ url_for('routes.horarios_disponiveis_participante', evento_id=evento.id) }}" class="btn btn-primary btn-lg">
+        <i class="fas fa-calendar-plus me-2"></i> Agendar Visita
+      </a>
+      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- compute flag for available scheduling slots per event
- surface a link for participants to schedule a visit when slots are open

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686fde6a9ba08324836334b034cc775a