### PR TITLE
Add evento link to ReviewerApplication

### DIFF
--- a/migrations/versions/b1d3f5a7c9e8_add_evento_id_to_reviewer_application.py
+++ b/migrations/versions/b1d3f5a7c9e8_add_evento_id_to_reviewer_application.py
@@ -1,0 +1,24 @@
+"""add evento_id to reviewer application
+
+Revision ID: b1d3f5a7c9e8
+Revises: 91da4eee8c01
+Create Date: 2025-07-10 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b1d3f5a7c9e8'
+down_revision = '91da4eee8c01'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('reviewer_application', sa.Column('evento_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_reviewer_application_evento_id_evento', 'reviewer_application', 'evento', ['evento_id'], ['id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_reviewer_application_evento_id_evento', 'reviewer_application', type_='foreignkey')
+    op.drop_column('reviewer_application', 'evento_id')

--- a/models.py
+++ b/models.py
@@ -1300,8 +1300,10 @@ class ReviewerApplication(db.Model):
     usuario_id = db.Column(db.Integer, db.ForeignKey("usuario.id"), nullable=False)
     stage = db.Column(db.String(50), default="novo")
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    evento_id = db.Column(db.Integer, db.ForeignKey('evento.id'), nullable=True)
 
     usuario = db.relationship("Usuario", backref=db.backref("reviewer_applications", lazy=True))
+    evento = db.relationship('Evento', backref=db.backref('reviewer_applications', lazy=True))
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<ReviewerApplication usuario={self.usuario_id} stage={self.stage}>"
@@ -1309,16 +1311,6 @@ class ReviewerApplication(db.Model):
     numero_revisores = db.Column(db.Integer, default=2)
     prazo_revisao = db.Column(db.DateTime, nullable=True)
     modelo_blind = db.Column(db.String(20), default="single")  # single | double | open
-
-    evento = db.relationship(
-        "Evento", backref=db.backref("revisao_config", uselist=False)
-    )
-
-    def __repr__(self):
-        return (
-            f"<RevisaoConfig evento={self.evento_id} revisores={self.numero_revisores} "
-            f"blind={self.modelo_blind}>"
-        )
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_reviewer_applications.py
+++ b/tests/test_reviewer_applications.py
@@ -49,6 +49,7 @@ pdf_service_stub.gerar_qrcode_token = lambda *a, **k: send_file(BytesIO(b''), do
 pdf_service_stub.gerar_programacao_evento_pdf = lambda *a, **k: send_file(BytesIO(b''), download_name='x.pdf')
 pdf_service_stub.gerar_placas_oficinas_pdf = lambda *a, **k: send_file(BytesIO(b''), download_name='x.pdf')
 pdf_service_stub.exportar_checkins_pdf_opcoes = lambda *a, **k: send_file(BytesIO(b''), download_name='x.pdf')
+pdf_service_stub.gerar_revisor_details_pdf = lambda *a, **k: send_file(BytesIO(b''), download_name='x.pdf')
 sys.modules.setdefault('services.pdf_service', pdf_service_stub)
 arquivo_utils_stub = types.ModuleType('utils.arquivo_utils')
 arquivo_utils_stub.arquivo_permitido = lambda *a, **k: True


### PR DESCRIPTION
## Summary
- link `ReviewerApplication` to `Evento`
- create Alembic migration for new foreign key
- ensure PDF service stub defines required function for tests

## Testing
- `pytest tests/test_revisor_process_extra.py::test_eligible_events_route -q`
- `pytest -q` *(fails: sqlalchemy.exc.IntegrityError and BuildError)*

------
https://chatgpt.com/codex/tasks/task_e_686fdd885678832498f8674ddaf433b9