### PR TITLE
Add new reviewer application migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Com o ambiente configurado você pode aplicar as migrações executando:
 flask db upgrade
 ```
 
+Uma nova revisão `671cbede4123` adiciona os campos `numero_revisores`, `prazo_revisao` e
+`modelo_blind` à tabela `reviewer_application`.
+
 `SECRET_KEY` garante que as sessões geradas por uma instância do Flask possam
 ser lidas por outra. Em produção, utilize um valor seguro e idêntico em todas as
 réplicas do aplicativo.

--- a/migrations/versions/671cbede4123_add_review_params_to_reviewer_application.py
+++ b/migrations/versions/671cbede4123_add_review_params_to_reviewer_application.py
@@ -1,0 +1,28 @@
+"""add review control fields to reviewer_application
+
+Revision ID: 671cbede4123
+Revises: b1d3f5a7c9e8
+Create Date: 2026-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '671cbede4123'
+down_revision = 'b1d3f5a7c9e8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('reviewer_application') as batch_op:
+        batch_op.add_column(sa.Column('numero_revisores', sa.Integer(), nullable=False, server_default='2'))
+        batch_op.add_column(sa.Column('prazo_revisao', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('modelo_blind', sa.String(length=20), nullable=False, server_default='single'))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('reviewer_application') as batch_op:
+        batch_op.drop_column('modelo_blind')
+        batch_op.drop_column('prazo_revisao')
+        batch_op.drop_column('numero_revisores')


### PR DESCRIPTION
## Summary
- create migration to extend `reviewer_application` with review settings
- mention the new migration in the README

## Testing
- `pytest -q` *(fails: BuildError and IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_686fe27737c08324b518d27e15adcfec