### PR TITLE
Fix missing Inscricao import

### DIFF
--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -12,7 +12,8 @@ from PIL import Image
 from extensions import db
 from models import (
     Evento, ProfessorBloqueado, SalaVisitacao, HorarioVisitacao,
-    AgendamentoVisita, AlunoVisitante, ConfiguracaoAgendamento, Oficina
+    AgendamentoVisita, AlunoVisitante, ConfiguracaoAgendamento, Oficina,
+    Inscricao,
 
 )
 from services.pdf_service import gerar_pdf_comprovante_agendamento


### PR DESCRIPTION
## Summary
- fix reference to Inscricao model in professor routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_686fe2f25b0c832482c832313514ae0e