### PR TITLE
Add candidatura detail view

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -318,6 +318,18 @@ def advance(cand_id: int):
     return redirect(url_for("dashboard_routes.dashboard_cliente"))
 
 
+@revisor_routes.route("/revisor/view/<int:cand_id>")
+@login_required
+def view_candidatura(cand_id: int):
+    """Exibe os detalhes e respostas de uma candidatura."""
+    if current_user.tipo not in {"cliente", "admin", "superadmin"}:  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
+
+    cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
+    return render_template("revisor/candidatura_detail.html", candidatura=cand)
+
+
 # -----------------------------------------------------------------------------
 # EVENTOS ELEGÍVEIS PARA PARTICIPANTES
 # -----------------------------------------------------------------------------

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1502,6 +1502,7 @@
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button class="btn btn-sm btn-danger">Rejeitar</button>
             </form>
+            <a href="{{ url_for('revisor_routes.view_candidatura', cand_id=cand.id) }}" class="btn btn-sm btn-secondary ms-1">Ver Detalhes</a>
           </td>
         </tr>
         {% else %}

--- a/templates/revisor/candidatura_detail.html
+++ b/templates/revisor/candidatura_detail.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Detalhes da Candidatura{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Detalhes da Candidatura</h1>
+  <p><strong>Nome:</strong> {{ candidatura.nome or candidatura.email }}</p>
+  <p><strong>Status:</strong> {{ candidatura.status }}</p>
+  <table class="table table-striped mt-4">
+    <thead>
+      <tr><th>Campo</th><th>Resposta</th></tr>
+    </thead>
+    <tbody>
+    {% for key, value in candidatura.respostas.items() %}
+      <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('dashboard_routes.dashboard_cliente') }}" class="btn btn-secondary mt-3">Voltar</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add view_candidatura route to show answers
- display candidatura items with new template
- expose "Ver Detalhes" in dashboard
- stub heavy dependencies in test and cover the new route

## Testing
- `pytest tests/test_revisor_process.py::test_view_candidatura_route -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff34e79c88324b7a7eed4de13f17a