### PR TITLE
Fix redirect for QR checkin

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -10,6 +10,7 @@ from models import (
     Checkin, Inscricao, Oficina, ConfiguracaoCliente, AgendamentoVisita, Evento
 )
 from utils import formatar_brasilia, determinar_turno
+from .agendamento_routes import agendamento_routes  # Needed for URL generation
 
 checkin_routes = Blueprint('checkin_routes', __name__)
 
@@ -267,9 +268,8 @@ def checkin_token():
     else:
         # Realizar check-in
         return redirect(url_for(
-            'routes.checkin_agendamento', 
-            agendamento_id=agendamento.id,
-            token=token
+            'agendamento_routes.checkin_agendamento',
+            qr_code_token=token
         ))
     
     # Redirecionar para detalhes do agendamento


### PR DESCRIPTION
## Summary
- import `agendamento_routes` blueprint so url generation works
- redirect to the new `agendamento_routes.checkin_agendamento` route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68712a7617088324a1c951e43bde3534