### PR TITLE
Add configuracao_evento to_dict

### DIFF
--- a/models.py
+++ b/models.py
@@ -691,6 +691,33 @@ class ConfiguracaoEvento(db.Model):
     limite_formularios = db.Column(db.Integer, default=3)
     limite_revisores = db.Column(db.Integer, default=2)
 
+    def to_dict(self):
+        """Return a dictionary representation of configuration flags."""
+        fields = [
+            "permitir_checkin_global",
+            "habilitar_qrcode_evento_credenciamento",
+            "habilitar_feedback",
+            "habilitar_certificado_individual",
+            "mostrar_taxa",
+            "habilitar_submissao_trabalhos",
+            "review_model",
+            "num_revisores_min",
+            "num_revisores_max",
+            "prazo_parecer_dias",
+            "obrigatorio_nome",
+            "obrigatorio_cpf",
+            "obrigatorio_email",
+            "obrigatorio_senha",
+            "obrigatorio_formacao",
+            "allowed_file_types",
+            "taxa_diferenciada",
+            "limite_eventos",
+            "limite_inscritos",
+            "limite_formularios",
+            "limite_revisores",
+        ]
+        return {f: getattr(self, f) for f in fields}
+
 
 
 

--- a/tests/test_config_event_route.py
+++ b/tests/test_config_event_route.py
@@ -1,0 +1,66 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Cliente, Evento, ConfiguracaoCliente
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_configuracao_evento_defaults(client, app):
+    with app.app_context():
+        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+        evento = Evento(cliente_id=cliente.id, nome='EV')
+        db.session.add(evento)
+        db.session.commit()
+        eid = evento.id
+        db.session.add(ConfiguracaoCliente(cliente_id=cliente.id))
+        db.session.commit()
+
+    login(client, 'cli@example.com', '123')
+    resp = client.get(f'/api/configuracao_evento/{eid}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    expected_keys = [
+        'permitir_checkin_global',
+        'habilitar_qrcode_evento_credenciamento',
+        'habilitar_feedback',
+        'habilitar_certificado_individual',
+        'mostrar_taxa',
+        'habilitar_submissao_trabalhos',
+        'review_model',
+        'num_revisores_min',
+        'num_revisores_max',
+        'prazo_parecer_dias',
+        'obrigatorio_nome',
+        'obrigatorio_cpf',
+        'obrigatorio_email',
+        'obrigatorio_senha',
+        'obrigatorio_formacao',
+        'allowed_file_types',
+    ]
+    for key in expected_keys:
+        assert key in data
+    assert data['success'] is True


### PR DESCRIPTION
## Summary
- implement `ConfiguracaoEvento.to_dict`
- expose event configuration using the new helper
- test `/api/configuracao_evento/<id>` returns all expected fields

## Testing
- `pytest tests/test_config_event_route.py -q`
- `pytest -q` *(fails: BuildError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68716a7dc67c83249b32ea804c085316