### PR TITLE
Add event preview link to client dashboard

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -109,12 +109,21 @@ const fieldButtonMap = {
 };
 
 const eventoSelect = document.getElementById("selectConfigEvento");
+const previewEventoBtn = document.getElementById("previewEventoBtn");
 if (eventoSelect) {
   EVENTO_ATUAL = eventoSelect.value;
+  const updatePreview = () => {
+    if (previewEventoBtn) {
+      const base = previewEventoBtn.dataset.baseUrl || previewEventoBtn.href;
+      previewEventoBtn.href = `${base}${encodeURIComponent(eventoSelect.value)}`;
+    }
+  };
+  updatePreview();
   carregarConfiguracao(EVENTO_ATUAL);
   eventoSelect.addEventListener("change", function () {
     if (!this.value) return;
     EVENTO_ATUAL = this.value;
+    updatePreview();
     carregarConfiguracao(EVENTO_ATUAL);
   });
 }

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -884,12 +884,21 @@
                 <!-- Seletor de Evento -->
                 <div class="mb-4">
                   <label for="selectConfigEvento" class="form-label">Evento</label>
-                  <select id="selectConfigEvento" class="form-select">
-                    <option value="">-- Selecione um evento --</option>
-                    {% for evento in eventos %}
-                      <option value="{{ evento.id }}">{{ evento.nome }}</option>
-                    {% endfor %}
-                  </select>
+                  <div class="d-flex gap-2">
+                    <select id="selectConfigEvento" class="form-select">
+                      <option value="">-- Selecione um evento --</option>
+                      {% for evento in eventos %}
+                        <option value="{{ evento.id }}">{{ evento.nome }}</option>
+                      {% endfor %}
+                    </select>
+                    <a id="previewEventoBtn"
+                       class="btn btn-outline-secondary"
+                       target="_blank"
+                       data-base-url="{{ url_for('evento_routes.exibir_evento', evento_id=0)[:-1] }}"
+                       href="{{ url_for('evento_routes.exibir_evento', evento_id=0)[:-1] }}">
+                      <i class="bi bi-eye-fill me-2"></i> Visualizar Evento
+                    </a>
+                  </div>
                 </div>
 
                 <!-- Itens de Configuração -->

--- a/tests/test_dashboard_cliente_preview.py
+++ b/tests/test_dashboard_cliente_preview.py
@@ -1,0 +1,41 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+from app import create_app
+from extensions import db
+from models import Usuario, Cliente, Evento
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+        Evento(cliente_id=cliente.id, nome='EV')
+        db.session.commit()
+        Usuario(id=cliente.id, nome='CliUser', cpf='1', email='cli@test', senha=generate_password_hash('123'), formacao='x', tipo='cliente')
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_preview_evento_button_present(client, app):
+    login(client, 'cli@test', '123')
+    resp = client.get('/dashboard_cliente')
+    assert resp.status_code == 200
+    assert b'id="previewEventoBtn"' in resp.data


### PR DESCRIPTION
## Summary
- show a "Visualizar Evento" link beside the event selector in dashboard_cliente.html
- update JS to keep the preview link pointed to the selected event
- add regression test ensuring the link renders for logged in clients

## Testing
- `pytest tests/test_dashboard_cliente_preview.py -q`
- `pytest -q` *(fails: BuildError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68716a8048f48324aa2a2a490c6aaf2b