### PR TITLE
Implement preview_evento route

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -727,6 +727,38 @@ def exibir_evento(evento_id):
         grouped_oficinas=grouped_oficinas
     )
 
+
+@evento_routes.route('/preview_evento/<int:evento_id>')
+def preview_evento(evento_id):
+    """Versão pública da visualização de um evento."""
+    evento = Evento.query.get_or_404(evento_id)
+
+    oficinas = Oficina.query.filter_by(cliente_id=evento.cliente_id).all()
+
+    grouped_oficinas = defaultdict(list)
+    for oficina in oficinas:
+        for dia in oficina.dias:
+            data_str = dia.data.strftime('%d/%m/%Y')
+            grouped_oficinas[data_str].append({
+                'titulo': oficina.titulo,
+                'descricao': oficina.descricao,
+                'ministrante': oficina.ministrante_obj,
+                'horario_inicio': dia.horario_inicio,
+                'horario_fim': dia.horario_fim
+            })
+
+    sorted_keys = sorted(
+        grouped_oficinas.keys(),
+        key=lambda d: datetime.strptime(d, '%d/%m/%Y')
+    )
+
+    return render_template(
+        'evento/preview_evento.html',
+        evento=evento,
+        sorted_keys=sorted_keys,
+        grouped_oficinas=grouped_oficinas
+    )
+
 @evento_routes.route('/criar_evento', methods=['GET', 'POST'])
 @login_required
 def criar_evento():

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -894,8 +894,8 @@
                     <a id="previewEventoBtn"
                        class="btn btn-outline-secondary"
                        target="_blank"
-                       data-base-url="{{ url_for('evento_routes.exibir_evento', evento_id=0)[:-1] }}"
-                       href="{{ url_for('evento_routes.exibir_evento', evento_id=0)[:-1] }}">
+                       data-base-url="{{ url_for('evento_routes.preview_evento', evento_id=0)[:-1] }}"
+                       href="{{ url_for('evento_routes.preview_evento', evento_id=0)[:-1] }}">
                       <i class="bi bi-eye-fill me-2"></i> Visualizar Evento
                     </a>
                   </div>

--- a/templates/evento/preview_evento.html
+++ b/templates/evento/preview_evento.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}{{ evento.nome }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <h2>{{ evento.nome }}</h2>
+  <p>{{ evento.descricao }}</p>
+  {% for data in sorted_keys %}
+    <h4 class="mt-4">{{ data }}</h4>
+    <ul class="list-group mb-3">
+      {% for of in grouped_oficinas[data] %}
+        <li class="list-group-item">
+          <strong>{{ of.titulo }}</strong> - {{ of.ministrante.nome }}
+          <div class="small text-muted">
+            {{ of.horario_inicio.strftime('%H:%M') }} - {{ of.horario_fim.strftime('%H:%M') }}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a public `preview_evento` route in `evento_routes`
- link preview button in dashboard to new route
- add simple template to render event preview

## Testing
- `pytest -q` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6871718ee3848324932e1cd52aa3db21