### PR TITLE
Fix config toggle field names

### DIFF
--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -736,10 +736,10 @@ def toggle_configuracao_evento(evento_id, campo):
     if evento.cliente_id != current_user.id:
         return jsonify({"success": False, "message": "Acesso negado"}), 403
     valid = {
-        'permitir_checkin',
-        'habilitar_qrcode_credenciamento',
+        'permitir_checkin_global',
+        'habilitar_qrcode_evento_credenciamento',
         'habilitar_feedback',
-        'habilitar_certificado',
+        'habilitar_certificado_individual',
         'mostrar_taxa',
         'obrigatorio_nome',
         'obrigatorio_cpf',

--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -96,10 +96,10 @@ const URL_EVENTO_CONFIG_BASE = typeof URL_EVENTO_CONFIG_BASE !== "undefined" ? U
 let EVENTO_ATUAL = null;
 
 const fieldButtonMap = {
-  "permitir_checkin": document.getElementById("btnToggleCheckin"),
-  "habilitar_qrcode_credenciamento": document.getElementById("btnToggleQrCredenciamento"),
+  "permitir_checkin_global": document.getElementById("btnToggleCheckin"),
+  "habilitar_qrcode_evento_credenciamento": document.getElementById("btnToggleQrCredenciamento"),
   "habilitar_feedback": document.getElementById("btnToggleFeedback"),
-  "habilitar_certificado": document.getElementById("btnToggleCertificado"),
+  "habilitar_certificado_individual": document.getElementById("btnToggleCertificado"),
   "mostrar_taxa": document.getElementById("btnToggleMostrarTaxa"),
   "obrigatorio_nome": document.getElementById("btnToggleObrigatorioNome"),
   "obrigatorio_cpf": document.getElementById("btnToggleObrigatorioCpf"),

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -912,7 +912,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Permite que participantes façam check-in pelo aplicativo</p>
                       </div>
-                      <button type="button" id="btnToggleCheckin" class="btn btn-toggle btn-danger" data-field="permitir_checkin">
+                      <button type="button" id="btnToggleCheckin" class="btn btn-toggle btn-danger" data-field="permitir_checkin_global">
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -926,7 +926,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Habilita uso de QR code para credenciamento em eventos</p>
                       </div>
-                      <button type="button" id="btnToggleQrCredenciamento" class="btn btn-toggle btn-danger" data-field="habilitar_qrcode_credenciamento">
+                      <button type="button" id="btnToggleQrCredenciamento" class="btn btn-toggle btn-danger" data-field="habilitar_qrcode_evento_credenciamento">
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -955,7 +955,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Permite que participantes baixem certificados</p>
                       </div>
-                      <button type="button" id="btnToggleCertificado" class="btn btn-toggle btn-danger" data-field="habilitar_certificado">
+                      <button type="button" id="btnToggleCertificado" class="btn btn-toggle btn-danger" data-field="habilitar_certificado_individual">
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>


### PR DESCRIPTION
## Summary
- align dashboard toggle `data-field` attributes with `ConfiguracaoEvento` column names
- update JS mapping for new config field names
- accept new names in `toggle_configuracao_evento`

## Testing
- `pytest tests/test_config_event_route.py::test_configuracao_evento_defaults -q`


------
https://chatgpt.com/codex/tasks/task_e_687171b187d0832497de30fcf4b619ea