### PR TITLE
Add preview button href test

### DIFF
--- a/tests/test_dashboard_cliente_preview.py
+++ b/tests/test_dashboard_cliente_preview.py
@@ -19,7 +19,8 @@ def app():
         cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
         db.session.add(cliente)
         db.session.commit()
-        Evento(cliente_id=cliente.id, nome='EV')
+        evento = Evento(cliente_id=cliente.id, nome='EV')
+        db.session.add(evento)
         db.session.commit()
         Usuario(id=cliente.id, nome='CliUser', cpf='1', email='cli@test', senha=generate_password_hash('123'), formacao='x', tipo='cliente')
         db.session.commit()
@@ -34,8 +35,31 @@ def login(client, email, senha):
     return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
 
 
+from bs4 import BeautifulSoup
+
+
 def test_preview_evento_button_present(client, app):
     login(client, 'cli@test', '123')
     resp = client.get('/dashboard_cliente')
     assert resp.status_code == 200
-    assert b'id="previewEventoBtn"' in resp.data
+
+    soup = BeautifulSoup(resp.data, 'html.parser')
+    preview_btn = soup.select_one('#previewEventoBtn')
+    assert preview_btn is not None
+
+    evento_select = soup.select_one('#selectConfigEvento')
+    assert evento_select is not None
+    first_event_id = None
+    for option in evento_select.find_all('option'):
+        value = option.get('value')
+        if value:
+            first_event_id = value
+            break
+
+    assert first_event_id is not None
+
+    expected_url = preview_btn['data-base-url'] + str(first_event_id)
+    assert expected_url.endswith(str(first_event_id))
+
+    preview_resp = client.get(expected_url)
+    assert preview_resp.status_code in (200, 302)


### PR DESCRIPTION
## Summary
- ensure test DB contains a demo event
- parse `/dashboard_cliente` with BeautifulSoup and verify preview link

## Testing
- `pytest -q tests/test_dashboard_cliente_preview.py -vv`
- `pytest -q` *(fails: DetachedInstanceError & IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_6871718fb2808324b3c49f3bd8b88f2f