### PR TITLE
Fix config base fallback in dashboard cliente

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -92,7 +92,10 @@ document.addEventListener('DOMContentLoaded', function() {
   } else {
     console.warn("Elementos select de estado ou cidade não encontrados.");
   }
-const URL_EVENTO_CONFIG_BASE = typeof URL_EVENTO_CONFIG_BASE !== "undefined" ? URL_EVENTO_CONFIG_BASE : "/api/configuracao_evento";
+const URL_EVENTO_CONFIG_BASE =
+  typeof window.URL_EVENTO_CONFIG_BASE !== "undefined"
+    ? window.URL_EVENTO_CONFIG_BASE
+    : "/api/configuracao_evento";
 let EVENTO_ATUAL = null;
 
 const fieldButtonMap = {


### PR DESCRIPTION
## Summary
- use `window.URL_EVENTO_CONFIG_BASE` when available

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687177df58388324bdf9a1cd35c5769c