### PR TITLE
Fix time display in event templates

### DIFF
--- a/templates/evento/exibir_evento.html
+++ b/templates/evento/exibir_evento.html
@@ -11,7 +11,7 @@
         <li class="list-group-item">
           <strong>{{ of.titulo }}</strong> - {{ of.ministrante.nome }}
           <div class="small text-muted">
-            {{ of.horario_inicio.strftime('%H:%M') }} - {{ of.horario_fim.strftime('%H:%M') }}
+            {{ of.horario_inicio }} - {{ of.horario_fim }}
           </div>
         </li>
       {% endfor %}

--- a/templates/evento/preview_evento.html
+++ b/templates/evento/preview_evento.html
@@ -11,7 +11,7 @@
         <li class="list-group-item">
           <strong>{{ of.titulo }}</strong> - {{ of.ministrante.nome }}
           <div class="small text-muted">
-            {{ of.horario_inicio.strftime('%H:%M') }} - {{ of.horario_fim.strftime('%H:%M') }}
+            {{ of.horario_inicio }} - {{ of.horario_fim }}
           </div>
         </li>
       {% endfor %}


### PR DESCRIPTION
## Summary
- adjust preview and event templates to show times without formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6871799853bc8324895b54f157e964ce