### PR TITLE
Fix QR check-in POST requests

### DIFF
--- a/templates/checkin/scan_qr.html
+++ b/templates/checkin/scan_qr.html
@@ -141,6 +141,7 @@
     
     let scanner = null;
     const checkinsRegistrados = new Set(); // Evita duplicar a mesma pessoa+oficina
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
     
     function onScanSuccess(decodedText) {
         let scannedToken = null;
@@ -171,7 +172,10 @@
         try {
             const response = await fetch("{{ url_for('checkin_routes.leitor_checkin_json') }}", {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": csrfToken
+                },
                 body: JSON.stringify({ token })
             });
     


### PR DESCRIPTION
## Summary
- include CSRF token in QR code check-in AJAX calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6871c50d680c8324af8d44638a95ef2c