### PR TITLE
Fix stray comment in checkin_routes

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -301,7 +301,7 @@ def leitor_checkin_json():
         return jsonify(status='error',
                        message='Inscrição não encontrada.'), 404
 
-    cliente_id   = inscricao.cliente_id        # já existe no modelo :contentReference[oaicite:0]{index=0}
+    cliente_id   = inscricao.cliente_id
     sala_cliente = f"cliente_{cliente_id}"     # sala usada no Socket.IO
 
     # ---------- EVENTO ----------


### PR DESCRIPTION
## Summary
- remove an outdated inline comment referencing `contentReference` in `routes/checkin_routes.py`

## Testing
- `pip install python-dotenv werkzeug flask bleach`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 9 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6871cd27d6308324968573760d99b5a8