### PR TITLE
Fix QR label hyphenation

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -315,7 +315,7 @@ def leitor_checkin_json():
         novo = Checkin(usuario_id = inscricao.usuario_id,
                        evento_id  = inscricao.evento_id,
                        cliente_id = cliente_id,          # ★ grava aqui
-                       palavra_chave = "QR‑EVENTO")
+                       palavra_chave = "QR-EVENTO")
     # ---------- OFICINA ----------
     elif inscricao.oficina_id:
         if Checkin.query.filter_by(usuario_id=inscricao.usuario_id,
@@ -326,7 +326,7 @@ def leitor_checkin_json():
         novo = Checkin(usuario_id = inscricao.usuario_id,
                        oficina_id = inscricao.oficina_id,
                        cliente_id = cliente_id,          # ★ grava aqui
-                       palavra_chave = "QR‑OFICINA")
+                       palavra_chave = "QR-OFICINA")
     else:
         return jsonify(status='error',
                        message='Inscrição sem evento ou oficina.'), 400
@@ -378,8 +378,7 @@ def lista_checkins_qr():
             Checkin.palavra_chave.in_([
                 'QR-AUTO',
                 'QR-EVENTO',
-                'QR-OFICINA',
-                'QR‑OFICINA'
+                'QR-OFICINA'
             ]),
             or_(
                 Usuario.cliente_id == current_user.id,

--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -65,8 +65,7 @@ def dashboard_cliente():
             Checkin.palavra_chave.in_([
                 'QR-AUTO',
                 'QR-EVENTO',
-                'QR-OFICINA',
-                'QR‑OFICINA'
+                'QR-OFICINA'
             ]),
             or_(
                 Usuario.cliente_id == current_user.id,

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1313,7 +1313,7 @@ def gerar_pdf_checkins_qr():
         .outerjoin(Checkin.oficina)
         .outerjoin(Checkin.usuario)
         .filter(
-            Checkin.palavra_chave.in_(['QR-AUTO', 'QR-EVENTO', 'QR-OFICINA', 'QR‑OFICINA']),
+            Checkin.palavra_chave.in_(['QR-AUTO', 'QR-EVENTO', 'QR-OFICINA']),
             or_(
                 Usuario.cliente_id == current_user.id,
                 Oficina.cliente_id == current_user.id,


### PR DESCRIPTION
## Summary
- standardize QR label hyphens in checkin handling
- query only uses normalized labels

## Testing
- `pytest -q` *(fails: werkzeug.routing.BuildError etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6871cd28d4ac83249b1e139d83b89008