### PR TITLE
Add password validation on signup reuse

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -126,6 +126,9 @@ def cadastro_participante(identifier: str | None = None):
 
             usuario = None
             if duplicado:
+                if not check_password_hash(duplicado.senha, senha):
+                    flash("Senha incorreta. Faça login.", "warning")
+                    return redirect(url_for("auth_routes.login"))
                 usuario = duplicado
                 inscr_existente = Inscricao.query.filter_by(
                     usuario_id=duplicado.id, evento_id=evento.id

--- a/tests/test_usuario_registration_multi_event.py
+++ b/tests/test_usuario_registration_multi_event.py
@@ -79,3 +79,24 @@ def test_existing_user_registers_new_event(client, app):
         assert Inscricao.query.filter_by(usuario_id=usuario.id, evento_id=evento1.id).count() == 1
         assert Inscricao.query.filter_by(usuario_id=usuario.id, evento_id=evento2.id).count() == 1
         assert Inscricao.query.count() == 2
+
+
+def test_existing_user_wrong_password_fails(client, app):
+    data = {
+        'nome': 'User',
+        'cpf': '111',
+        'email': 'user@example.com',
+        'senha': 'wrong',
+        'formacao': 'F',
+    }
+
+    resp = client.post('/inscricao/token/t2', data=data, follow_redirects=True)
+    assert resp.status_code in (200, 302)
+    assert b'Login AppFiber' in resp.data
+
+    with app.app_context():
+        usuario = Usuario.query.filter_by(email='user@example.com').first()
+        evento2 = Evento.query.filter_by(nome='E2').first()
+        assert Usuario.query.count() == 1
+        assert Inscricao.query.filter_by(usuario_id=usuario.id, evento_id=evento2.id).count() == 0
+        assert Inscricao.query.count() == 1


### PR DESCRIPTION
## Summary
- require existing users to enter correct password when signing up for an event
- test signup flow for existing users with wrong and correct password

## Testing
- `pytest tests/test_usuario_registration_multi_event.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68769d86bf2c8324a2a52e396c27e1f4