### PR TITLE
Allow participants to view other client forms

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -17,7 +17,10 @@ naming_convention = {
     "pk": "pk_%(table_name)s",
 }
 
-db = SQLAlchemy(metadata=MetaData(naming_convention=naming_convention))
+db = SQLAlchemy(
+    metadata=MetaData(naming_convention=naming_convention),
+    session_options={"expire_on_commit": False},
+)
 login_manager = LoginManager()
 migrate = Migrate()
 mail = Mail()

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -279,10 +279,14 @@ def listar_formularios_participante():
         flash("Você não está associado a nenhum cliente.", "warning")
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
         
-    # Base query: formulários criados pelo cliente do participante
-    query = Formulario.query.filter_by(cliente_id=cliente_id)
+    # Base query
     if evento_id:
-        query = query.join(Formulario.eventos).filter(Evento.id == evento_id)
+        # Se um evento foi selecionado, exibe formulários associados
+        # independentemente do cliente do participante
+        query = Formulario.query.join(Formulario.eventos).filter(Evento.id == evento_id)
+    else:
+        # Mantém o comportamento atual quando nenhum evento é fornecido
+        query = Formulario.query.filter_by(cliente_id=cliente_id)
     formularios = query.all()
     
     # Não há relação direta entre formulários e ministrantes no modelo atual,

--- a/tests/test_formulario_participante_crossclient.py
+++ b/tests/test_formulario_participante_crossclient.py
@@ -1,0 +1,62 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Cliente, Evento, Formulario, Usuario
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
+        db.session.add_all([c1, c2])
+        db.session.commit()
+        f1 = Formulario(nome='F1', cliente_id=c1.id)
+        f2 = Formulario(nome='F2', cliente_id=c2.id)
+        ev = Evento(cliente_id=c2.id, nome='EV', inscricao_gratuita=True, publico=True)
+        db.session.add_all([f1, f2, ev])
+        db.session.commit()
+        ev.formularios.append(f2)
+        db.session.commit()
+        p1 = Usuario(nome='Part1', cpf='1', email='p1@test', senha=generate_password_hash('123'), formacao='x', tipo='participante', cliente_id=c1.id, evento_id=ev.id)
+        p2 = Usuario(nome='Part2', cpf='2', email='p2@test', senha=generate_password_hash('123'), formacao='x', tipo='participante', cliente_id=c1.id)
+        db.session.add_all([p1, p2])
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_cross_client_event_forms_visible(client, app):
+    with app.app_context():
+        evento = Evento.query.filter_by(nome='EV').first()
+    login(client, 'p1@test', '123')
+    resp = client.get(f'/formularios_participante?evento_id={evento.id}')
+    assert resp.status_code == 200
+    data = resp.get_data(as_text=True)
+    assert 'F2' in data
+    assert 'F1' not in data
+
+
+def test_default_behavior_same_client(client, app):
+    login(client, 'p2@test', '123')
+    resp = client.get('/formularios_participante')
+    assert resp.status_code == 200
+    data = resp.get_data(as_text=True)
+    assert 'F1' in data
+    assert 'F2' not in data


### PR DESCRIPTION
## Summary
- allow participants to list event forms from other clients
- keep default behaviour when no event is supplied
- prevent session expiration after commit
- test listing forms for cross-client events

## Testing
- `pytest tests/test_formulario_participante_crossclient.py -q`
- `pytest -q` *(fails: BuildError in routes.gerar_etiquetas_route and others)*

------
https://chatgpt.com/codex/tasks/task_e_68769d8f1f288324bc202cc8fe8d6dea