### PR TITLE
Fix login redirect preserving next parameter

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -294,6 +294,9 @@
                 
                 <form action="{{ url_for('auth_routes.login') }}" method="POST" class="login-form">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    {% if next %}
+                    <input type="hidden" name="next" value="{{ next }}">
+                    {% endif %}
                     <div class="form-group">
                         <label for="email">E-mail</label>
                         <div class="input-wrapper">


### PR DESCRIPTION
## Summary
- preserve the `next` parameter during login so users return to the intended page
- make MFA flow redirect to the stored page
- include hidden `next` input in login page

## Testing
- `pytest -q` *(fails: 42 failed, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6876ac54d6d8832489b1f2077b6d5a14