### PR TITLE
Implement usuario-client association

### DIFF
--- a/migrations/versions/c52904b5be19_create_usuario_clientes_table.py
+++ b/migrations/versions/c52904b5be19_create_usuario_clientes_table.py
@@ -1,0 +1,42 @@
+"""create usuario_clientes association table
+
+Revision ID: c52904b5be19
+Revises: 2ff567091303
+Create Date: 2026-01-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect, text
+
+# revision identifiers, used by Alembic.
+revision = 'c52904b5be19'
+down_revision = '2ff567091303'
+branch_labels = None
+depends_on = None
+
+TABLE = 'usuario_clientes'
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+
+    if TABLE not in insp.get_table_names():
+        op.create_table(
+            TABLE,
+            sa.Column('usuario_id', sa.Integer(), sa.ForeignKey('usuario.id'), primary_key=True),
+            sa.Column('cliente_id', sa.Integer(), sa.ForeignKey('cliente.id'), primary_key=True),
+        )
+
+    bind.execute(text(
+        f"INSERT INTO {TABLE} (usuario_id, cliente_id) "
+        "SELECT id, cliente_id FROM usuario WHERE cliente_id IS NOT NULL"
+    ))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+
+    if TABLE in insp.get_table_names():
+        op.drop_table(TABLE)

--- a/models.py
+++ b/models.py
@@ -38,7 +38,8 @@ class Usuario(db.Model, UserMixin):
     tipo_inscricao_id = db.Column(db.Integer, db.ForeignKey('evento_inscricao_tipo.id'), nullable=True)
 
     tipo_inscricao = db.relationship('EventoInscricaoTipo', backref=db.backref('usuarios', lazy=True))
-    cliente = db.relationship('Cliente', backref=db.backref('usuarios', lazy=True))
+    cliente = db.relationship('Cliente', backref=db.backref('usuarios_legacy', lazy=True))
+    clientes = db.relationship('Cliente', secondary='usuario_clientes', back_populates='usuarios')
     evento = db.relationship('Evento', backref=db.backref('usuarios', lazy=True))
     # NOVOS CAMPOS PARA LOCAIS DE ATUAÇÃO:
     estados = db.Column(db.String(255), nullable=True)   # Ex.: "SP,RJ,MG"
@@ -118,6 +119,13 @@ evento_formulario_association = db.Table(
     'evento_formulario_association',
     db.Column('evento_id', db.Integer, db.ForeignKey('evento.id'), primary_key=True),
     db.Column('formulario_id', db.Integer, db.ForeignKey('formularios.id'), primary_key=True)
+)
+
+# Association table linking usuarios e clientes
+usuario_clientes = db.Table(
+    'usuario_clientes',
+    db.Column('usuario_id', db.Integer, db.ForeignKey('usuario.id')),
+    db.Column('cliente_id', db.Integer, db.ForeignKey('cliente.id')),
 )
 
 
@@ -493,8 +501,9 @@ class Cliente(db.Model, UserMixin):
 
      # Relacionamento com Oficina
     oficinas = db.relationship("Oficina", back_populates="cliente")  # ✅ Agora usa `back_populates`
-    
+
     configuracao = db.relationship('ConfiguracaoCliente', back_populates='cliente', uselist=False)
+    usuarios = db.relationship('Usuario', secondary='usuario_clientes', back_populates='clientes')
     
     # Novos campos (caminho das imagens):
     logo_certificado = db.Column(db.String(255), nullable=True)       # Logo

--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -360,10 +360,15 @@ def listar_usuarios(cliente_id: int):
         flash("Acesso negado!", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
 
-    from models import Usuario, Cliente
+    from models import Usuario, Cliente, usuario_clientes
 
     cliente = Cliente.query.get_or_404(cliente_id)
-    usuarios = Usuario.query.filter_by(cliente_id=cliente.id).all()
+    usuarios = (
+        Usuario.query
+        .join(usuario_clientes)
+        .filter(usuario_clientes.c.cliente_id == cliente.id)
+        .all()
+    )
 
     return render_template(
         "cliente/listar_usuarios.html", cliente=cliente, usuarios=usuarios

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -9,7 +9,7 @@ from models import (
     Evento, Oficina, Inscricao, Usuario, LinkCadastro,
     LoteInscricao, EventoInscricaoTipo, LoteTipoInscricao,
     CampoPersonalizadoCadastro, RespostaCampo, RespostaFormulario, Formulario, RegraInscricaoEvento,
-    Patrocinador, Ministrante, InscricaoTipo, ConfiguracaoCliente
+    Patrocinador, Ministrante, InscricaoTipo, ConfiguracaoCliente, Cliente
 )
 import os
 from mp_fix_patch import fix_mp_notification_url, create_mp_preference
@@ -169,6 +169,10 @@ def cadastro_participante(identifier: str | None = None):
             else:
                 if usuario.evento_id is None:
                     usuario.evento_id = evento.id
+
+            cliente_obj = Cliente.query.get(cliente_id)
+            if cliente_obj and cliente_obj not in usuario.clientes:
+                usuario.clientes.append(cliente_obj)
 
             inscricao = Inscricao(
                 usuario_id=usuario.id,

--- a/tests/test_usuario_cliente_association.py
+++ b/tests/test_usuario_cliente_association.py
@@ -1,0 +1,77 @@
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Cliente, Evento, Usuario, Inscricao, LinkCadastro, usuario_clientes
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        admin = Usuario(nome='Admin', cpf='0', email='admin@test', senha=generate_password_hash('123'), formacao='X', tipo='admin')
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
+        db.session.add_all([admin, c1, c2])
+        db.session.commit()
+        e1 = Evento(cliente_id=c1.id, nome='E1', habilitar_lotes=False, inscricao_gratuita=True)
+        e2 = Evento(cliente_id=c2.id, nome='E2', habilitar_lotes=False, inscricao_gratuita=True)
+        db.session.add_all([e1, e2])
+        db.session.commit()
+        link1 = LinkCadastro(cliente_id=c1.id, evento_id=e1.id, token='t1')
+        link2 = LinkCadastro(cliente_id=c2.id, evento_id=e2.id, token='t2')
+        db.session.add_all([link1, link2])
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def _assoc_count(app, usuario_id, cliente_id):
+    with app.app_context():
+        res = db.session.execute(
+            db.select(db.func.count()).select_from(usuario_clientes).where(
+                usuario_clientes.c.usuario_id == usuario_id,
+                usuario_clientes.c.cliente_id == cliente_id,
+            )
+        ).scalar()
+        return res
+
+
+def test_association_and_listing(client, app):
+    data = {'nome': 'User', 'cpf': '111', 'email': 'user@test', 'senha': '123', 'formacao': 'F'}
+    resp = client.post('/inscricao/token/t1', data=data, follow_redirects=True)
+    assert resp.status_code in (200, 302)
+
+    resp = client.post('/inscricao/token/t2', data=data, follow_redirects=True)
+    assert resp.status_code in (200, 302)
+
+    with app.app_context():
+        user = Usuario.query.filter_by(email='user@test').first()
+        c1 = Cliente.query.filter_by(nome='C1').first()
+        c2 = Cliente.query.filter_by(nome='C2').first()
+        assert _assoc_count(app, user.id, c1.id) == 1
+        assert _assoc_count(app, user.id, c2.id) == 1
+
+    login(client, 'admin@test', '123')
+    resp1 = client.get(f'/listar_usuarios/{c1.id}')
+    assert resp1.status_code == 200
+    assert 'user@test' in resp1.get_data(as_text=True)
+
+    resp2 = client.get(f'/listar_usuarios/{c2.id}')
+    assert resp2.status_code == 200
+    assert 'user@test' in resp2.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- add many-to-many table `usuario_clientes`
- relate `Cliente` and `Usuario` via `usuario_clientes`
- update participant registration to store client relations
- filter users by client using join
- migration to populate association table
- tests for cross-client event registrations

## Testing
- `pytest tests/test_usuario_cliente_association.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877da0888a883248ee113a339a5ee04