### PR TITLE
Filter dashboard events by participant

### DIFF
--- a/tests/test_dashboard_participante_public_event.py
+++ b/tests/test_dashboard_participante_public_event.py
@@ -111,4 +111,4 @@ def test_public_event_visible_to_participant(app):
             ctx = dashboard_participante()
         logout_user()
     nomes = [e.nome for e in ctx['eventos_sorted']]
-    assert 'Public Event' in nomes
+    assert 'Public Event' not in nomes


### PR DESCRIPTION
## Summary
- only fetch dashboard events linked to the current participant
- update tests to expect that unrelated public events are omitted

## Testing
- `pytest tests/test_dashboard_participante_public_event.py tests/test_submission_only.py`
- `pytest -q` *(fails: sqlalchemy errors and BuildError)*

------
https://chatgpt.com/codex/tasks/task_e_687805be958c8324a6ae4d827ba6a4ad