### PR TITLE
Enforce Google OAuth variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ SECRET_KEY=
 MAIL_USERNAME=
 MAIL_PASSWORD=
 
-# Google OAuth credentials
+# Google OAuth credentials (REQUIRED)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ export DB_ONLINE="<url_do_banco_online>"
 export DB_LOCAL="<url_do_banco_local>"
 ```
 
+As variáveis `GOOGLE_CLIENT_ID` e `GOOGLE_CLIENT_SECRET` são **obrigatórias**
+para a autenticação via Gmail. A aplicação encerrará a inicialização caso elas
+não estejam definidas no ambiente.
+
 ## Banco de Dados
 
 Depois de clonar o repositório ou atualizar o código, instale as dependências

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3354,6 +3354,11 @@ TOKEN_FILE = "token.json"
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 
+if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+    raise EnvironmentError(
+        "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set in the environment"
+    )
+
 from decimal import Decimal, ROUND_HALF_UP
 from models import Configuracao
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -52,6 +52,11 @@ TOKEN_FILE = "token.json"
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 
+if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+    raise EnvironmentError(
+        "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set in the environment"
+    )
+
 from decimal import Decimal, ROUND_HALF_UP
 from models import Configuracao, Cliente
 from flask import current_app, request


### PR DESCRIPTION
## Summary
- document that `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are required
- mark them as required in `.env.example`
- raise an exception on startup if either variable is missing in `utils/__init__.py` and `services/pdf_service.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6878097d382883248c296077419cdf93