### PR TITLE
Implement email password reset tokens

### DIFF
--- a/models.py
+++ b/models.py
@@ -540,6 +540,21 @@ class LinkCadastro(db.Model):
 
     def __repr__(self):
         return f"<LinkCadastro cliente_id={self.cliente_id}, evento_id={self.evento_id}, token={self.token}, slug={self.slug_customizado}>"
+
+
+class PasswordResetToken(db.Model):
+    __tablename__ = 'password_reset_token'
+
+    id = db.Column(db.Integer, primary_key=True)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    token = db.Column(db.String(36), unique=True, nullable=False, default=lambda: str(uuid.uuid4()))
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used = db.Column(db.Boolean, default=False)
+
+    usuario = db.relationship('Usuario')
+
+    def __repr__(self):
+        return f"<PasswordResetToken usuario_id={self.usuario_id} token={self.token}>"
     
 
 from extensions import db

--- a/templates/auth/reset_senha_cpf.html
+++ b/templates/auth/reset_senha_cpf.html
@@ -7,7 +7,8 @@
       <p class="subtitle">Crie uma nova senha segura para sua conta</p>
     </div>
     
-    <form method="POST" class="reset-password-form">
+  <form method="POST" class="reset-password-form">
+      <input type="hidden" name="token" value="{{ token }}">
       <div class="form-group">
         <label for="nova_senha">Nova Senha</label>
         <div class="password-input">

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,64 @@
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db, mail
+from models import Usuario, PasswordResetToken
+from werkzeug.security import generate_password_hash
+import pytest
+import os
+
+@pytest.fixture
+def app():
+    os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+    os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        user = Usuario(nome='User', cpf='123', email='user@test', senha=generate_password_hash('123'), formacao='F')
+        db.session.add(user)
+        db.session.commit()
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_password_reset_flow(client, app, monkeypatch):
+    sent = {}
+
+    def fake_send(msg):
+        sent['msg'] = msg
+
+    monkeypatch.setattr(mail, 'send', fake_send)
+
+    client.post('/esqueci_senha_cpf', data={'cpf': '123'}, follow_redirects=True)
+    assert 'msg' in sent
+    body = sent['msg'].body
+    assert 'token=' in body
+    token = body.split('token=')[1].strip()
+
+    resp = client.post(f'/reset_senha_cpf?token={token}', data={
+        'token': token,
+        'nova_senha': 'short',
+        'confirmar_senha': 'short'
+    }, follow_redirects=True)
+    assert b'requisitos' in resp.data
+
+    resp = client.post(f'/reset_senha_cpf?token={token}', data={
+        'token': token,
+        'nova_senha': 'Senha123',
+        'confirmar_senha': 'Senha123'
+    }, follow_redirects=True)
+    assert resp.request.path == '/login'
+
+    with app.app_context():
+        user = Usuario.query.filter_by(cpf='123').first()
+        assert user.verificar_senha('Senha123')
+        assert PasswordResetToken.query.filter_by(token=token, used=True).count() == 1

--- a/utils/security.py
+++ b/utils/security.py
@@ -7,3 +7,12 @@ def sanitize_input(text: str) -> str:
         return ""
     return bleach.clean(text, tags=[], strip=True)
 
+
+def password_is_strong(password: str, min_length: int = 8) -> bool:
+    """Simple password strength validation."""
+    if not password or len(password) < min_length:
+        return False
+    has_letter = any(c.isalpha() for c in password)
+    has_digit = any(c.isdigit() for c in password)
+    return has_letter and has_digit
+


### PR DESCRIPTION
## Summary
- add `PasswordResetToken` model
- validate password strength in `utils.security`
- send password reset token via e-mail
- verify token before allowing password change
- include token field in password reset template
- test password reset token workflow

## Testing
- `pytest tests/test_password_reset.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687957b949208324be84aa8a9ac65c7d