### PR TITLE
Add password reset token migration

### DIFF
--- a/migrations/versions/9bac7f9f0073_add_password_reset_token_table.py
+++ b/migrations/versions/9bac7f9f0073_add_password_reset_token_table.py
@@ -1,0 +1,30 @@
+"""Add password reset token table
+
+Revision ID: 9bac7f9f0073
+Revises: a5154a3f3a4c
+Create Date: 2025-07-20 04:08:13
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '9bac7f9f0073'
+down_revision = 'a5154a3f3a4c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'password_reset_token',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('usuario_id', sa.Integer(), sa.ForeignKey('usuario.id'), nullable=False),
+        sa.Column('token', sa.String(length=36), nullable=False, unique=True),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('used', sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('password_reset_token')


### PR DESCRIPTION
## Summary
- create migration adding `password_reset_token` table

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'password_is_strong')*

------
https://chatgpt.com/codex/tasks/task_e_687c6abcf87c83248e61f425d5e5011d