### PR TITLE
Fix password reset form submission

### DIFF
--- a/templates/auth/esqueci_senha_cpf.html
+++ b/templates/auth/esqueci_senha_cpf.html
@@ -321,9 +321,8 @@ document.addEventListener('DOMContentLoaded', function() {
   form.addEventListener('submit', (e) => {
     e.preventDefault();
     if (isValidCPF(cpfInput.value)) {
-      // Aqui você adicionaria a lógica para enviar o formulário
-      console.log('Formulário enviado com CPF válido.');
-      alert('Um link para redefinição de senha foi enviado para o seu e-mail.');
+      setValid('CPF válido.');
+      form.submit();
     } else {
       setInvalid('Por favor, insira um CPF válido para continuar.');
     }


### PR DESCRIPTION
## Summary
- ensure CPF form actually submits once validation passes

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError cannot import 'password_is_strong' from 'utils.security')*

------
https://chatgpt.com/codex/tasks/task_e_6883ca981e6083249f4165efc5ab906a