### PR TITLE
Fix OAuth flow after library update

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3739,11 +3739,13 @@ def obter_credenciais():
 
             # Exibir o link de autenticacao manualmente
             auth_url, _ = flow.authorization_url(prompt="consent")
-            # replace the surrogate pair with the actual character
             print(f"🔗 Acesse este link para autenticacao manual:\n{auth_url}")
 
             # Executar autenticacao manual (esperar codigo do usuario)
-            creds = flow.run_console()
+            flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+            code = input("Digite o codigo de autorizacao: ")
+            flow.fetch_token(code=code)
+            creds = flow.credentials
 
         with open(TOKEN_FILE, "w") as token:
             token.write(creds.to_json())

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -416,12 +416,13 @@ def obter_credenciais():
 
             # Exibir o link de autenticacao manualmente
             auth_url, _ = flow.authorization_url(prompt="consent")
-          
             print(f"🔗 Acesse este link para autenticacao manual:\n{auth_url}")
 
-           
             # Executar autenticacao manual (esperar codigo do usuario)
-            creds = flow.run_console()
+            flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+            code = input("Digite o codigo de autorizacao: ")
+            flow.fetch_token(code=code)
+            creds = flow.credentials
 
         with open(TOKEN_FILE, "w") as token:
             token.write(creds.to_json())


### PR DESCRIPTION
## Summary
- adapt manual OAuth login to use internal logic since `run_console` was removed

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError cannot import name 'password_is_strong' from 'utils.security')*

------
https://chatgpt.com/codex/tasks/task_e_6883cfae807c83248e10735a1200468d