### PR TITLE
Allow Gmail token from env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ MAIL_PASSWORD=
 # Google OAuth credentials (REQUIRED)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+GMAIL_TOKEN=
+GMAIL_TOKEN_FILE=
 
 # Base URL for building external links (e.g. Mercado Pago notifications)
 APP_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ export RECAPTCHA_PUBLIC_KEY="<sua_chave_publica_recaptcha>"
 export RECAPTCHA_PRIVATE_KEY="<sua_chave_privada_recaptcha>"
 export DB_ONLINE="<url_do_banco_online>"
 export DB_LOCAL="<url_do_banco_local>"
+export GMAIL_TOKEN="{\"token\":\"...\"}"  # opcional se nao usar token.json
+export GMAIL_TOKEN_FILE="/caminho/para/token.json"  # opcional, padrao token.json
 ```
 
 As variáveis `GOOGLE_CLIENT_ID` e `GOOGLE_CLIENT_SECRET` são **obrigatórias**
@@ -56,8 +58,17 @@ ser lidas por outra. Em produção, utilize um valor seguro e idêntico em todas
 réplicas do aplicativo.
 
 Essas variaveis substituem o antigo arquivo `credentials.json` utilizado para a
-autenticacao com a API do Gmail. O arquivo `token.json` sera gerado apos a
-primeira autenticacao.
+autenticacao com a API do Gmail.
+
+Para enviar e-mails sem interacao manual, gere um **refresh token** no
+[OAuth Playground](https://developers.google.com/oauthplayground). Clique no
+icone de engrenagem, marque "Use your own OAuth credentials" e informe seu
+`GOOGLE_CLIENT_ID` e `GOOGLE_CLIENT_SECRET`. Selecione o escopo
+`https://www.googleapis.com/auth/gmail.send`, autorize e troque o codigo por um
+token. Salve o JSON de resposta em um arquivo `token.json` ou defina o conteudo
+na variavel `GMAIL_TOKEN`. A aplicacao carregara essas credenciais
+automaticamente, permitindo o envio de e-mails sem solicitar codigo de
+autorizacao.
 
 `APP_BASE_URL` define a URL base para gerar links externos, como o `notification_url` do Mercado Pago. Em desenvolvimento, aponte para um endereço público (ex.: URL do ngrok).
 

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3342,6 +3342,7 @@ import requests
 from reportlab.lib.units import inch
 import os
 import base64
+import json
 import google.auth
 import google.auth.transport.requests
 from google.oauth2.credentials import Credentials
@@ -3384,6 +3385,8 @@ SCOPES = ["https://www.googleapis.com/auth/gmail.send"]
 TOKEN_FILE = "token.json"
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
+TOKEN_ENV_VAR = "GMAIL_TOKEN"
+TOKEN_FILE_ENV_VAR = "GMAIL_TOKEN_FILE"
 
 if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
     raise EnvironmentError(
@@ -3709,46 +3712,42 @@ def gerar_qr_code_inscricao(token):
     img.save(img_path)
     return img_path
 
-def obter_credenciais():
-    """Autentica e retorna credenciais OAuth 2.0 para envio de e-mails"""
+def obter_credenciais(token_file: str | None = None):
+    """Retorna credenciais OAuth 2.0 para envio de e-mails sem interação."""
+    token_file = token_file or os.getenv(TOKEN_FILE_ENV_VAR, TOKEN_FILE)
+
     creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    token_data = os.getenv(TOKEN_ENV_VAR)
+    if token_data:
+        try:
+            info = json.loads(token_data)
+            creds = Credentials.from_authorized_user_info(info, SCOPES)
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Erro ao carregar token do env %s: %s", TOKEN_ENV_VAR, exc)
+
+    if not creds and token_file and os.path.exists(token_file):
+        try:
+            creds = Credentials.from_authorized_user_file(token_file, SCOPES)
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Erro ao ler token file %s: %s", token_file, exc)
+
+    if creds and creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(Request())
+            if token_file:
+                with open(token_file, "w") as token:
+                    token.write(creds.to_json())
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Erro ao atualizar credenciais OAuth: %s", exc)
+            return None
 
     if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
-                logger.error("Variaveis GOOGLE_CLIENT_ID e GOOGLE_CLIENT_SECRET nao estao definidas.")
-                return None
-
-            flow = InstalledAppFlow.from_client_config(
-                {
-                    "installed": {
-                        "client_id": GOOGLE_CLIENT_ID,
-                        "client_secret": GOOGLE_CLIENT_SECRET,
-                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                        "token_uri": "https://oauth2.googleapis.com/token",
-                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"
-                    }
-                },
-                SCOPES,
-                redirect_uri="https://appfiber.com.br/",
-            )
-
-            # Exibir o link de autenticacao manualmente
-            auth_url, _ = flow.authorization_url(prompt="consent")
-            print(f"🔗 Acesse este link para autenticacao manual:\n{auth_url}")
-
-            # Executar autenticacao manual (esperar codigo do usuario)
-            flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
-            code = input("Digite o codigo de autorizacao: ")
-            flow.fetch_token(code=code)
-            creds = flow.credentials
-
-        with open(TOKEN_FILE, "w") as token:
-            token.write(creds.to_json())
+        logger.error(
+            "Nenhuma credencial OAuth valida encontrada. Gere um refresh token manualmente e defina em %s ou salve no arquivo %s.",
+            TOKEN_ENV_VAR,
+            token_file,
+        )
+        return None
 
     return creds
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover
     A4 = None
 import os
 import base64
+import json
 
 try:
     from google.oauth2.credentials import Credentials
@@ -51,6 +52,8 @@ SCOPES = ["https://www.googleapis.com/auth/gmail.send"]
 TOKEN_FILE = "token.json"
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
+TOKEN_ENV_VAR = "GMAIL_TOKEN"
+TOKEN_FILE_ENV_VAR = "GMAIL_TOKEN_FILE"
 
 if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
     raise EnvironmentError(
@@ -386,46 +389,42 @@ def gerar_qr_code_inscricao(token):
     img.save(img_path)
     return img_path
 
-def obter_credenciais():
-    """Autentica e retorna credenciais OAuth 2.0 para envio de e-mails"""
+def obter_credenciais(token_file: str | None = None):
+    """Retorna credenciais OAuth 2.0 para envio de e-mails sem interação."""
+    token_file = token_file or os.getenv(TOKEN_FILE_ENV_VAR, TOKEN_FILE)
+
     creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    token_data = os.getenv(TOKEN_ENV_VAR)
+    if token_data:
+        try:
+            info = json.loads(token_data)
+            creds = Credentials.from_authorized_user_info(info, SCOPES)
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Erro ao carregar token do env %s: %s", TOKEN_ENV_VAR, exc)
+
+    if not creds and token_file and os.path.exists(token_file):
+        try:
+            creds = Credentials.from_authorized_user_file(token_file, SCOPES)
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Erro ao ler token file %s: %s", token_file, exc)
+
+    if creds and creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(Request())
+            if token_file:
+                with open(token_file, "w") as token:
+                    token.write(creds.to_json())
+        except Exception as exc:  # pragma: no cover - log and continue
+            logger.error("Erro ao atualizar credenciais OAuth: %s", exc)
+            return None
 
     if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
-                logger.error("Variaveis GOOGLE_CLIENT_ID e GOOGLE_CLIENT_SECRET nao estao definidas.")
-                return None
-
-            flow = InstalledAppFlow.from_client_config(
-                {
-                    "installed": {
-                        "client_id": GOOGLE_CLIENT_ID,
-                        "client_secret": GOOGLE_CLIENT_SECRET,
-                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                        "token_uri": "https://oauth2.googleapis.com/token",
-                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"
-                    }
-                },
-                SCOPES,
-                redirect_uri="https://appfiber.com.br/",
-            )
-
-            # Exibir o link de autenticacao manualmente
-            auth_url, _ = flow.authorization_url(prompt="consent")
-            print(f"🔗 Acesse este link para autenticacao manual:\n{auth_url}")
-
-            # Executar autenticacao manual (esperar codigo do usuario)
-            flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
-            code = input("Digite o codigo de autorizacao: ")
-            flow.fetch_token(code=code)
-            creds = flow.credentials
-
-        with open(TOKEN_FILE, "w") as token:
-            token.write(creds.to_json())
+        logger.error(
+            "Nenhuma credencial OAuth valida encontrada. Gere um refresh token manualmente e defina em %s ou salve no arquivo %s.",
+            TOKEN_ENV_VAR,
+            token_file,
+        )
+        return None
 
     return creds
 


### PR DESCRIPTION
## Summary
- load Gmail credentials from `GMAIL_TOKEN` or `GMAIL_TOKEN_FILE`
- update duplicate logic in `pdf_service`
- document how to create and configure the token
- provide new examples in `.env.example`

## Testing
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6883d8b0c79c8324bd2ffcaa291cbe11