### PR TITLE
Fix password reset email HTML

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -210,6 +210,12 @@ def esqueci_senha_cpf():
             link = url_for('auth_routes.reset_senha_cpf', token=token.token, _external=True)
             assunto = 'Redefini\u00e7\u00e3o de Senha'
             corpo_texto = f'Acesse o link para redefinir sua senha: {link}'
+            corpo_html = f"""
+            <p>Olá, {usuario.nome}!</p>
+            <p>Recebemos uma solicitação para redefinir sua senha. Para prosseguir, acesse o link abaixo:</p>
+            <p><a href='{link}'>{link}</a></p>
+            <p>Se você não solicitou esta alteração, ignore este e-mail.</p>
+            """
             try:
                 logger.info("Tentando enviar email de redefinição de senha via OAuth")
                 enviar_email(
@@ -218,6 +224,7 @@ def esqueci_senha_cpf():
                     nome_oficina='',
                     assunto=assunto,
                     corpo_texto=corpo_texto,
+                    corpo_html=corpo_html,
                 )
                 logger.info("Email enviado com sucesso")
             except Exception as e:

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3753,7 +3753,8 @@ def obter_credenciais(token_file: str | None = None):
 
 
 @_profile
-def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_texto, anexo_path=None):
+def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_texto,
+                 anexo_path=None, corpo_html=None):
     """Wrapper para envio de e-mail utilizando o serviço definido em utils."""
     from utils import enviar_email as _send
 
@@ -3764,6 +3765,7 @@ def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_t
         assunto=assunto,
         corpo_texto=corpo_texto,
         anexo_path=anexo_path,
+        corpo_html=corpo_html,
     )
         
 

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -38,14 +38,17 @@ def client(app):
 def test_password_reset_flow(client, app, monkeypatch):
     sent = {}
 
-    def fake_send(destinatario, nome_participante, nome_oficina, assunto, corpo_texto, anexo_path=None):
+    def fake_send(destinatario, nome_participante, nome_oficina, assunto, corpo_texto,
+                  anexo_path=None, corpo_html=None):
         sent['dest'] = destinatario
         sent['assunto'] = assunto
         sent['body'] = corpo_texto
 
     monkeypatch.setattr('routes.auth_routes.enviar_email', fake_send)
+    monkeypatch.setattr('requests.post',
+                       lambda *a, **k: type('obj', (), {'json': lambda: {'success': True, 'score': 1}}))
 
-    client.post('/esqueci_senha_cpf', data={'cpf': '123'}, follow_redirects=True)
+    client.post('/esqueci_senha_cpf', data={'cpf': '123', 'g-recaptcha-response': 'dummy'}, follow_redirects=True)
     assert 'body' in sent
     assert 'token=' in sent['body']
     token = sent['body'].split('token=')[1].strip()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -429,32 +429,40 @@ def obter_credenciais(token_file: str | None = None):
     return creds
 
 
-def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_texto, anexo_path=None):
-    """Envia um e-mail utilizando o serviço Mailjet."""
+def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_texto,
+                 anexo_path=None, corpo_html=None):
+    """Envia um e-mail utilizando o serviço Mailjet.
+
+    Se ``corpo_html`` não for fornecido, utiliza um modelo simples de confirmação
+    de inscrição. Esse parâmetro permite personalizar o conteúdo HTML de e-mails
+    como a recuperação de senha, garantindo que o texto exibido ao usuário seja
+    adequado ao contexto.
+    """
     from services.mailjet_service import send_via_mailjet
 
-    corpo_html = f"""
-    <html>
-    <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
-        <div style="max-width: 600px; margin: auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
-            <h2 style="color: #2C3E50; text-align: center;">Confirmação de Inscrição</h2>
-            <p>Olá, <b>{nome_participante}</b>!</p>
-            <p>Você se inscreveu com sucesso na oficina <b>{nome_oficina}</b>.</p>
-            <p>Aguardamos você no evento!</p>
+    if corpo_html is None:
+        corpo_html = f"""
+        <html>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+            <div style="max-width: 600px; margin: auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
+                <h2 style="color: #2C3E50; text-align: center;">Confirmação de Inscrição</h2>
+                <p>Olá, <b>{nome_participante}</b>!</p>
+                <p>Você se inscreveu com sucesso na oficina <b>{nome_oficina}</b>.</p>
+                <p>Aguardamos você no evento!</p>
 
-            <div style="padding: 15px; background-color: #f4f4f4; border-left: 5px solid #3498db;">
-                <p><b>Detalhes da Oficina:</b></p>
-                <p><b>Nome:</b> {nome_oficina}</p>
+                <div style="padding: 15px; background-color: #f4f4f4; border-left: 5px solid #3498db;">
+                    <p><b>Detalhes da Oficina:</b></p>
+                    <p><b>Nome:</b> {nome_oficina}</p>
+                </div>
+
+                <p>Caso tenha dúvidas, entre em contato conosco.</p>
+                <p style="text-align: center;">
+                    <b>Equipe Organizadora</b>
+                </p>
             </div>
-
-            <p>Caso tenha dúvidas, entre em contato conosco.</p>
-            <p style="text-align: center;">
-                <b>Equipe Organizadora</b>
-            </p>
-        </div>
-    </body>
-    </html>
-    """
+        </body>
+        </html>
+        """
 
     attachments = [anexo_path] if anexo_path else None
     try:


### PR DESCRIPTION
## Summary
- handle custom HTML in enviar_email
- propagate corpo_html parameter to wrapper
- send a reset password-specific email template
- adjust password reset test for new behaviour

## Testing
- `pytest tests/test_password_reset.py::test_password_reset_flow -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688929d4c9308324a94bcd02eca96b5e