### PR TITLE
Centralize toast flash messages

### DIFF
--- a/templates/auth/cadastro_ministrante.html
+++ b/templates/auth/cadastro_ministrante.html
@@ -42,25 +42,6 @@
         </div>
         
         <div class="card-body p-4">
-          {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-              {% for category, message in messages %}
-                <div class="alert alert-{{ category }} alert-dismissible fade show mb-4" role="alert">
-                  <div class="d-flex align-items-center">
-                    {% if category == 'success' %}
-                      <i class="bi bi-check-circle-fill me-2 fs-5"></i>
-                    {% elif category == 'danger' %}
-                      <i class="bi bi-exclamation-triangle-fill me-2 fs-5"></i>
-                    {% else %}
-                      <i class="bi bi-info-circle-fill me-2 fs-5"></i>
-                    {% endif %}
-                    <div>{{ message }}</div>
-                  </div>
-                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-              {% endfor %}
-            {% endif %}
-          {% endwith %}
 
           <form method="POST" enctype="multipart/form-data" class="needs-validation" novalidate id="form-ministrante">
             <!-- Etapa 1: Informações Pessoais -->

--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -224,21 +224,6 @@
             </div>
             
             <div class="modal-body">
-                {% with messages = get_flashed_messages(with_categories=true) %}
-                    {% if messages %}
-                        {% for category, message in messages %}
-                        <div class="alert-message {{ category }}">
-                            <i class="fas 
-                                {% if category == 'success' %}fa-check-circle
-                                {% elif category == 'danger' %}fa-exclamation-circle
-                                {% elif category == 'warning' %}fa-exclamation-triangle
-                                {% else %}fa-info-circle{% endif %}">
-                            </i>
-                            <span>{{ message }}</span>
-                        </div>
-                        {% endfor %}
-                    {% endif %}
-                {% endwith %}
                 
                 {% if evento and evento.habilitar_lotes and not lote_vigente %}
                 <div class="alert-message warning">

--- a/templates/auth/cadastro_usuario.html
+++ b/templates/auth/cadastro_usuario.html
@@ -80,16 +80,6 @@
     </div>
     
     <div class="card-body">
-      {% with msgs = get_flashed_messages(with_categories=True, category_filter=['participante']) %}
-        {% if msgs %}
-          {% for category, message in msgs %}
-            <div class="alert alert-info alert-custom alert-dismissible fade show">
-              {{ message }}
-              <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
 
       <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', identifier=token) if token else url_for('inscricao_routes.cadastro_participante') }}">
         <div class="form-grid">

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -154,22 +154,6 @@
       .login-form-header h2 { font-size: 1.75rem; font-weight: 700; color: var(--text); margin-bottom: 8px; }
       .login-form-header p { color: var(--text-light); font-size: 1rem; }
 
-      #alert-container { margin-bottom: 24px; }
-      .alert {
-        display: flex; align-items: flex-start; padding: 12px 16px;
-        border-radius: 12px; border: 1px solid transparent; margin-bottom: 16px; font-size: 0.9rem;
-      }
-      .alert-icon { font-size: 1.25rem; margin-right: 12px; line-height: 1.4; }
-      .alert-content { flex: 1; }
-      .alert-title { font-weight: 600; margin-bottom: 2px; }
-      .alert-close {
-        background: none; border: none; cursor: pointer; color: inherit;
-        opacity: 0.7; transition: opacity 0.2s; margin-left: 16px;
-      }
-      .alert-close:hover { opacity: 1; }
-      .alert.alert-error { background-color: var(--alert-error-bg); border-color: var(--alert-error-border); color: var(--alert-error-text); }
-      .alert.alert-success { background-color: var(--alert-success-bg); border-color: var(--alert-success-border); color: var(--alert-success-text); }
-      .alert.alert-info { background-color: var(--alert-info-bg); border-color: var(--alert-info-border); color: var(--alert-info-text); }
 
       .login-form { display: flex; flex-direction: column; gap: 24px; flex: 1; }
       .form-group { text-align: left; }
@@ -269,28 +253,7 @@
                     <p>Faça login para continuar</p>
                 </div>
                 
-                <div id="alert-container">
-                    {% if error %}
-                    <div class="alert alert-error">
-                        <div class="alert-icon"><i class="bi bi-exclamation-circle-fill"></i></div>
-                        <div class="alert-content">
-                            <div class="alert-title">Erro</div>
-                            <div class="alert-message">{{ error }}</div>
-                        </div>
-                        <button class="alert-close"><i class="bi bi-x-lg"></i></button>
-                    </div>
-                    {% endif %}
-                    {% if success %}
-                    <div class="alert alert-success">
-                        <div class="alert-icon"><i class="bi bi-check-circle-fill"></i></div>
-                        <div class="alert-content">
-                            <div class="alert-title">Sucesso</div>
-                            <div class="alert-message">{{ success }}</div>
-                        </div>
-                        <button class="alert-close"><i class="bi bi-x-lg"></i></button>
-                    </div>
-                    {% endif %}
-                </div>
+                {% include 'partials/flash_messages.html' %}
                 
                 <form action="{{ url_for('auth_routes.login') }}" method="POST" class="login-form">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -345,12 +308,6 @@
         icon.classList.toggle('bi-eye', isPassword);
       });
 
-      // Script para fechar alertas
-      document.querySelectorAll('.alert-close').forEach(button => {
-        button.addEventListener('click', function() {
-          this.closest('.alert').style.display = 'none';
-        });
-      });
     </script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -229,28 +229,7 @@
     <div class="navbar-spacer" style="height: var(--navbar-height);"></div>
 
     <!-- MENSAGENS FLASH -->
-    {% with msgs = get_flashed_messages(with_categories=true) %}
-        {% if msgs %}
-            <div class="toast-container position-fixed bottom-0 end-0 p-3">
-                {% for category, message in msgs %}
-                    {% set toast_class = "info" if category == "message" else category %}
-                    <div class="toast align-items-center text-bg-{{ toast_class }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
-                        <div class="d-flex">
-                            <div class="toast-body">
-                                <i class="bi
-                                    {% if toast_class == "success" %}bi-check-circle
-                                    {% elif toast_class == "danger" %}bi-exclamation-circle
-                                    {% elif toast_class == "warning" %}bi-exclamation-triangle
-                                    {% else %}bi-info-circle{% endif %} me-2"></i>
-                                {{ message }}
-                            </div>
-                            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
-                        </div>
-                    </div>
-                {% endfor %}
-            </div>
-        {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <!-- CONTEÚDO PRINCIPAL -->
     <main id="main-content">
@@ -441,11 +420,6 @@
                 });
             });
             
-            // Inicializa e exibe toasts gerados via mensagens flash
-            document.querySelectorAll('.toast').forEach(toastEl => {
-                const toast = new bootstrap.Toast(toastEl, { delay: 5000 });
-                toast.show();
-            });
         });
     </script>
     {% endblock %}

--- a/templates/checkin/checkin.html
+++ b/templates/checkin/checkin.html
@@ -249,22 +249,6 @@
 </style>
 
 <div class="container">
-    <!-- Bloco de alertas -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                    {% if category == 'success' %}
-                        <i class="fas fa-check-circle me-2"></i>
-                    {% elif category == 'danger' %}
-                        <i class="fas fa-exclamation-circle me-2"></i>
-                    {% endif %}
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
 
     <div class="checkin-container">
         <div class="checkin-header">

--- a/templates/evento/meus_eventos.html
+++ b/templates/evento/meus_eventos.html
@@ -10,16 +10,7 @@
     </a>
   </div>
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-          {{ message }}
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-        </div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+
 
   <div class="card shadow-sm border-0">
     <div class="card-body p-0">

--- a/templates/inscricao/gerenciar_inscricoes.html
+++ b/templates/inscricao/gerenciar_inscricoes.html
@@ -19,26 +19,6 @@
     </div>
   </div>
 
-  <!-- FLASHES -->
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }} alert-dismissible fade show mb-4" role="alert">
-          <div class="d-flex align-items-center">
-            {% if category == 'success' %}
-              <i class="bi bi-check-circle-fill me-2 fs-5"></i>
-            {% elif category == 'danger' %}
-              <i class="bi bi-exclamation-triangle-fill me-2 fs-5"></i>
-            {% else %}
-              <i class="bi bi-info-circle-fill me-2 fs-5"></i>
-            {% endif %}
-            <div>{{ message }}</div>
-          </div>
-          <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-        </div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
 
   <!-- =================================================== -->
   <!-- FILTROS ------------------------------------------- -->

--- a/templates/ministrante/editar_ministrante.html
+++ b/templates/ministrante/editar_ministrante.html
@@ -8,16 +8,7 @@
       <h2 class="mb-0 text-center">Editar Ministrante</h2>
     </div>
     <div class="card-body">
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for category, message in messages %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-              {{ message }}
-              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
+
 
       <form method="POST" enctype="multipart/form-data" action="{{ url_for('ministrante_routes.editar_ministrante', ministrante_id=ministrante.id) }}">
         {% if current_user.tipo == 'admin' %}

--- a/templates/ministrante/gerenciar_ministrantes.html
+++ b/templates/ministrante/gerenciar_ministrantes.html
@@ -12,25 +12,6 @@
     </a>
   </div>
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }} alert-dismissible fade show mb-4" role="alert">
-          <div class="d-flex align-items-center">
-            {% if category == 'success' %}
-              <i class="bi bi-check-circle-fill me-2 fs-5"></i>
-            {% elif category == 'danger' %}
-              <i class="bi bi-exclamation-triangle-fill me-2 fs-5"></i>
-            {% else %}
-              <i class="bi bi-info-circle-fill me-2 fs-5"></i>
-            {% endif %}
-            <div>{{ message }}</div>
-          </div>
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
-        </div>
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
 
   <div class="card shadow-sm border-0">
     <div class="card-header bg-white d-flex justify-content-between align-items-center p-3 border-bottom">

--- a/templates/partials/flash_messages.html
+++ b/templates/partials/flash_messages.html
@@ -1,0 +1,30 @@
+{% with msgs = get_flashed_messages(with_categories=true) %}
+  {% if msgs %}
+    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+      {% for category, message in msgs %}
+        {% set toast_class = "info" if category == "message" else category %}
+        <div class="toast align-items-center text-bg-{{ toast_class }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
+          <div class="d-flex">
+            <div class="toast-body">
+              <i class="bi
+                {% if toast_class == 'success' %}bi-check-circle
+                {% elif toast_class == 'danger' %}bi-exclamation-circle
+                {% elif toast_class == 'warning' %}bi-exclamation-triangle
+                {% else %}bi-info-circle{% endif %} me-2"></i>
+              {{ message }}
+            </div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.toast').forEach(function(toastEl) {
+          const toast = new bootstrap.Toast(toastEl, { delay: 5000 });
+          toast.show();
+        });
+      });
+    </script>
+  {% endif %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- add flash message toast partial
- include partial in base layout and login page
- remove duplicated flash message sections from other templates
- drop custom alert JS now that toasts auto-dismiss

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'password_is_strong')*

------
https://chatgpt.com/codex/tasks/task_e_688988579fa08324a694acb85e35403e