### PR TITLE
Add registration confirmation email template

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -765,7 +765,17 @@ def inscrever(oficina_id):
             pdf_path = gerar_comprovante_pdf(current_user, oficina, inscricao)
 
             assunto = f"Confirmação de Inscrição - {oficina.titulo}"
-            corpo_texto = f"Olá {current_user.nome},\n\nVocê se inscreveu na oficina '{oficina.titulo}'.\nSegue o comprovante de inscrição em anexo."
+            corpo_texto = (
+                f"Olá {current_user.nome},\n\n"
+                f"Você se inscreveu na oficina '{oficina.titulo}'.\n"
+                "Segue o comprovante de inscrição em anexo."
+            )
+
+            corpo_html = render_template(
+                'emails/confirmacao_inscricao_oficina.html',
+                participante_nome=current_user.nome,
+                oficina=oficina,
+            )
 
             enviar_email(
                 destinatario=current_user.email,
@@ -773,7 +783,8 @@ def inscrever(oficina_id):
                 nome_oficina=oficina.titulo,
                 assunto=assunto,
                 corpo_texto=corpo_texto,
-                anexo_path=pdf_path
+                anexo_path=pdf_path,
+                corpo_html=corpo_html,
             )
         except Exception as e:
             logger.error(f"❌ ERRO ao enviar e-mail: {e}", exc_info=True)

--- a/templates/emails/confirmacao_inscricao_oficina.html
+++ b/templates/emails/confirmacao_inscricao_oficina.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Confirmação de Inscrição</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        .container {
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        .header {
+            background-color: #28a745;
+            color: white;
+            padding: 10px 20px;
+            text-align: center;
+            border-radius: 5px 5px 0 0;
+        }
+        .footer {
+            background-color: #f5f5f5;
+            padding: 10px 20px;
+            text-align: center;
+            font-size: 0.8em;
+            color: #777;
+            border-radius: 0 0 5px 5px;
+        }
+        .info-block {
+            background-color: #f9f9f9;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Confirmação de Inscrição</h1>
+        </div>
+
+        <p>Olá, {{ participante_nome }}!</p>
+
+        <p>Sua inscrição na oficina <strong>{{ oficina.titulo }}</strong> foi confirmada.</p>
+
+        <div class="info-block">
+            <p><strong>Cidade:</strong> {{ oficina.cidade }} - {{ oficina.estado }}</p>
+            <p><strong>Ministrante:</strong> {{ oficina.ministrante_obj.nome }}</p>
+            <p><strong>Datas e horários:</strong></p>
+            <ul>
+                {% for dia in oficina.dias %}
+                    <li>{{ dia.data.strftime('%d/%m/%Y') }} - {{ dia.horario_inicio }} às {{ dia.horario_fim }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+
+        <p>Em anexo está o seu comprovante de inscrição.</p>
+
+        <div class="footer">
+            <p>Este é um e-mail automático. Por favor, não responda.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -430,7 +430,8 @@ def obter_credenciais(token_file: str | None = None):
 
 
 def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_texto,
-                 anexo_path=None, corpo_html=None):
+                 anexo_path=None, corpo_html=None, template_path=None,
+                 template_context=None):
     """Envia um e-mail utilizando o serviço Mailjet.
 
     Se ``corpo_html`` não for fornecido, utiliza um modelo simples de confirmação
@@ -439,9 +440,13 @@ def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_t
     adequado ao contexto.
     """
     from services.mailjet_service import send_via_mailjet
+    from flask import render_template
 
     if corpo_html is None:
-        corpo_html = f"""
+        if template_path:
+            corpo_html = render_template(template_path, **(template_context or {}))
+        else:
+            corpo_html = f"""
         <html>
         <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
             <div style="max-width: 600px; margin: auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
@@ -462,7 +467,7 @@ def enviar_email(destinatario, nome_participante, nome_oficina, assunto, corpo_t
             </div>
         </body>
         </html>
-        """
+            """
 
     attachments = [anexo_path] if anexo_path else None
     try:


### PR DESCRIPTION
## Summary
- create new HTML email template for workshop confirmations
- allow `utils.enviar_email` to render an HTML template
- send the rendered email when confirming workshop registration

## Testing
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688988408b048324890f65908d14a255