### PR TITLE
Clean up usuario_clientes associations on client removal

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -156,6 +156,7 @@ def excluir_cliente(cliente_id):
             Sorteio,
             Pagamento,
             Usuario,
+            usuario_clientes,
             AgendamentoVisita,
             AlunoVisitante,
             ProfessorBloqueado,
@@ -198,7 +199,18 @@ def excluir_cliente(cliente_id):
 
                 RespostaFormulario.query.filter_by(usuario_id=usuario.id).delete()
 
-        Usuario.query.filter_by(cliente_id=cliente.id).delete()
+        # Remover associações entre usuários e clientes (tanto deste cliente
+        # quanto outras referencias destes usuários)
+        db.session.execute(
+            usuario_clientes.delete().where(
+                or_(
+                    usuario_clientes.c.usuario_id.in_(usuario_ids),
+                    usuario_clientes.c.cliente_id == cliente.id,
+                )
+            )
+        )
+
+        Usuario.query.filter_by(cliente_id=cliente.id).delete(synchronize_session=False)
 
         # ===============================
         # 2️⃣ OFICINAS


### PR DESCRIPTION
## Summary
- clean up usuario-clientes join table when deleting a client
- disable session sync when deleting usuario records for speed

## Testing
- `pytest tests/test_event_client_deletion.py::test_excluir_cliente_remove_pagamentos -q`
- `pytest tests/test_cliente_admin_auth.py::test_excluir_clientes_denied -q`


------
https://chatgpt.com/codex/tasks/task_e_688a59256f28832486642e0e2e13203b