### PR TITLE
Fix CSRF errors in dashboard forms

### DIFF
--- a/templates/dashboard/dashboard_admin.html
+++ b/templates/dashboard/dashboard_admin.html
@@ -122,6 +122,7 @@
                   <h4 class="mb-3">Gestão de Clientes</h4>
                   <div class="table-responsive">
                     <form id="clientesForm" method="POST">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <table class="table table-hover align-middle">
                       <thead class="table-light">
                         <tr>
@@ -268,6 +269,7 @@
 <div class="modal fade" id="modalTaxa" tabindex="-1">
   <div class="modal-dialog modal-lg"><div class="modal-content">
    <form method="POST" action="{{ url_for('mercadopago_routes.atualizar_taxa') }}" id="taxaForm">
+     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
      <div class="modal-header bg-primary text-white">
        <h5 class="modal-title"><i class="bi bi-cash-coin me-2"></i>Configuração de Taxa</h5>
        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
@@ -478,6 +480,7 @@
     <div class="modal-content">
       <!-- Use um placeholder (cliente_id=0) para que o action seja atualizado via JS -->
       <form action="{{ url_for('cliente_routes.editar_cliente', cliente_id=0) }}" method="POST" id="formEditarCliente">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="modal-header">
           <h5 class="modal-title" id="modalEditarClienteLabel">Editar Cliente</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>


### PR DESCRIPTION
## Summary
- add hidden CSRF token field in dashboard admin POST forms

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'password_is_strong')*

------
https://chatgpt.com/codex/tasks/task_e_688a72a67fc8832482574ad983a32e05