### PR TITLE
Cascade delete password reset tokens

### DIFF
--- a/migrations/versions/e6154b1f9b2a_cascade_password_reset_tokens.py
+++ b/migrations/versions/e6154b1f9b2a_cascade_password_reset_tokens.py
@@ -1,0 +1,48 @@
+"""Cascade delete password reset tokens
+
+Revision ID: e6154b1f9b2a
+Revises: 9bac7f9f0073
+Create Date: 2025-08-05 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e6154b1f9b2a"
+down_revision = "9bac7f9f0073"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "fk_password_reset_token_usuario_id_usuario",
+        "password_reset_token",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_password_reset_token_usuario_id_usuario",
+        "password_reset_token",
+        "usuario",
+        ["usuario_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_password_reset_token_usuario_id_usuario",
+        "password_reset_token",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_password_reset_token_usuario_id_usuario",
+        "password_reset_token",
+        "usuario",
+        ["usuario_id"],
+        ["id"],
+    )
+

--- a/models.py
+++ b/models.py
@@ -41,6 +41,12 @@ class Usuario(db.Model, UserMixin):
     cliente = db.relationship('Cliente', backref=db.backref('usuarios_legacy', lazy=True))
     clientes = db.relationship('Cliente', secondary='usuario_clientes', back_populates='usuarios')
     evento = db.relationship('Evento', backref=db.backref('usuarios', lazy=True))
+    password_reset_tokens = db.relationship(
+        'PasswordResetToken',
+        backref='usuario',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+    )
     # NOVOS CAMPOS PARA LOCAIS DE ATUAÇÃO:
     estados = db.Column(db.String(255), nullable=True)   # Ex.: "SP,RJ,MG"
     cidades = db.Column(db.String(255), nullable=True)   # Ex.: "São Paulo,Rio de Janeiro,Belo Horizonte"
@@ -546,12 +552,14 @@ class PasswordResetToken(db.Model):
     __tablename__ = 'password_reset_token'
 
     id = db.Column(db.Integer, primary_key=True)
-    usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    usuario_id = db.Column(
+        db.Integer,
+        db.ForeignKey('usuario.id', ondelete='CASCADE'),
+        nullable=False,
+    )
     token = db.Column(db.String(36), unique=True, nullable=False, default=lambda: str(uuid.uuid4()))
     expires_at = db.Column(db.DateTime, nullable=False)
     used = db.Column(db.Boolean, default=False)
-
-    usuario = db.relationship('Usuario')
 
     def __repr__(self):
         return f"<PasswordResetToken usuario_id={self.usuario_id} token={self.token}>"


### PR DESCRIPTION
## Summary
- Delete password reset tokens when a user is removed
- Add backref from Usuario to associated PasswordResetToken rows
- Create migration applying cascade to password reset token foreign key

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'password_is_strong'; ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68914d8831248324a060c4763b7f1b97