### PR TITLE
Delete password reset tokens when removing users

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -161,6 +161,7 @@ def excluir_cliente(cliente_id):
             AgendamentoVisita,
             AlunoVisitante,
             ProfessorBloqueado,
+            PasswordResetToken,
         )
 
         # ===============================
@@ -199,6 +200,10 @@ def excluir_cliente(cliente_id):
                 ).delete(synchronize_session=False)
 
                 RespostaFormulario.query.filter_by(usuario_id=usuario.id).delete()
+
+        PasswordResetToken.query.filter(
+            PasswordResetToken.usuario_id.in_(usuario_ids)
+        ).delete(synchronize_session=False)
 
         # Remover associações entre usuários e clientes (tanto deste cliente
         # quanto outras referencias destes usuários)

--- a/routes/participante_routes.py
+++ b/routes/participante_routes.py
@@ -3,7 +3,7 @@ participante_routes = Blueprint("participante_routes", __name__)
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from werkzeug.security import generate_password_hash
-from models import Usuario
+from models import Usuario, PasswordResetToken
 from extensions import db
 
 
@@ -33,7 +33,8 @@ def excluir_participante(participante_id):
     if participante.tipo != 'participante':
         flash('Esse usuário não é um participante.', 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
-    
+
+    PasswordResetToken.query.filter_by(usuario_id=participante.id).delete()
     db.session.delete(participante)
     db.session.commit()
     flash('Participante excluído com sucesso!', 'success')

--- a/tests/test_user_deletion_password_reset.py
+++ b/tests/test_user_deletion_password_reset.py
@@ -1,0 +1,66 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+from datetime import datetime, timedelta
+from config import Config
+
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models import Usuario, PasswordResetToken  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        admin = Usuario(
+            nome='Admin', cpf='admin', email='admin@test',
+            senha=generate_password_hash('123'), formacao='F', tipo='admin'
+        )
+        participante = Usuario(
+            nome='User', cpf='123', email='user@test',
+            senha=generate_password_hash('123'), formacao='F', tipo='participante'
+        )
+        db.session.add_all([admin, participante])
+        db.session.commit()
+        token = PasswordResetToken(
+            usuario_id=participante.id,
+            expires_at=datetime.utcnow() + timedelta(hours=1)
+        )
+        db.session.add(token)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_delete_participant_removes_password_tokens(client, app):
+    login(client, 'admin@test', '123')
+    with app.app_context():
+        user = Usuario.query.filter_by(cpf='123').first()
+        assert PasswordResetToken.query.filter_by(usuario_id=user.id).count() == 1
+        uid = user.id
+
+    resp = client.post(f'/excluir_participante/{uid}', follow_redirects=True)
+    assert resp.status_code in (200, 302)
+
+    with app.app_context():
+        assert Usuario.query.get(uid) is None
+        assert PasswordResetToken.query.filter_by(usuario_id=uid).count() == 0


### PR DESCRIPTION
## Summary
- remove password reset tokens tied to a participant when the participant is deleted
- clear password reset tokens for all client users during client deletion
- test participant deletion to ensure password reset tokens are cleaned up

## Testing
- `pytest tests/test_user_deletion_password_reset.py -q`
- `pytest tests/test_event_client_deletion.py::test_excluir_cliente_remove_pagamentos -q`


------
https://chatgpt.com/codex/tasks/task_e_68914d884b108324807e83ed01f3c978