### PR TITLE
refactor: move cliente form and drop bcrypt

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,5 +1,12 @@
 from flask_wtf import FlaskForm, RecaptchaField
-from wtforms import StringField, FloatField, IntegerField, SelectMultipleField, PasswordField
+from wtforms import (
+    StringField,
+    FloatField,
+    IntegerField,
+    SelectMultipleField,
+    PasswordField,
+    SubmitField,
+)
 from wtforms.validators import DataRequired, Optional, Email
 
 class TipoInscricaoEventoForm(FlaskForm):
@@ -10,6 +17,13 @@ class RegraInscricaoEventoForm(FlaskForm):
     tipo_inscricao_id = IntegerField('Tipo de Inscrição', validators=[DataRequired()])
     limite_oficinas = IntegerField('Limite de Oficinas', validators=[Optional()])
     oficinas_permitidas = SelectMultipleField('Oficinas Permitidas', coerce=int)
+
+
+class EditarClienteForm(FlaskForm):
+    nome = StringField('Nome', validators=[DataRequired()])
+    email = StringField('E-mail', validators=[DataRequired(), Email()])
+    senha = PasswordField('Nova Senha')
+    submit = SubmitField('Salvar Alterações')
 
 
 class PublicClienteForm(FlaskForm):

--- a/models.py
+++ b/models.py
@@ -2,24 +2,12 @@
 import os
 import uuid
 from datetime import datetime, date
-import bcrypt
 from flask_login import UserMixin
-from werkzeug.security import check_password_hash, generate_password_hash
+from werkzeug.security import check_password_hash
 from extensions import db  # Se você inicializa o SQLAlchemy em 'extensions.py'
 from sqlalchemy.orm import relationship  # Adicione esta linha!
-from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField
-from wtforms.validators import DataRequired, Email
 
 
-# =================================
-#             CLIENTE
-# =================================
-class EditarClienteForm(FlaskForm):
-    nome = StringField('Nome', validators=[DataRequired()])
-    email = StringField('E-mail', validators=[DataRequired(), Email()])
-    senha = PasswordField('Nova Senha')
-    submit = SubmitField('Salvar Alterações')
 # =================================
 #             USUÁRIO
 # =================================
@@ -1414,7 +1402,7 @@ class Submission(db.Model):
         """Valida o código de acesso enviado pelo usuário."""
         if not code:
             return False
-        return bcrypt.checkpw(code.encode(), self.code_hash.encode())
+        return check_password_hash(self.code_hash, code)
 
 
 # -----------------------------------------------------------------------------

--- a/populate_script.py
+++ b/populate_script.py
@@ -47,7 +47,6 @@ from datetime import datetime, timedelta
 from werkzeug.security import generate_password_hash
 from faker import Faker
 import uuid
-import bcrypt
 from slugify import slugify  # You may need to pip install python-slugify
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import text
@@ -1086,7 +1085,7 @@ def criar_submissoes(eventos, usuarios, quantidade_por_evento=3):
         for _ in range(quantidade_por_evento):
             autor = random.choice(participantes)
             raw_code = fake.lexify(text="??????")
-            code_hash = bcrypt.hashpw(raw_code.encode(), bcrypt.gensalt()).decode()
+            code_hash = generate_password_hash(raw_code)
             sub = Submission(
                 title=fake.sentence(nb_words=6),
                 abstract=fake.paragraph(),

--- a/requirements
+++ b/requirements
@@ -1,6 +1,5 @@
 alembic==1.14.1
 APScheduler==3.11.0
-bcrypt==4.3.0
 bidict==0.23.1
 bleach==6.2.0
 blinker==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 alembic==1.14.1
 APScheduler==3.11.0
-bcrypt==4.3.0
 bidict==0.23.1
 bleach==6.2.0
 blinker==1.9.0

--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -1,8 +1,8 @@
 from flask import Blueprint, request, jsonify, abort
 import uuid
 import secrets
-import bcrypt
 from datetime import datetime, timedelta
+from werkzeug.security import generate_password_hash
 from models import Submission, Review, Assignment, ConfiguracaoCliente, AuditLog
 from extensions import db
 from services.mailjet_service import send_via_mailjet
@@ -21,7 +21,7 @@ def create_submission():
 
     locator = str(uuid.uuid4())
     raw_code = secrets.token_urlsafe(8)[:8]
-    code_hash = bcrypt.hashpw(raw_code.encode(), bcrypt.gensalt()).decode()
+    code_hash = generate_password_hash(raw_code)
 
     submission = Submission(title=title, content=content,
                             locator=locator, code_hash=code_hash)

--- a/tests/test_review_tracking.py
+++ b/tests/test_review_tracking.py
@@ -1,5 +1,5 @@
-import bcrypt
 import pytest
+from werkzeug.security import generate_password_hash
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
 Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
@@ -16,7 +16,7 @@ def app():
     with app.app_context():
         db.create_all()
         raw_code = 'secret'
-        sub = Submission(title='T', locator='loc1', code_hash=bcrypt.hashpw(raw_code.encode(), bcrypt.gensalt()).decode())
+        sub = Submission(title='T', locator='loc1', code_hash=generate_password_hash(raw_code))
         db.session.add(sub)
         db.session.commit()
         rev = Review(submission_id=sub.id, locator='revloc', access_code='revcode')


### PR DESCRIPTION
## Summary
- move EditarClienteForm into forms module
- replace bcrypt with Werkzeug security helpers
- remove bcrypt dependency from requirements and scripts

## Testing
- `pytest` *(fails: ImportError cannot import name 'password_is_strong'; ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6895fcd2edd08324ab2bb44d4994341a