### PR TITLE
Refactor Celery initialization to factory pattern

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,27 +1,49 @@
-from celery import Celery
-from app import create_app
 import os
 
-celery = Celery(
-    __name__,
-    broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
-    backend=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
-)
+from celery import Celery
+from celery.signals import worker_process_init
 
-app = create_app()
+from app import create_app
 
-class FlaskTask(celery.Task):
-    def __call__(self, *args, **kwargs):
-        with app.app_context():
-            return self.run(*args, **kwargs)
 
-celery.Task = FlaskTask
+def create_celery() -> Celery:
+    """Factory for the Celery application.
+
+    The Flask application is created only when the worker process initializes,
+    avoiding a global application instance at import time.
+    """
+
+    celery = Celery(
+        __name__,
+        broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+        backend=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+    )
+
+    app = None
+
+    @worker_process_init.connect
+    def init_flask_app(**_: object) -> None:
+        nonlocal app
+        app = create_app()
+
+    class FlaskTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery.Task = FlaskTask
+    return celery
+
+
+celery = create_celery()
+
 
 @celery.task
 def send_email_task(*args, **kwargs):
     from utils import enviar_email
 
     enviar_email(*args, **kwargs)
+
 
 @celery.task
 def gerar_comprovante_task(*args, **kwargs):


### PR DESCRIPTION
## Summary
- create factory to build Celery app on worker start
- delay Flask app creation until worker process initialization

## Testing
- `pytest` *(fails: ImportError: cannot import name 'password_is_strong' from 'utils.security'; ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6895fcd36b4c83248c57e298378c6b4f