### PR TITLE
Use migrations for database setup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 
-web: gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
+web: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ pacotes opcionais descritos em `requirements-dev.txt`:
 pip install -r requirements-dev.txt
 ```
 
-Com o ambiente configurado você pode aplicar as migrações executando:
+Com o ambiente configurado, gere e aplique as migrações com os comandos abaixo:
 
 ```bash
+flask db migrate
 flask db upgrade
 ```
+
+Todas as alterações no esquema do banco devem passar por esse fluxo de migrações;
+`db.create_all` não é utilizado.
 
 Uma nova revisão `671cbede4123` adiciona os campos `numero_revisores`, `prazo_revisao` e
 `modelo_blind` à tabela `reviewer_application`.

--- a/app.py
+++ b/app.py
@@ -71,9 +71,6 @@ def create_app():
     except ImportError as e:
         app.logger.warning(f"Não foi possível carregar rotas de diagnóstico: {e}")
 
-    with app.app_context():
-        db.create_all()
-
     # Agendamento do reconciliador e rotas utilitárias são registrados aqui
     scheduler = BackgroundScheduler()
     scheduler.add_job(reconciliar_pendentes, "cron", hour=3, minute=0)

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: system-web
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
+    startCommand: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
## Summary
- remove db.create_all from Flask application
- run `flask db upgrade` before starting app in Procfile and Render config
- document use of `flask db migrate`/`flask db upgrade` for schema changes

## Testing
- `pytest` *(fails: cannot import name 'password_is_strong'; ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6895fcdd83888324b849e72d7b25181c