### PR TITLE
Remove password reset tokens on client deletion

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -157,6 +157,7 @@ def excluir_cliente(cliente_id):
             Sorteio,
             Pagamento,
             Usuario,
+            PasswordResetToken,
             usuario_clientes,
             AgendamentoVisita,
             AlunoVisitante,
@@ -174,6 +175,7 @@ def excluir_cliente(cliente_id):
                 Checkin.query.filter_by(usuario_id=usuario.id).delete()
                 Inscricao.query.filter_by(usuario_id=usuario.id).delete()
                 Feedback.query.filter_by(usuario_id=usuario.id).delete()
+                PasswordResetToken.query.filter_by(usuario_id=usuario.id).delete()
                 resposta_ids = db.session.query(RespostaFormulario.id).filter_by(
                     usuario_id=usuario.id
                 )
@@ -212,6 +214,7 @@ def excluir_cliente(cliente_id):
         )
 
         Usuario.query.filter_by(cliente_id=cliente.id).delete(synchronize_session=False)
+        db.session.commit()
 
         # ===============================
         # 2️⃣ OFICINAS


### PR DESCRIPTION
## Summary
- purge password reset tokens for each client user before deletion and commit after removing related records
- cover client deletion with active password reset tokens

## Testing
- `pytest tests/test_event_client_deletion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68967765e7a483249d1025bbad783de3