### PR TITLE
Use event name for QR check-in grouping

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1438,11 +1438,16 @@ def gerar_pdf_checkins_qr():
             dt = dt.replace(tzinfo=pytz.utc)
         return dt.astimezone(brasilia_tz)
 
-    # 7. Agrupamento dos check-ins por oficina
-    oficinas_grupos = defaultdict(list)
+    # 7. Agrupamento dos check-ins por oficina ou evento
+    grupos_checkins = defaultdict(list)
     for checkin in checkins_qr:
-        oficina_titulo = checkin.oficina.titulo if checkin.oficina else "Oficina não especificada"
-        oficinas_grupos[oficina_titulo].append(checkin)
+        if checkin.oficina:
+            grupo_titulo = checkin.oficina.titulo
+        elif checkin.evento:
+            grupo_titulo = checkin.evento.nome
+        else:
+            grupo_titulo = "Atividade não especificada"
+        grupos_checkins[grupo_titulo].append(checkin)
 
     # 8. Definição do estilo de tabela
     table_style = TableStyle([
@@ -1476,15 +1481,15 @@ def gerar_pdf_checkins_qr():
         ('WORDWRAP', (0, 0), (-1, -1), True),
     ])
 
-    # 9. Gerar tabelas para cada oficina
+    # 9. Gerar tabelas para cada grupo
     total_checkins = 0
-    
-    for oficina_titulo, checkins in oficinas_grupos.items():
-        total_oficina = len(checkins)
-        total_checkins += total_oficina
-        
-        # Adicionar subtítulo da oficina
-        elements.append(Paragraph(f"Oficina: {oficina_titulo} ({total_oficina} check-ins)", subtitle_style))
+
+    for grupo_titulo, checkins in grupos_checkins.items():
+        total_grupo = len(checkins)
+        total_checkins += total_grupo
+
+        # Adicionar subtítulo do grupo
+        elements.append(Paragraph(f"Atividade: {grupo_titulo} ({total_grupo} check-ins)", subtitle_style))
         
         # Preparar dados da tabela
         # Usamos Paragraph para cada célula, o que permite o WORDWRAP aplicado acima.


### PR DESCRIPTION
## Summary
- Group QR-code check-ins by workshop or event name
- Label each group as an activity and fall back to event names when workshop is missing

## Testing
- `python - <<'PY'
import os, glob, logging
os.environ['DATABASE_URL']='sqlite:///:memory:'
os.environ['GOOGLE_CLIENT_ID']='dummy'
os.environ['GOOGLE_CLIENT_SECRET']='dummy'
os.environ['FLASK_DEBUG']='0'
from app import create_app
from extensions import db
from models import Cliente, Usuario, Evento, Checkin
from flask_login import login_user
from services.pdf_service import gerar_pdf_checkins_qr
from datetime import datetime
import PyPDF2

logging.getLogger().setLevel(logging.ERROR)

app=create_app()
with app.app_context():
    db.create_all()
    cliente=Cliente(nome='Cliente1', email='cliente@example.com', senha='123')
    db.session.add(cliente)
    db.session.commit()
    evento=Evento(nome='Evento Demo', cliente_id=cliente.id)
    db.session.add(evento)
    db.session.commit()
    usuario=Usuario(nome='User1', cpf='11111111111', email='user1@example.com', senha='123', formacao='NA', cliente_id=cliente.id)
    db.session.add(usuario)
    db.session.commit()
    checkin=Checkin(usuario_id=usuario.id, evento_id=evento.id, palavra_chave='QR-EVENTO', cliente_id=cliente.id, data_hora=datetime.utcnow())
    db.session.add(checkin)
    db.session.commit()
    with app.test_request_context('/'):
        login_user(cliente)
        gerar_pdf_checkins_qr()
        path=sorted(glob.glob('static/relatorios/checkins_qr_*.pdf'))[-1]
        reader=PyPDF2.PdfReader(path)
        text=''.join(page.extract_text() or '' for page in reader.pages)
        print(text)
PY`
- `pytest` *(fails: ImportError: cannot import name 'password_is_strong' from 'utils.security')*


------
https://chatgpt.com/codex/tasks/task_e_68967770f0148324a4a316f27a9205cb