### PR TITLE
Handle forbidden status for event toggle fetch

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -164,8 +164,15 @@ toggleButtons.forEach(button => {
       },
       credentials: 'include'
     })
-      .then(res => res.json())
-  .then(data => {
+      .then(res => {
+        if (res.status === 403) {
+          alert('Você não tem permissão para alterar este evento.');
+          return;
+        }
+        return res.json();
+      })
+      .then(data => {
+        if (!data) return;
         if (data.success) {
           atualizarBotao(button, data.value);
         } else {


### PR DESCRIPTION
## Summary
- Show alert when toggling event config returns 403

## Testing
- `pytest` (fails: IntegrityError, BuildError, 14 failed, 6 passed)


------
https://chatgpt.com/codex/tasks/task_e_68967a93a6888324b1c1597ce7df5a86