### PR TITLE
Handle empty event selection on client dashboard

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -114,15 +114,26 @@ const fieldButtonMap = {
 const eventoSelect = document.getElementById("selectConfigEvento");
 const previewEventoBtn = document.getElementById("previewEventoBtn");
 if (eventoSelect) {
-  EVENTO_ATUAL = eventoSelect.value;
   const updatePreview = () => {
     if (previewEventoBtn) {
       const base = previewEventoBtn.dataset.baseUrl || previewEventoBtn.href;
       previewEventoBtn.href = `${base}${encodeURIComponent(eventoSelect.value)}`;
     }
   };
-  updatePreview();
-  carregarConfiguracao(EVENTO_ATUAL);
+
+  if (!eventoSelect.value) {
+    const primeiraOpcao = Array.from(eventoSelect.options).find(opt => opt.value);
+    if (primeiraOpcao) {
+      eventoSelect.value = primeiraOpcao.value;
+    }
+  }
+
+  EVENTO_ATUAL = eventoSelect.value;
+  if (EVENTO_ATUAL) {
+    updatePreview();
+    carregarConfiguracao(EVENTO_ATUAL);
+  }
+
   eventoSelect.addEventListener("change", function () {
     if (!this.value) return;
     EVENTO_ATUAL = this.value;


### PR DESCRIPTION
## Summary
- Auto-select first event when event dropdown is empty
- Trigger configuration loading and preview update for selected event

## Testing
- `pytest` (fails: BuildError, AssertionError, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68967a9066b083249e95d457f8d16b33