### PR TITLE
Desabilita botoes de configuracao ate selecionar evento

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -111,21 +111,32 @@ const fieldButtonMap = {
   "obrigatorio_formacao": document.getElementById("btnToggleObrigatorioFormacao")
 };
 
+const configButtons = Object.values(fieldButtonMap).filter(btn => btn);
 const eventoSelect = document.getElementById("selectConfigEvento");
 const previewEventoBtn = document.getElementById("previewEventoBtn");
+function setConfigButtonsState(enabled) {
+  configButtons.forEach(btn => {
+    btn.disabled = !enabled;
+  });
+}
+
 if (eventoSelect) {
   EVENTO_ATUAL = eventoSelect.value;
+  setConfigButtonsState(Boolean(EVENTO_ATUAL));
   const updatePreview = () => {
     if (previewEventoBtn) {
       const base = previewEventoBtn.dataset.baseUrl || previewEventoBtn.href;
       previewEventoBtn.href = `${base}${encodeURIComponent(eventoSelect.value)}`;
     }
   };
-  updatePreview();
-  carregarConfiguracao(EVENTO_ATUAL);
+  if (EVENTO_ATUAL) {
+    updatePreview();
+    carregarConfiguracao(EVENTO_ATUAL);
+  }
   eventoSelect.addEventListener("change", function () {
-    if (!this.value) return;
     EVENTO_ATUAL = this.value;
+    setConfigButtonsState(Boolean(EVENTO_ATUAL));
+    if (!EVENTO_ATUAL) return;
     updatePreview();
     carregarConfiguracao(EVENTO_ATUAL);
   });

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -912,7 +912,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Permite que participantes façam check-in pelo aplicativo</p>
                       </div>
-                      <button type="button" id="btnToggleCheckin" class="btn btn-toggle btn-danger" data-field="permitir_checkin_global">
+                      <button type="button" id="btnToggleCheckin" class="btn btn-toggle btn-danger" data-field="permitir_checkin_global" disabled>
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -926,7 +926,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Habilita uso de QR code para credenciamento em eventos</p>
                       </div>
-                      <button type="button" id="btnToggleQrCredenciamento" class="btn btn-toggle btn-danger" data-field="habilitar_qrcode_evento_credenciamento">
+                      <button type="button" id="btnToggleQrCredenciamento" class="btn btn-toggle btn-danger" data-field="habilitar_qrcode_evento_credenciamento" disabled>
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -941,7 +941,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Habilita envio de feedback nas atividades</p>
                       </div>
-                      <button type="button" id="btnToggleFeedback" class="btn btn-toggle btn-danger" data-field="habilitar_feedback">
+                      <button type="button" id="btnToggleFeedback" class="btn btn-toggle btn-danger" data-field="habilitar_feedback" disabled>
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -955,7 +955,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Permite que participantes baixem certificados</p>
                       </div>
-                      <button type="button" id="btnToggleCertificado" class="btn btn-toggle btn-danger" data-field="habilitar_certificado_individual">
+                      <button type="button" id="btnToggleCertificado" class="btn btn-toggle btn-danger" data-field="habilitar_certificado_individual" disabled>
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -969,7 +969,7 @@
                         </h6>
                         <p class="text-muted small mb-0">Exibe a taxa de serviço separadamente</p>
                       </div>
-                      <button type="button" id="btnToggleMostrarTaxa" class="btn btn-toggle btn-danger" data-field="mostrar_taxa">
+                      <button type="button" id="btnToggleMostrarTaxa" class="btn btn-toggle btn-danger" data-field="mostrar_taxa" disabled>
                         <i class="bi bi-x-circle-fill"></i> Desativado
                       </button>
                     </div>
@@ -982,19 +982,19 @@
                     <i class="bi bi-card-checklist text-primary me-2"></i> Campos Obrigatórios
                   </h6>
                   <div class="d-flex flex-wrap gap-2">
-                    <button type="button" id="btnToggleObrigatorioNome" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_nome" data-label="Nome">
+                    <button type="button" id="btnToggleObrigatorioNome" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_nome" data-label="Nome" disabled>
                       Nome
                     </button>
-                    <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_cpf" data-label="CPF">
+                    <button type="button" id="btnToggleObrigatorioCpf" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_cpf" data-label="CPF" disabled>
                       CPF
                     </button>
-                    <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_email" data-label="Email">
+                    <button type="button" id="btnToggleObrigatorioEmail" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_email" data-label="Email" disabled>
                       Email
                     </button>
-                    <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_senha" data-label="Senha">
+                    <button type="button" id="btnToggleObrigatorioSenha" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_senha" data-label="Senha" disabled>
                       Senha
                     </button>
-                    <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_formacao" data-label="Formação">
+                    <button type="button" id="btnToggleObrigatorioFormacao" class="btn btn-sm btn-toggle btn-success" data-field="obrigatorio_formacao" data-label="Formação" disabled>
                       Formação
                     </button>
                   </div>


### PR DESCRIPTION
## Summary
- Inicializa botoes de configuracao desabilitados no dashboard do cliente
- Habilita ou desabilita botoes conforme selecao de evento

## Testing
- `pytest` *(falhou: BuildError, AssertionError, RuntimeError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68967a92a63883249eebf5614c1fe4c9