### PR TITLE
Add relatório card to client dashboard

### DIFF
--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -776,6 +776,20 @@
         </div>
       </div>
     </div>
+    <div class="col-lg-6 col-xl-3">
+      <div class="card h-100 shadow-sm hover-shadow border-0">
+        <div class="card-body">
+          <div class="text-primary mb-3">
+            <i class="bi bi-file-earmark-bar-graph fs-1"></i>
+          </div>
+          <h5 class="card-title fw-bold">Relatório</h5>
+          <p class="card-text text-muted">Gere relatórios detalhados dos eventos</p>
+          <a href="{{ url_for('relatorio_routes.gerar_relatorio_evento') }}" class="btn btn-primary mt-2 w-100">
+            <i class="bi bi-file-earmark-bar-graph me-2"></i> Gerar Relatório
+          </a>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Configurações e Instruções -->


### PR DESCRIPTION
## Summary
- add Relatório card to dashboard with link to event report generator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6896bc5ae514832491c46d8dee0a5437