### PR TITLE
feat: add event report generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,3 +86,7 @@ wsproto==1.2.0
 WTForms==3.2.1
 XlsxWriter==3.2.2
 mailjet-rest==1.5.1
+docx2pdf==0.1.8
+python-docx==1.1.2
+transformers==4.46.1
+huggingface-hub==0.26.2

--- a/services/relatorio_service.py
+++ b/services/relatorio_service.py
@@ -1,0 +1,98 @@
+from io import BytesIO
+from typing import List, Dict, Any
+import tempfile
+import os
+
+from docx import Document
+from docx2pdf import convert as docx2pdf_convert
+from transformers import pipeline
+
+
+# Initialize a lightweight text generation pipeline
+# Using t5-small for free summarization/text generation
+_model = pipeline("text2text-generation", model="t5-small")
+
+
+def gerar_texto_relatorio(evento, dados_selecionados: List[str]) -> str:
+    """Gera texto de relatório para um evento usando modelo T5.
+
+    Parameters
+    ----------
+    evento: models.Evento
+        Instância do evento.
+    dados_selecionados: List[str]
+        Lista de campos ou informações selecionadas para compor o relatório.
+
+    Returns
+    -------
+    str
+        Texto gerado pelo modelo com base nos dados fornecidos.
+    """
+    entrada = f"Evento: {getattr(evento, 'nome', '')}. " + " ".join(dados_selecionados)
+    resultado = _model(entrada, max_length=200, do_sample=False)
+    return resultado[0]["generated_text"].strip()
+
+
+def criar_documento_word(texto: str, cabecalho: str = "", rodape: str = "", dados: Dict[str, Any] | None = None) -> BytesIO:
+    """Cria um documento Word com cabeçalho, rodapé e corpo de texto.
+
+    Parameters
+    ----------
+    texto: str
+        Corpo principal do relatório.
+    cabecalho: str
+        Conteúdo do cabeçalho.
+    rodape: str
+        Conteúdo do rodapé.
+    dados: Dict[str, Any] | None
+        Dados adicionais para inclusão no documento.
+
+    Returns
+    -------
+    BytesIO
+        Documento Word em memória.
+    """
+    doc = Document()
+    section = doc.sections[0]
+    if cabecalho:
+        section.header.paragraphs[0].text = cabecalho
+    if rodape:
+        section.footer.paragraphs[0].text = rodape
+
+    for linha in texto.split("\n"):
+        doc.add_paragraph(linha)
+
+    if dados:
+        for chave, valor in dados.items():
+            doc.add_paragraph(f"{chave}: {valor}")
+
+    buffer = BytesIO()
+    doc.save(buffer)
+    buffer.seek(0)
+    return buffer
+
+
+def converter_para_pdf(docx_bytes: BytesIO) -> BytesIO:
+    """Converte bytes de um documento Word para PDF.
+
+    Parameters
+    ----------
+    docx_bytes: BytesIO
+        Documento Word em memória.
+
+    Returns
+    -------
+    BytesIO
+        PDF gerado a partir do documento Word.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp_docx:
+        tmp_docx.write(docx_bytes.getvalue())
+        tmp_docx.flush()
+        tmp_pdf = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
+        tmp_pdf.close()
+        docx2pdf_convert(tmp_docx.name, tmp_pdf.name)
+        with open(tmp_pdf.name, "rb") as f:
+            pdf_data = f.read()
+    os.unlink(tmp_docx.name)
+    os.unlink(tmp_pdf.name)
+    return BytesIO(pdf_data)


### PR DESCRIPTION
## Summary
- add relatorio service with text generation, Word creation and PDF conversion
- expose gerar_relatorio_evento route to preview and export reports
- include document and transformers dependencies

## Testing
- `pytest` *(fails: ValueError: pandas.__spec__ is None)*

------
https://chatgpt.com/codex/tasks/task_e_6896bc6d8dc8832492917f0053d36f49