### PR TITLE
Unify report text generation

### DIFF
--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -1,6 +1,16 @@
 from flask import Blueprint, send_file, flash, redirect, url_for, request
 from flask_login import login_required, current_user
-from models import Oficina, Feedback, Evento, Inscricao, Usuario, CampoPersonalizadoCadastro, RespostaCampo
+from models import (
+    Oficina,
+    Feedback,
+    Evento,
+    Inscricao,
+    Usuario,
+    CampoPersonalizadoCadastro,
+    RespostaCampo,
+    Checkin,
+    Sorteio,
+)
 from services.pdf_service import (
     gerar_pdf_inscritos_pdf,
     gerar_lista_frequencia_pdf,
@@ -8,10 +18,10 @@ from services.pdf_service import (
     gerar_pdf_feedback
 )
 from services.relatorio_service import (
-    gerar_texto_relatorio,
     criar_documento_word,
     converter_para_pdf,
 )
+from services.ia_service import gerar_texto_relatorio
 from io import BytesIO
 from openpyxl import Workbook
 from reportlab.lib.pagesizes import A4
@@ -178,7 +188,36 @@ def gerar_relatorio_evento(evento_id):
     rodape = payload.get('rodape', '')
     dados_extra = payload.get('dados_extra', {})
 
-    texto = gerar_texto_relatorio(evento, dados_selecionados)
+    dados = {'evento': evento}
+    if any(opt in dados_selecionados for opt in ('atividades', 'ministrantes', 'datas')):
+        oficinas = Oficina.query.filter_by(evento_id=evento.id).all()
+        if 'atividades' in dados_selecionados:
+            dados['atividades'] = oficinas
+        if 'ministrantes' in dados_selecionados:
+            dados['ministrantes'] = [of.ministrante_obj for of in oficinas if of.ministrante_obj]
+        if 'datas' in dados_selecionados:
+            datas = []
+            for of in oficinas:
+                for dia in of.dias:
+                    datas.append({
+                        'oficina': of.titulo,
+                        'data': dia.data,
+                        'inicio': dia.horario_inicio,
+                        'fim': dia.horario_fim,
+                    })
+            dados['datas'] = datas
+    if 'sorteio' in dados_selecionados:
+        dados['sorteios'] = Sorteio.query.filter_by(evento_id=evento.id).all()
+    if any(opt in dados_selecionados for opt in ('num_inscritos', 'lista_nominal', 'checkins')):
+        inscricoes = Inscricao.query.filter_by(evento_id=evento.id).all()
+        if 'num_inscritos' in dados_selecionados:
+            dados['num_inscritos'] = len(inscricoes)
+        if 'lista_nominal' in dados_selecionados:
+            dados['lista_nominal'] = [ins.usuario.nome for ins in inscricoes]
+        if 'checkins' in dados_selecionados:
+            dados['checkins'] = Checkin.query.filter_by(evento_id=evento.id).all()
+
+    texto = gerar_texto_relatorio(dados)
     docx_buffer = criar_documento_word(texto, cabecalho, rodape, dados_extra)
     pdf_buffer = converter_para_pdf(docx_buffer)
 

--- a/routes/relatorio_routes.py
+++ b/routes/relatorio_routes.py
@@ -20,6 +20,8 @@ from models import (
 from datetime import datetime
 import os
 
+from services.ia_service import gerar_texto_relatorio
+
 
 def montar_relatorio_mensagem(incluir_financeiro=False):
     from sqlalchemy import func
@@ -228,7 +230,6 @@ def gerar_relatorio_evento():
                 if incluir_checkins:
                     dados['checkins'] = Checkin.query.filter_by(evento_id=selected_event.id).all()
 
-        from services.ia_service import gerar_texto_relatorio
         texto_base = gerar_texto_relatorio(dados)
 
         preview = f"{cabecalho}\n{texto_base}\n{rodape}".strip()

--- a/services/relatorio_service.py
+++ b/services/relatorio_service.py
@@ -1,36 +1,10 @@
 from io import BytesIO
-from typing import List, Dict, Any
+from typing import Dict, Any
 import tempfile
 import os
 
 from docx import Document
 from docx2pdf import convert as docx2pdf_convert
-from transformers import pipeline
-
-
-# Initialize a lightweight text generation pipeline
-# Using t5-small for free summarization/text generation
-_model = pipeline("text2text-generation", model="t5-small")
-
-
-def gerar_texto_relatorio(evento, dados_selecionados: List[str]) -> str:
-    """Gera texto de relatório para um evento usando modelo T5.
-
-    Parameters
-    ----------
-    evento: models.Evento
-        Instância do evento.
-    dados_selecionados: List[str]
-        Lista de campos ou informações selecionadas para compor o relatório.
-
-    Returns
-    -------
-    str
-        Texto gerado pelo modelo com base nos dados fornecidos.
-    """
-    entrada = f"Evento: {getattr(evento, 'nome', '')}. " + " ".join(dados_selecionados)
-    resultado = _model(entrada, max_length=200, do_sample=False)
-    return resultado[0]["generated_text"].strip()
 
 
 def criar_documento_word(texto: str, cabecalho: str = "", rodape: str = "", dados: Dict[str, Any] | None = None) -> BytesIO:


### PR DESCRIPTION
## Summary
- Centralize `gerar_texto_relatorio` in `services.ia_service` and drop old transformer-based version
- Update HTML and PDF report routes to use the unified generator and import it consistently
- Collect selected event data in PDF route before generating text

## Testing
- `pytest` *(fails: werkzeug.routing.exceptions.BuildError, AssertionError, AttributeError, RuntimeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc6d7c448324960cb6f87fc3fd49