### PR TITLE
Load report generation model lazily

### DIFF
--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -8,7 +8,6 @@ from services.pdf_service import (
     gerar_pdf_feedback
 )
 from services.relatorio_service import (
-    gerar_texto_relatorio,
     criar_documento_word,
     converter_para_pdf,
 )
@@ -177,6 +176,7 @@ def gerar_relatorio_evento(evento_id):
     cabecalho = payload.get('cabecalho', '')
     rodape = payload.get('rodape', '')
     dados_extra = payload.get('dados_extra', {})
+    from services.relatorio_service import gerar_texto_relatorio
 
     texto = gerar_texto_relatorio(evento, dados_selecionados)
     docx_buffer = criar_documento_word(texto, cabecalho, rodape, dados_extra)


### PR DESCRIPTION
## Summary
- Load T5 text-generation pipeline on demand in `relatorio_service`
- Handle missing model with fallback message
- Import `gerar_texto_relatorio` only when needed in PDF routes

## Testing
- `pytest` *(fails: 41 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc72965c83249afd927781568eed