### PR TITLE
Handle DOCX to PDF conversion failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ No dashboard do cliente é possível exportar a lista de inscritos de um evento 
 
 Para sinalizar as atividades de um evento, utilize a rota `/gerar_placas/<evento_id>` ou o botão **Baixar Placas** no dashboard do cliente. Um PDF é gerado com uma página por oficina, contendo título e ministrante.
 
+### Conversão de DOCX para PDF
+
+Relatórios em PDF são gerados a partir de documentos Word usando `docx2pdf`. Caso a conversão falhe, o sistema tenta utilizar `pypandoc` se estiver disponível; do contrário, retorna o arquivo DOCX original. Instale `pypandoc` para habilitar o fallback.
+
 ### Impersonação de clientes
 
 Administradores podem acessar o painel de qualquer cliente clicando em **Acessar** na seção de Gestão de Clientes do dashboard. A navegação mostrará um link "Sair do modo cliente" para retornar à conta de administrador.


### PR DESCRIPTION
## Summary
- guard DOCX to PDF conversion with error handling and fallback to pypandoc or original file
- document conversion dependency and fallback in README

## Testing
- `pytest tests/test_config_bytes_database_url.py::test_create_app_with_bytes_database_url -q` *(fails: OSError: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc7563a083249d4d0c3d533ae237