### PR TITLE
Add tests for relatorio services and routes

### DIFF
--- a/tests/test_ia_service.py
+++ b/tests/test_ia_service.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+from services.ia_service import gerar_texto_relatorio
+
+
+def test_gerar_texto_relatorio_composto():
+    evento = SimpleNamespace(nome='Evento Teste')
+    dados = {
+        'evento': evento,
+        'atividades': [1, 2],
+        'num_inscritos': 5
+    }
+    texto = gerar_texto_relatorio(dados)
+    assert 'Relatório do evento Evento Teste.' in texto
+    assert 'O evento contou com 2 atividade(s).' in texto
+    assert 'Número de inscritos: 5.' in texto

--- a/tests/test_relatorio_pdf_routes.py
+++ b/tests/test_relatorio_pdf_routes.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import types
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from config import Config
+from app import create_app
+from extensions import db
+from models import Usuario, Cliente, Evento
+
+# Configure in-memory database
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+    os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+    sys.modules.pop('services.relatorio_service', None)
+    sys.modules['transformers'] = types.SimpleNamespace(pipeline=lambda *a, **k: lambda *a2, **k2: None)
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
+        db.session.add_all([cliente, admin])
+        db.session.commit()
+        evento = Evento(cliente_id=cliente.id, nome='Evento')
+        db.session.add(evento)
+        db.session.commit()
+    yield app
+    sys.modules.pop('transformers', None)
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post('/login', data={'email': 'admin@test', 'senha': '123'}, follow_redirects=True)
+
+
+def test_gerar_relatorio_evento_preview(client, app):
+    login(client)
+    with app.app_context():
+        evento = Evento.query.first()
+    pdf_bytes = b'%PDF-1.4'
+    with patch('routes.relatorio_pdf_routes.gerar_texto_relatorio', return_value='TXT'), \
+         patch('routes.relatorio_pdf_routes.criar_documento_word', return_value=BytesIO(b'DOC')), \
+         patch('routes.relatorio_pdf_routes.converter_para_pdf', return_value=BytesIO(pdf_bytes)):
+        resp = client.post(f'/gerar_relatorio_evento/{evento.id}?preview=1', json={'dados': []})
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/pdf'
+    assert resp.data.startswith(pdf_bytes)

--- a/tests/test_relatorio_routes.py
+++ b/tests/test_relatorio_routes.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from config import Config
+from app import create_app
+from extensions import db
+from models import Usuario
+
+# Configure in-memory database
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+    os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+    sys.modules.pop('services.relatorio_service', None)
+    sys.modules['transformers'] = types.SimpleNamespace(pipeline=lambda *a, **k: lambda *a2, **k2: None)
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        admin = Usuario(
+            nome='Admin', cpf='1', email='admin@test',
+            senha=generate_password_hash('123'), formacao='x', tipo='admin'
+        )
+        db.session.add(admin)
+        db.session.commit()
+    yield app
+    sys.modules.pop('transformers', None)
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post('/login', data={'email': 'admin@test', 'senha': '123'}, follow_redirects=True)
+
+
+def test_relatorio_mensagem(client, app):
+    login(client)
+    with patch('routes.relatorio_routes.montar_relatorio_mensagem', return_value='MSG'):
+        resp = client.get('/relatorio_mensagem')
+    assert resp.status_code == 200
+    assert b'MSG' in resp.data
+    assert 'text/html' in resp.headers.get('Content-Type', '')

--- a/tests/test_relatorio_service.py
+++ b/tests/test_relatorio_service.py
@@ -1,0 +1,40 @@
+import importlib
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def relatorio_service_module():
+    """Reload relatorio_service with a stubbed transformers pipeline."""
+    import sys, types
+    sys.modules.pop('services.relatorio_service', None)
+    fake_model = MagicMock(return_value=[{"generated_text": "texto gerado"}])
+    fake_transformers = types.SimpleNamespace(pipeline=lambda *a, **k: fake_model)
+    sys.modules['transformers'] = fake_transformers
+    relatorio_service = importlib.import_module('services.relatorio_service')
+    yield relatorio_service, fake_model
+    sys.modules.pop('transformers', None)
+
+
+def test_gerar_texto_relatorio(relatorio_service_module):
+    service, fake_model = relatorio_service_module
+    evento = SimpleNamespace(nome='Evento X')
+    texto = service.gerar_texto_relatorio(evento, ['dados'])
+    fake_model.assert_called_once()
+    assert texto == 'texto gerado'
+
+
+def test_converter_para_pdf(relatorio_service_module):
+    service, _ = relatorio_service_module
+
+    def fake_convert(input_path, output_path):
+        with open(output_path, 'wb') as f:
+            f.write(b'%PDF-1.4')
+
+    with patch('services.relatorio_service.docx2pdf_convert', side_effect=fake_convert):
+        pdf = service.converter_para_pdf(BytesIO(b'docx'))
+
+    assert pdf.getvalue().startswith(b'%PDF')


### PR DESCRIPTION
## Summary
- Add unit tests for `relatorio_service` and `ia_service`
- Add integration tests for relatorio routes and PDF generation

## Testing
- `pytest tests/test_relatorio_service.py tests/test_ia_service.py tests/test_relatorio_routes.py tests/test_relatorio_pdf_routes.py -q`
- `pytest -q` *(fails: pandas.__spec__ is None and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc782ce08324a84c48d1ca21fc98