### PR TITLE
Atualiza evento do usuário ao inscrever em novo evento

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -167,8 +167,10 @@ def cadastro_participante(identifier: str | None = None):
                 db.session.add(usuario)
                 db.session.flush()
             else:
-                if usuario.evento_id is None:
+                if usuario.evento_id != evento.id:
                     usuario.evento_id = evento.id
+                    if current_user.is_authenticated and current_user.id == usuario.id:
+                        current_user.evento_id = evento.id
 
             cliente_obj = Cliente.query.get(cliente_id)
             if cliente_obj and cliente_obj not in usuario.clientes:


### PR DESCRIPTION
## Summary
- Atualiza `usuario.evento_id` para refletir o evento da nova inscrição
- Sincroniza `current_user.evento_id` quando o usuário já estiver autenticado

## Testing
- `pytest` *(falhou: BuildError e outras falhas nos testes existentes)*
- Script manual de fluxo de inscrição para verificar atualização do `current_user.evento_id`


------
https://chatgpt.com/codex/tasks/task_e_6897e913615083248cf002cc436edce5