### PR TITLE
Add CSRF token to POST forms

### DIFF
--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -13,9 +13,10 @@
     <div class="card shadow-sm">
         <div class="card-body p-4">
             <form method="POST">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="mb-4">
                     <label for="nome" class="form-label fw-medium">Nome do Formulário</label>
-                    <input type="text" id="nome" name="nome" class="form-control form-control-lg" 
+                    <input type="text" id="nome" name="nome" class="form-control form-control-lg"
                            required placeholder="Digite o nome do formulário" autofocus>
                     <div class="form-text">O nome ajuda a identificar o formulário na lista.</div>
                 </div>

--- a/templates/formulario/editar_formulario.html
+++ b/templates/formulario/editar_formulario.html
@@ -4,6 +4,7 @@
     <h2>Editar Formulário</h2>
 
     <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-3">
             <label for="nome" class="form-label">Nome do Formulário</label>
             <input type="text" id="nome" name="nome" class="form-control" value="{{ formulario.nome }}" required>

--- a/templates/formulario/gerenciar_campos.html
+++ b/templates/formulario/gerenciar_campos.html
@@ -81,9 +81,10 @@
                 </div>
                 <div class="card-body">
                     <form method="POST">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <div class="mb-3">
                             <label for="nome" class="form-label fw-medium">Nome do Campo</label>
-                            <input type="text" id="nome" name="nome" class="form-control" 
+                            <input type="text" id="nome" name="nome" class="form-control"
                                    required placeholder="Ex: Nome, Email, Telefone...">
                         </div>
                         
@@ -156,6 +157,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     <form action="{{ url_for('formularios_routes.deletar_campo', campo_id=campo.id) }}" method="POST" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="btn btn-danger">Remover Campo</button>
                     </form>
                 </div>

--- a/templates/reviewer/application_form.html
+++ b/templates/reviewer/application_form.html
@@ -3,6 +3,7 @@
 <div class="container py-5">
   <h1 class="mb-4">Candidatar-se a Revisor</h1>
   <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <p>Confirme para enviar sua candidatura.</p>
     <button type="submit" class="btn btn-primary">Enviar</button>
   </form>


### PR DESCRIPTION
## Summary
- add CSRF hidden inputs to formulario creation, editing, and field management forms
- include CSRF token in reviewer application form

## Testing
- `pytest` *(fails: werkzeug routing BuildError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898a26791f8832481936e98a4a0e2d6