### PR TITLE
Handle JSON payload in create_review

### DIFF
--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -168,8 +168,9 @@ def create_review():
         flash("Acesso negado!", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
 
-    trabalho_id = request.form.get("trabalho_id") or request.json.get("trabalho_id")
-    reviewer_id = request.form.get("reviewer_id") or request.json.get("reviewer_id")
+    data = request.get_json(silent=True) or {}
+    trabalho_id = request.form.get("trabalho_id") or data.get("trabalho_id")
+    reviewer_id = request.form.get("reviewer_id") or data.get("reviewer_id")
 
     if not trabalho_id or not reviewer_id:
         return {"success": False, "message": "dados insuficientes"}, 400


### PR DESCRIPTION
## Summary
- handle JSON and form payloads consistently when creating reviews

## Testing
- `pytest` *(fails: BuildError for URL and multiple other failures)*

------
https://chatgpt.com/codex/tasks/task_e_6898a2792bc883248120fd7e2cd1bb7f