### PR TITLE
Validate peer review rating input

### DIFF
--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -209,7 +209,14 @@ def review_form(locator):
             flash("Código incorreto!", "danger")
             return render_template("peer_review/review_form.html", review=review)
 
-        review.note = request.form.get("nota")
+        try:
+            nota = int(request.form.get("nota"))
+            if nota not in range(1, 6):
+                raise ValueError
+        except (TypeError, ValueError):
+            flash("Nota inválida (use 1–5).", "danger")
+            return render_template("peer_review/review_form.html", review=review)
+        review.note = nota
         review.comments = request.form.get("comentarios")
         review.blind_type = "nome" if request.form.get("mostrar_nome") == "on" else "anonimo"
         review.finished_at = datetime.utcnow()


### PR DESCRIPTION
## Summary
- validate nota field in peer review form to accept only integers 1-5 and flash error otherwise

## Testing
- `pytest` *(fails: IntegrityError/BuildError in campo routes tests)*

------
https://chatgpt.com/codex/tasks/task_e_6898a287f5c88324bb130c1eef4e7a92