### PR TITLE
Restrict feedback response access to authorized users

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -498,6 +498,31 @@ def dar_feedback_resposta(resposta_id):
         return redirect(url_for('dashboard_routes.dashboard'))
 
     resposta = RespostaFormulario.query.get_or_404(resposta_id)
+
+    # Clientes só podem acessar respostas de seus próprios formulários
+    if current_user.tipo == 'cliente':
+        if resposta.formulario.cliente_id != current_user.id:
+            flash('Acesso negado', 'danger')
+            return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+    # Ministrantes só podem avaliar respostas de eventos/oficinas que ministram
+    elif isinstance(current_user, Ministrante):
+        eventos_formulario = resposta.formulario.eventos
+        autorizado = False
+        for evento in eventos_formulario:
+            for oficina in evento.oficinas:
+                if (
+                    oficina.ministrante_id == current_user.id
+                    or current_user in oficina.ministrantes_associados
+                ):
+                    autorizado = True
+                    break
+            if autorizado:
+                break
+        if not autorizado:
+            flash('Acesso negado', 'danger')
+            return redirect(url_for('dashboard_ministrante_routes.dashboard_ministrante'))
+
     lista_campos = resposta.formulario.campos
     resposta_campos = resposta.respostas_campos
 


### PR DESCRIPTION
## Summary
- validate that clients can view feedback only for their own forms
- restrict ministrantes to feedback for events or workshops they instruct

## Testing
- `pytest -q --maxfail=1` *(fails: NOT NULL constraint failed: campos_personalizados_cadastro.evento_id)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa2d7f9883249410035857ad8e04