### PR TITLE
Restrict inline status updates to permitted users

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -702,6 +702,11 @@ def listar_respostas():
 @login_required
 @mfa_required
 def definir_status_inline():
+    # 0) Verifica se o usuário possui permissão
+    if getattr(current_user, 'tipo', None) not in ('cliente', 'ministrante'):
+        flash("Acesso negado!", "danger")
+        return redirect(request.referrer or url_for('dashboard_routes.dashboard'))
+
     # 1) Pega valores do form
     resposta_id = request.form.get('resposta_id')
     novo_status = request.form.get('status_avaliacao')
@@ -717,9 +722,8 @@ def definir_status_inline():
         flash("Resposta não encontrada!", "warning")
         return redirect(request.referrer or url_for('dashboard_routes.dashboard'))
 
-    # 4) Atualiza
+    # 4) Atualiza e registra log
     resposta.status_avaliacao = novo_status
-    db.session.commit()
     uid = current_user.id if hasattr(current_user, 'id') else None
     log = AuditLog(user_id=uid, submission_id=resposta_id, event_type='decision')
     db.session.add(log)


### PR DESCRIPTION
## Summary
- enforce user-type check for inline status updates to allow only clientes or ministrantes
- log decisions before commit and persist changes in a single transaction

## Testing
- `pytest` *(fails: werkzeug.routing.exceptions.BuildError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa31cd2c83249dad091178b83866