### PR TITLE
Allow dynamic workshop choices in registration rule form

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -18,6 +18,17 @@ class RegraInscricaoEventoForm(FlaskForm):
     limite_oficinas = IntegerField('Limite de Oficinas', validators=[Optional()])
     oficinas_permitidas = SelectMultipleField('Oficinas Permitidas', coerce=int)
 
+    def __init__(self, oficinas_choices=None, *args, **kwargs):
+        """Permite injetar escolhas para as oficinas permitidas.
+
+        Parameters
+        ----------
+        oficinas_choices: list[tuple[int, str]] | None
+            Lista de pares ``(id, nome)`` das oficinas disponíveis.
+        """
+        super().__init__(*args, **kwargs)
+        self.oficinas_permitidas.choices = oficinas_choices or []
+
 
 class EditarClienteForm(FlaskForm):
     nome = StringField('Nome', validators=[DataRequired()])


### PR DESCRIPTION
## Summary
- Accept workshop choices for `RegraInscricaoEventoForm` via constructor
- Populate form choices in `configurar_regras_inscricao` route before rendering

## Testing
- `pytest -q` *(fails: 41 failed, 67 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa4974788324a9586d2ee464eeba