### PR TITLE
Add password confirmation for public client registration

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -7,7 +7,7 @@ from wtforms import (
     PasswordField,
     SubmitField,
 )
-from wtforms.validators import DataRequired, Optional, Email
+from wtforms.validators import DataRequired, Optional, Email, Length, EqualTo
 
 class TipoInscricaoEventoForm(FlaskForm):
     nome = StringField('Nome do Tipo de Inscrição', validators=[DataRequired()])
@@ -29,5 +29,6 @@ class EditarClienteForm(FlaskForm):
 class PublicClienteForm(FlaskForm):
     nome = StringField('Nome', validators=[DataRequired()])
     email = StringField('E-mail', validators=[DataRequired(), Email()])
-    senha = PasswordField('Senha', validators=[DataRequired()])
+    senha = PasswordField('Senha', validators=[DataRequired(), Length(min=8)])
+    confirmacao_senha = PasswordField('Confirmar Senha', validators=[DataRequired(), EqualTo('senha')])
     # Não utilizamos RecaptchaField para v3, a validação é feita manualmente

--- a/templates/auth/cadastrar_cliente_publico.html
+++ b/templates/auth/cadastrar_cliente_publico.html
@@ -41,6 +41,11 @@
             <label for="senha"><i class="fas fa-lock me-2"></i>Senha</label>
           </div>
 
+          <div class="form-floating mb-4">
+            <input type="password" class="form-control form-control-lg" id="confirmacao_senha" name="confirmacao_senha" placeholder="Confirmar Senha" required>
+            <label for="confirmacao_senha"><i class="fas fa-lock me-2"></i>Confirmar Senha</label>
+          </div>
+
           <!-- reCAPTCHA v3 não tem interface visível -->
           <input type="hidden" name="g-recaptcha-response" id="g-recaptcha-response">
           {% if form.errors.get('recaptcha', []) %}


### PR DESCRIPTION
## Summary
- enforce min-length and confirmation on public client password
- display confirm password field on public client signup template

## Testing
- `pytest` *(fails: 40 failed, 68 passed, 66 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa4a66ec832481c8686cef5a88cf