### PR TITLE
feat: add event-specific configuration

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -7,7 +7,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 from models import (
-    Checkin, Inscricao, Oficina, ConfiguracaoCliente,
+    Checkin, Inscricao, Oficina, ConfiguracaoCliente, ConfiguracaoEvento,
     AgendamentoVisita, Evento, Usuario
 )
 from utils import formatar_brasilia, determinar_turno
@@ -151,7 +151,13 @@ def checkin(oficina_id):
     cliente_id_oficina = oficina.cliente_id
 
     config_cliente = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id_oficina).first()
-    if not config_cliente or not config_cliente.permitir_checkin_global:
+    config_evento = ConfiguracaoEvento.query.filter_by(evento_id=oficina.evento_id).first()
+    permitido = False
+    if config_evento and config_evento.permitir_checkin_global:
+        permitido = True
+    elif config_cliente and config_cliente.permitir_checkin_global:
+        permitido = True
+    if not permitido:
         flash("Check-in indisponível para esta oficina!", "danger")
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
 

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -9,7 +9,7 @@ from models import (
     Evento, Oficina, Inscricao, Usuario, LinkCadastro,
     LoteInscricao, EventoInscricaoTipo, LoteTipoInscricao,
     CampoPersonalizadoCadastro, RespostaCampo, RespostaFormulario, Formulario, RegraInscricaoEvento,
-    Patrocinador, Ministrante, InscricaoTipo, ConfiguracaoCliente, Cliente
+    Patrocinador, Ministrante, InscricaoTipo, ConfiguracaoCliente, ConfiguracaoEvento, Cliente
 )
 import os
 from mp_fix_patch import fix_mp_notification_url, create_mp_preference
@@ -514,12 +514,23 @@ def _render_form(*, link, evento, lote_vigente, lotes_ativos, cliente_id):
         tipos_inscricao = []
 
     config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
-    mostrar_taxa = config_cli.mostrar_taxa if config_cli else True
-    obrigatorio_nome = config_cli.obrigatorio_nome if config_cli else True
-    obrigatorio_cpf = config_cli.obrigatorio_cpf if config_cli else True
-    obrigatorio_email = config_cli.obrigatorio_email if config_cli else True
-    obrigatorio_senha = config_cli.obrigatorio_senha if config_cli else True
-    obrigatorio_formacao = config_cli.obrigatorio_formacao if config_cli else True
+    config_evento = (
+        ConfiguracaoEvento.query.filter_by(evento_id=evento.id).first() if evento else None
+    )
+
+    def _cfg(field: str, default: bool = True) -> bool:
+        if config_evento and getattr(config_evento, field) is not None:
+            return getattr(config_evento, field)
+        if config_cli and getattr(config_cli, field) is not None:
+            return getattr(config_cli, field)
+        return default
+
+    mostrar_taxa = _cfg("mostrar_taxa", True)
+    obrigatorio_nome = _cfg("obrigatorio_nome", True)
+    obrigatorio_cpf = _cfg("obrigatorio_cpf", True)
+    obrigatorio_email = _cfg("obrigatorio_email", True)
+    obrigatorio_senha = _cfg("obrigatorio_senha", True)
+    obrigatorio_formacao = _cfg("obrigatorio_formacao", True)
 
     # Estatísticas do lote vigente
     lote_stats = None

--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -389,7 +389,7 @@
   <!-- Container unificado para as ações -->
   <div class="container-fluid px-4 mt-5">
     <div class="d-flex flex-wrap justify-content-center gap-3">
-      {% if config_cliente and config_cliente.habilitar_submissao_trabalhos %}
+      {% if evento and evento.configuracao_evento and evento.configuracao_evento.habilitar_submissao_trabalhos %}
         <a href="{{ url_for('trabalho_routes.submeter_trabalho') }}" class="btn btn-success btn-lg">
           <i class="bi bi-upload me-2"></i> Submeter Trabalho
         </a>
@@ -418,12 +418,12 @@
 {% endif %}
   
 
-  {% if config_cliente and config_cliente.habilitar_qrcode_evento_credenciamento %}
+  {% if evento and evento.configuracao_evento and evento.configuracao_evento.habilitar_qrcode_evento_credenciamento %}
     <a href="{{ url_for('routes.gerar_evento_qrcode_pdf_route', evento_id=evento.id) }}" class="btn btn-primary">
       <i class="fas fa-qrcode"></i> Baixar QR Code do Evento
     </a>
   {% else %}
-    <p class="text-muted">QR Code do evento desativado pelo cliente.</p>
+    <p class="text-muted">QR Code do evento desativado.</p>
   {% endif %}
 
 
@@ -524,7 +524,7 @@
                     {% if oficina.id in inscricoes_ids %}
                         <div class="d-flex flex-column gap-2">
                             <!-- Check-in (só aparece se permitir_checkin_global == True) -->
-                            {% if permitir_checkin_global %}
+                            {% if evento and evento.configuracao_evento and evento.configuracao_evento.permitir_checkin_global %}
                             <a href="{{ url_for('checkin_routes.checkin', oficina_id=oficina.id) }}" class="btn btn-warning w-100">
                               <i class="fas fa-clipboard-check"></i> Realizar Check-in
                             </a>
@@ -543,7 +543,7 @@
                             </a>
 
                             <!-- Certificado Individual (só aparece se habilitar_certificado_individual == True) -->
-                            {% if habilitar_certificado_individual %}
+                            {% if evento and evento.configuracao_evento and evento.configuracao_evento.habilitar_certificado_individual %}
                             <a href="{{ url_for('comprovante_routes.gerar_certificado_individual', oficina_id=oficina.id) }}"
                               class="btn btn-success w-100">
                               <i class="fas fa-graduation-cap"></i> Baixar Certificado
@@ -551,7 +551,7 @@
                             {% endif %}
                           
                             <!-- Feedback (só aparece se habilitar_feedback == True) -->
-                            {% if habilitar_feedback %}
+                            {% if evento and evento.configuracao_evento and evento.configuracao_evento.habilitar_feedback %}
                             <a href="{{ url_for('feedback_routes.feedback', oficina_id=oficina.id) }}" class="btn btn-info w-100">
                                 <i class="fas fa-comment-dots"></i> Enviar Feedback
                             </a>
@@ -667,7 +667,7 @@ function inscrever(oficinaId) {
                 `;
                 buttonContainer.appendChild(cancelForm);
 
-                if ('{{ permitir_checkin_global }}' === 'True') {
+                if ('{{ evento.configuracao_evento.permitir_checkin_global if evento and evento.configuracao_evento else False }}' === 'True') {
                     const checkinBtn = document.createElement('a');
                     checkinBtn.setAttribute('href', `/checkin/${oficinaId}`);
                     checkinBtn.className = 'btn btn-warning w-100';


### PR DESCRIPTION
## Summary
- prefer event-specific configuration for registration options
- allow check-in when enabled by event or client settings
- expose event configuration on participant dashboard and templates

## Testing
- `pytest` *(fails: BuildError in various routes, missing templates)*

------
https://chatgpt.com/codex/tasks/task_e_6898faa39ca88324aa187ba889f1717f