### PR TITLE
Ajusta caminho do template de visualização de resposta

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -327,7 +327,7 @@ def visualizar_resposta(resposta_id):
         flash("Você não tem permissão para ver esta resposta.", "danger")
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
 
-    return render_template('visualizar_resposta.html', resposta=resposta)
+    return render_template('trabalho/visualizar_resposta.html', resposta=resposta)
 
 
     


### PR DESCRIPTION
## Summary
- corrige caminho do template ao exibir respostas de formulário

## Testing
- `pytest` *(falhou: 4 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68990396e1bc8324b44571fa1583efba