### PR TITLE
Check user existence before audit logging

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -815,7 +815,8 @@ def definir_status_inline():
 
     # 4) Atualiza e registra log
     resposta.status_avaliacao = novo_status
-    uid = current_user.id if hasattr(current_user, 'id') else None
+    usuario = Usuario.query.get(current_user.id) if hasattr(current_user, "id") else None
+    uid = usuario.id if usuario else None
     log = AuditLog(user_id=uid, submission_id=resposta_id, event_type='decision')
     db.session.add(log)
     db.session.commit()


### PR DESCRIPTION
## Summary
- Safely query the current user before logging a decision to avoid invalid foreign keys.

## Testing
- `pytest -q` *(fails: BuildError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_689a0854f70083248fba0956956588a7