### PR TITLE
Restrict admin scan route access

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -579,6 +579,7 @@ def processar_qrcode():
 @login_required
 def admin_scan():
     if current_user.tipo not in ('admin', 'cliente'):
-        flash("Acesso Autorizado!", "danger")
-        
-    return render_template("checkin/scan_qr.html")
+        flash('Acesso negado!', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    return render_template('checkin/scan_qr.html')


### PR DESCRIPTION
## Summary
- deny access to admin scan for unauthorized users

## Testing
- `pytest tests/test_checkin_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a115717888324a8587d862ce5e60b