### PR TITLE
Restrict QR code access for agendamento

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3648,6 +3648,9 @@ def marcar_presenca_aluno(aluno_id):
 def qrcode_agendamento(agendamento_id):
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
+    if current_user.id not in (agendamento.professor_id, agendamento.horario.evento.cliente_id):
+        abort(403)
+
     # Dados que estarão no QR Code
     qr_data = f"Agendamento ID: {agendamento.id}, Evento: {agendamento.horario.evento.nome}, Data: {agendamento.horario.data.strftime('%d/%m/%Y')}"
 


### PR DESCRIPTION
## Summary
- validate agendamento QR code access to professor or event owner before generating the code

## Testing
- `pytest` *(39 failing, 70 passing)*

------
https://chatgpt.com/codex/tasks/task_e_689a1151437c8324b5a78d19915bc141