### PR TITLE
Add CSRF token to agendamento dashboard fetch requests

### DIFF
--- a/templates/agendamento/dashboard_agendamentos.html
+++ b/templates/agendamento/dashboard_agendamentos.html
@@ -767,6 +767,7 @@
 
 <!-- Scripts -->
 <script>
+const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
 // Inicializar as tabs programaticamente
 document.addEventListener("DOMContentLoaded", function() {
   // Verificar se há um hash na URL
@@ -805,7 +806,8 @@ document.addEventListener("DOMContentLoaded", function() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Requested-With": "XMLHttpRequest"
+          "X-Requested-With": "XMLHttpRequest",
+          "X-CSRFToken": csrfToken
         },
         body: JSON.stringify({})
       })
@@ -1009,7 +1011,8 @@ function atualizarStatusAgendamento(agendamentoId, novoStatus) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Requested-With": "XMLHttpRequest"
+      "X-Requested-With": "XMLHttpRequest",
+      "X-CSRFToken": csrfToken
     },
     body: JSON.stringify({
       status: novoStatus
@@ -1070,7 +1073,8 @@ function togglePeriodoStatus(periodoId) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Requested-With": "XMLHttpRequest"
+      "X-Requested-With": "XMLHttpRequest",
+      "X-CSRFToken": csrfToken
     }
   })
   .then(response => response.json())


### PR DESCRIPTION
## Summary
- capture CSRF token from meta tag in agendamento dashboard
- include CSRF token header in POST fetch requests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_689a184492908324945559a5edd4f856