### PR TITLE
Add CSRF tokens to agendamento forms

### DIFF
--- a/templates/agendamento/agendar_visita.html
+++ b/templates/agendamento/agendar_visita.html
@@ -8,6 +8,7 @@
     <p><strong>Vagas Disponíveis:</strong> {{ horario.vagas_disponiveis }}</p>
 
     <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-3">
             <label class="form-label">Nome da Escola</label>
             <input type="text" name="escola_nome" class="form-control" required>

--- a/templates/agendamento/configurar_agendamentos.html
+++ b/templates/agendamento/configurar_agendamentos.html
@@ -31,6 +31,7 @@
         </div>
         <div class="card-body">
           <form method="POST" action="{{ url_for('agendamento_routes.configurar_agendamentos', evento_id=evento.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="prazo_cancelamento" class="form-label">Prazo para Cancelamento (horas)</label>

--- a/templates/agendamento/configurar_horarios_agendamento.html
+++ b/templates/agendamento/configurar_horarios_agendamento.html
@@ -84,6 +84,7 @@
                     <i class="bi bi-pencil"></i>
                   </a>
                   <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="d-inline" onsubmit="return confirm('Tem certeza que deseja excluir este horário?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <input type="hidden" name="acao" value="excluir">
                     <input type="hidden" name="horario_id" value="{{ horario.id }}">
                     <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
@@ -116,6 +117,7 @@
         </div>
         <div class="card-body">
           <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="acao" value="adicionar">
             <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
             
@@ -161,6 +163,7 @@
         </div>
         <div class="card-body">
           <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="acao" value="adicionar_periodo">
             <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
             

--- a/templates/agendamento/configurar_regras_inscricao.html
+++ b/templates/agendamento/configurar_regras_inscricao.html
@@ -28,6 +28,7 @@
 
       <div id="regras-container" {% if not evento %}class="d-none"{% endif %}>
         <form method="POST" id="regras-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="evento_id" id="form-evento-id" value="{{ evento.id if evento else '' }}">
           
           <!-- Tipos de Inscrição -->

--- a/templates/agendamento/criar_agendamento.html
+++ b/templates/agendamento/criar_agendamento.html
@@ -21,6 +21,7 @@
       {% endif %}
 
       <form method="POST" action="{{ url_for('agendamento_routes.criar_agendamento') }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="row">
           <!-- Coluna 1: Informações do Evento -->
           <div class="col-md-6">

--- a/templates/agendamento/criar_evento_agendamento.html
+++ b/templates/agendamento/criar_evento_agendamento.html
@@ -21,6 +21,7 @@
       {% endif %}
 
       <form method="POST" action="{{ url_for('evento_routes.configurar_evento') }}" enctype="multipart/form-data">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="row">
           <!-- Coluna 1: Informações Básicas -->
           <div class="col-md-6">

--- a/templates/agendamento/criar_periodo_agendamento.html
+++ b/templates/agendamento/criar_periodo_agendamento.html
@@ -24,6 +24,7 @@
       {% endif %}
 
       <form method="POST" action="{{ url_for('agendamento_routes.criar_periodo_agendamento') }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="row">
           <!-- Coluna 1: Informações do Evento e Período -->
           <div class="col-md-6">

--- a/templates/agendamento/dashboard_agendamentos.html
+++ b/templates/agendamento/dashboard_agendamentos.html
@@ -507,6 +507,7 @@
                     <div class="card-body">
                       <h6 class="mb-3">Configurações Adicionais</h6>
                       <form action="{{ url_for('agendamento_routes.salvar_config_agendamento') }}" method="POST">
+                          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <div class="mb-3">
                           <label for="capacidadeMaxima" class="form-label">Capacidade Máxima por Horário</label>
                           <input type="number" class="form-control" id="capacidadeMaxima" name="capacidade_maxima" value="{{ config_agendamento.capacidade_maxima if config_agendamento else 30 }}" min="1">
@@ -604,6 +605,7 @@
                   <div class="d-grid gap-3 mt-3">
                     <form action="{{ url_for('agendamento_routes.excluir_todos_agendamentos') }}" method="post"
                           onsubmit="return confirm('ATENÇÃO: Esta ação excluirá TODOS os agendamentos e não pode ser desfeita! Tem certeza que deseja continuar?');">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                       <button type="submit" class="btn btn-danger w-100">
                         <i class="bi bi-trash-fill me-2"></i> Excluir Todos os Agendamentos
                       </button>
@@ -611,6 +613,7 @@
                     
                     <form action="{{ url_for('agendamento_routes.resetar_configuracoes_agendamento') }}" method="post"
                           onsubmit="return confirm('Tem certeza que deseja restaurar as configurações padrão?');">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                       <button type="submit" class="btn btn-warning w-100">
                         <i class="bi bi-arrow-repeat me-2"></i> Restaurar Configurações Padrão
                       </button>

--- a/templates/agendamento/editar_agendamento.html
+++ b/templates/agendamento/editar_agendamento.html
@@ -11,6 +11,7 @@
         </div>
         <div class="card-body">
           <form method="POST">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="horario_id" class="form-label">Horário de Visitação</label>

--- a/templates/agendamento/editar_sala_visitacao.html
+++ b/templates/agendamento/editar_sala_visitacao.html
@@ -14,6 +14,7 @@
         </div>
         <div class="card-body">
           <form method="POST" action="{{ url_for('agendamento_routes.editar_sala_visitacao', sala_id=sala.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="nome" class="form-label">Nome da Sala *</label>

--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -40,6 +40,7 @@
         </div>
         <div class="card-body">
           <form method="POST" action="{{ url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="row mb-3">
               <div class="col-md-6">
                 <label for="data_inicial" class="form-label">Data Inicial</label>

--- a/templates/agendamento/importar_agendamentos.html
+++ b/templates/agendamento/importar_agendamentos.html
@@ -26,6 +26,7 @@
           {% endif %}
 
           <form method="POST" action="{{ url_for('agendamento_routes.importar_agendamentos') }}" enctype="multipart/form-data">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <!-- Evento -->
             <div class="mb-3">
               <label for="evento_id" class="form-label">Evento <span class="text-danger">*</span></label>

--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -190,6 +190,7 @@
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                           </div>
                           <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
+                              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="modal-body">
                               <input type="hidden" name="status" value="cancelado">
                               <p>Tem certeza que deseja cancelar este agendamento?</p>
@@ -216,6 +217,7 @@
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                           </div>
                           <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
+                              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="modal-body">
                               <input type="hidden" name="status" value="confirmado">
                               <p>Deseja confirmar este agendamento?</p>
@@ -242,6 +244,7 @@
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                           </div>
                           <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}" method="post">
+                              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="modal-body">
                               <input type="hidden" name="status" value="realizado">
                               <p>Confirma que este agendamento foi realizado?</p>

--- a/templates/agendamento/listar_horarios_agendamento.html
+++ b/templates/agendamento/listar_horarios_agendamento.html
@@ -126,6 +126,7 @@
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <form id="editarHorarioForm" method="POST" action="{{ url_for('agendamento_routes.editar_horario_agendamento') }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="modal-body">
           <input type="hidden" id="horario_id" name="horario_id">
           
@@ -180,6 +181,7 @@
       </div>
       <div class="modal-footer">
         <form id="excluirHorarioForm" method="POST" action="{{ url_for('agendamento_routes.excluir_horario_agendamento') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" id="excluir_horario_id" name="horario_id">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
           <button type="submit" class="btn btn-danger">Confirmar Exclusão</button>

--- a/templates/agendamento/salas_visitacao.html
+++ b/templates/agendamento/salas_visitacao.html
@@ -14,6 +14,7 @@
         </div>
         <div class="card-body">
           <form method="POST" action="{{ url_for('agendamento_routes.salas_visitacao', evento_id=evento.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="row">
               <div class="col-md-4 mb-3">
                 <label for="nome" class="form-label">Nome da Sala *</label>
@@ -114,6 +115,7 @@
       </div>
       <div class="modal-footer">
         <form id="excluirSalaForm" method="POST" action="">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
           <button type="submit" class="btn btn-danger">Confirmar Exclusão</button>
         </form>

--- a/templates/participante/cancelar_agendamento.html
+++ b/templates/participante/cancelar_agendamento.html
@@ -21,6 +21,7 @@
         <div class="card-body">
             <p>Tem certeza que deseja cancelar este agendamento? Esta ação não pode ser desfeita.</p>
             <form method="POST" action="{{ url_for('agendamento_routes.cancelar_agendamento_participante', agendamento_id=agendamento.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="mt-4 d-flex gap-2">
                     <button type="submit" class="btn btn-danger">
                         <i class="fas fa-times"></i> Confirmar Cancelamento

--- a/templates/participante/criar_agendamento.html
+++ b/templates/participante/criar_agendamento.html
@@ -32,6 +32,7 @@
         </div>
         <div class="card-body">
             <form method="POST" action="{{ url_for('routes.criar_agendamento_participante', horario_id=horario.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="row">
                     <div class="col-md-6 mb-3">
                         <label for="escola_nome" class="form-label">Nome da Escola *</label>


### PR DESCRIPTION
## Summary
- Include CSRF token in agendamento creation form and all other POST-based scheduling templates

## Testing
- `pytest` *(fails: BuildError and others, 39 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689a1844ede48324b06483b5ce5724c6