### PR TITLE
Fix indentation in status inline route

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -825,37 +825,37 @@ def definir_status_inline():
         return redirect(request.referrer or url_for('dashboard_routes.dashboard'))
 
     # 3) Busca a resposta no banco
-   resposta = RespostaFormulario.query.get(resposta_id)
-if not resposta:
-    flash("Resposta não encontrada!", "warning")
-    return redirect(request.referrer or url_for('dashboard_routes.dashboard'))
+    resposta = RespostaFormulario.query.get(resposta_id)
+    if not resposta:
+        flash("Resposta não encontrada!", "warning")
+        return redirect(request.referrer or url_for('dashboard_routes.dashboard'))
 
-# 4) Atualiza e registra log
-resposta.status_avaliacao = novo_status
+    # 4) Atualiza e registra log
+    resposta.status_avaliacao = novo_status
 
-# Obtém o ID do usuário autenticado de forma segura
-uid = current_user.id if hasattr(current_user, "id") else None
+    # Obtém o ID do usuário autenticado de forma segura
+    uid = current_user.id if hasattr(current_user, "id") else None
 
-# Determina a URL de retorno (prioriza a página anterior)
-redirect_url = request.referrer or url_for(
-    'formularios_routes.listar_respostas',
-    formulario_id=resposta.formulario_id,
-)
+    # Determina a URL de retorno (prioriza a página anterior)
+    redirect_url = request.referrer or url_for(
+        'formularios_routes.listar_respostas',
+        formulario_id=resposta.formulario_id,
+    )
 
-try:
-    log = AuditLog(user_id=uid, submission_id=resposta_id, event_type='decision')
-    db.session.add(log)
-    db.session.commit()
-    flash("Status atualizado com sucesso!", "success")
-except SQLAlchemyError:
-    db.session.rollback()
-    logger.exception("Erro ao salvar atualização de status")
-    flash("Não foi possível salvar a atualização de status.", "danger")
-    if request.accept_mimetypes.accept_json:
-        return jsonify({"message": "Status update could not be saved"}), 400
+    try:
+        log = AuditLog(user_id=uid, submission_id=resposta_id, event_type='decision')
+        db.session.add(log)
+        db.session.commit()
+        flash("Status atualizado com sucesso!", "success")
+    except SQLAlchemyError:
+        db.session.rollback()
+        logger.exception("Erro ao salvar atualização de status")
+        flash("Não foi possível salvar a atualização de status.", "danger")
+        if request.accept_mimetypes.accept_json:
+            return jsonify({"message": "Status update could not be saved"}), 400
+        return redirect(redirect_url)
+
+    # Redireciona para a mesma página (listar_respostas) ou usa request.referrer
     return redirect(redirect_url)
-
-# Redireciona para a mesma página (listar_respostas) ou usa request.referrer
-return redirect(redirect_url)
 
 


### PR DESCRIPTION
## Summary
- fix indentation so the status update logic stays inside `definir_status_inline`

## Testing
- `python -m py_compile routes/formularios_routes.py`
- `pytest -q` *(fails: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_689a232878c08324a247f6ab63f1b144