### PR TITLE
Require SECRET_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ export DB_ONLINE="<url_do_banco_online>"
 export DB_LOCAL="<url_do_banco_local>"
 ```
 
-As variáveis `GOOGLE_CLIENT_ID` e `GOOGLE_CLIENT_SECRET` são **obrigatórias**
-para a autenticação via Gmail. A aplicação encerrará a inicialização caso elas
-não estejam definidas no ambiente.
+As variáveis `SECRET_KEY`, `GOOGLE_CLIENT_ID` e `GOOGLE_CLIENT_SECRET` são **obrigatórias**.
+A `SECRET_KEY` deve ser um valor forte e aleatório; a aplicação encerrará a
+inicialização caso qualquer uma delas não esteja definida no ambiente. As
+chaves do Google são necessárias para a autenticação via Gmail.
 
 ## Banco de Dados
 

--- a/config.py
+++ b/config.py
@@ -22,7 +22,11 @@ class Config:
     # ------------------------------------------------------------------ #
     #  Chave secreta                                                     #
     # ------------------------------------------------------------------ #
-    SECRET_KEY = os.getenv("SECRET_KEY") or "dev-secret-key"
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    if not SECRET_KEY:
+        raise RuntimeError(
+            "SECRET_KEY environment variable is required; define a secure value."
+        )
     
     # ------------------------------------------------------------------ #
     #  Ambiente de desenvolvimento                                       #

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
           name: system-db
           property: connectionString
       - key: SECRET_KEY
-        value: "REPLACE_ME"
+        value: "REPLACE_ME"  # replace with a strong, random value
 
 # Provision a PostgreSQL database if needed
 # Comment out the database block if you already have one


### PR DESCRIPTION
## Summary
- raise error if SECRET_KEY env var is missing
- note SECRET_KEY requirement in README and Render config

## Testing
- `pytest -q` *(fails: IndentationError in routes/formularios_routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_689a23336f848324921783409867f89e