### PR TITLE
Add confirmation flow for professor schedules

### DIFF
--- a/templates/professor/adicionar_alunos.html
+++ b/templates/professor/adicionar_alunos.html
@@ -135,9 +135,11 @@
             </div>
         {% endif %}
         
+        {% if total_adicionados > 0 %}
         <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
+        {% endif %}
         
         <a href="{{ url_for('routes.qrcode_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-info">
             <i class="fas fa-qrcode"></i> Ver QR Code

--- a/templates/professor/confirmacao_agendamento.html
+++ b/templates/professor/confirmacao_agendamento.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+
+{% block title %}Agendamento Completo{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="alert alert-success">
+        <h4 class="alert-heading">Agendamento completo!</h4>
+        <p>Todos os alunos foram cadastrados. Baixe o comprovante para levar no dia da visita.</p>
+    </div>
+    <div class="d-flex gap-2 mt-3">
+        <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
+            <i class="fas fa-print"></i> Baixar Comprovante
+        </a>
+        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
+            <i class="fas fa-arrow-left"></i> Voltar aos Agendamentos
+        </a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Redirect to a confirmation page after completing student registration for a schedule
- Add link to print schedule only when there are registered students
- Prevent schedule printing without registered students

## Testing
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689a3b77de60832497111414f543bab4