### PR TITLE
Traduz dias da semana para português

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ logging.basicConfig(
 )
 
 from services.mp_service import get_sdk
+from utils.dia_semana import dia_semana
 
 
 def create_app():
@@ -58,6 +59,10 @@ def create_app():
             dt = dt.replace(tzinfo=pytz.utc)
         dt_brasilia = dt.astimezone(pytz.timezone("America/Sao_Paulo"))
         return dt_brasilia.strftime("%d/%m/%Y %H:%M:%S")
+
+    @app.template_filter("dia_semana")
+    def dia_semana_filter(value):
+        return dia_semana(value)
 
     # Registro de rotas
     from routes import register_routes

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1,5 +1,6 @@
 from flask_login import login_required
 from utils import external_url, determinar_turno
+from utils.dia_semana import dia_semana
 import logging
 import psutil
 import os
@@ -2980,8 +2981,9 @@ def gerar_programacao_evento_pdf(evento_id):
     # Programação por data
     for i, data in enumerate(sorted_dates):
         # Cabeçalho da data
-        data_formatada = datetime.strptime(data, '%d/%m/%Y').strftime('%A, %d de %B de %Y')
-        story.append(Paragraph(data_formatada.title(), styles['DateHeader']))
+        data_dt = datetime.strptime(data, '%d/%m/%Y')
+        data_formatada = f"{dia_semana(data_dt)}, {data_dt.strftime('%d de %B de %Y')}"
+        story.append(Paragraph(data_formatada, styles['DateHeader']))
         
         # Criar tabela para as oficinas do dia
         oficinas_do_dia = sorted(grouped_oficinas[data], key=lambda x: x['inicio'])

--- a/templates/agendamento/listar_horarios_agendamento.html
+++ b/templates/agendamento/listar_horarios_agendamento.html
@@ -42,7 +42,7 @@
               {% set data = horarios[0].data %}
               <div class="mb-4">
                 <h4>
-                  <i class="bi bi-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data.strftime('%A')|capitalize }})
+                  <i class="bi bi-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data|dia_semana|capitalize }})
                 </h4>
                 
                 <div class="table-responsive">

--- a/templates/emails/api/horarios_disponiveis.html
+++ b/templates/emails/api/horarios_disponiveis.html
@@ -34,7 +34,7 @@
             {% set data = horarios[0].data %}
             <div class="card mb-4">
                 <div class="card-header bg-success text-white">
-                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data.strftime('%A')|capitalize }})
+                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data|dia_semana|capitalize }})
                 </div>
                 <div class="card-body">
                     <table class="table table-striped table-hover">

--- a/templates/participante/horarios_disponiveis.html
+++ b/templates/participante/horarios_disponiveis.html
@@ -34,7 +34,7 @@
             {% set data = horarios[0].data %}
             <div class="card mb-4">
                 <div class="card-header bg-success text-white">
-                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data.strftime('%A')|capitalize }})
+                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data|dia_semana|capitalize }})
                 </div>
                 <div class="card-body">
                     <table class="table table-striped table-hover">

--- a/templates/professor/horarios_disponiveis.html
+++ b/templates/professor/horarios_disponiveis.html
@@ -34,7 +34,7 @@
             {% set data = horarios[0].data %}
             <div class="card mb-4">
                 <div class="card-header bg-success text-white">
-                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data.strftime('%A')|capitalize }})
+                    <i class="fas fa-calendar-day"></i> {{ data.strftime('%d/%m/%Y') }} ({{ data|dia_semana|capitalize }})
                 </div>
                 <div class="card-body">
                     <table class="table table-striped table-hover">

--- a/utils/dia_semana.py
+++ b/utils/dia_semana.py
@@ -1,0 +1,22 @@
+from datetime import date, datetime
+
+DIAS_SEMANA = {
+    'Monday': 'Segunda-feira',
+    'Tuesday': 'Terça-feira',
+    'Wednesday': 'Quarta-feira',
+    'Thursday': 'Quinta-feira',
+    'Friday': 'Sexta-feira',
+    'Saturday': 'Sábado',
+    'Sunday': 'Domingo',
+}
+
+def dia_semana(valor: datetime | date | str) -> str:
+    """Retorna o nome do dia da semana em português.
+
+    Aceita uma data ou uma string contendo o nome do dia em inglês.
+    """
+    if isinstance(valor, str):
+        nome_em_ingles = valor
+    else:
+        nome_em_ingles = valor.strftime('%A')
+    return DIAS_SEMANA.get(nome_em_ingles, nome_em_ingles)


### PR DESCRIPTION
## Summary
- Adiciona utilitário para tradução do dia da semana em português e registra filtro Jinja
- Atualiza templates para usar o filtro de tradução em vez de `strftime('%A')`
- Ajusta `services/pdf_service` para traduzir o cabeçalho de datas em PDFs

## Testing
- `pytest` *(falha: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_689a3b769e0883249f273ecf92ecb13c