### PR TITLE
Add option for single-response forms

### DIFF
--- a/migrations/versions/31e6ad1c6a4f_add_permitir_multiplas_respostas.py
+++ b/migrations/versions/31e6ad1c6a4f_add_permitir_multiplas_respostas.py
@@ -1,0 +1,25 @@
+"""Add permitir_multiplas_respostas to formularios
+
+Revision ID: 31e6ad1c6a4f
+Revises: 15b6b890ce1d
+Create Date: 2024-05-16 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "31e6ad1c6a4f"
+down_revision = "15b6b890ce1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "formularios",
+        sa.Column("permitir_multiplas_respostas", sa.Boolean(), server_default=sa.true(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("formularios", "permitir_multiplas_respostas")

--- a/models.py
+++ b/models.py
@@ -567,6 +567,7 @@ class Formulario(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nome = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=True)
+    permitir_multiplas_respostas = db.Column(db.Boolean, default=True)
     cliente_id = db.Column(db.Integer, db.ForeignKey('cliente.id'), nullable=True)  # Se cada cliente puder ter seus próprios formulários
     
 

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -103,10 +103,12 @@ def criar_formulario():
         nome = request.form.get('nome')
         descricao = request.form.get('descricao')
         evento_ids = request.form.getlist('eventos')
+        permitir_multiplas = 'permitir_multiplas_respostas' not in request.form
 
         novo_formulario = Formulario(
             nome=nome,
             descricao=descricao,
+            permitir_multiplas_respostas=permitir_multiplas,
             cliente_id=current_user.id
         )
 
@@ -130,6 +132,7 @@ def editar_formulario(formulario_id):
     if request.method == 'POST':
         formulario.nome = request.form.get('nome')
         formulario.descricao = request.form.get('descricao')
+        formulario.permitir_multiplas_respostas = 'permitir_multiplas_respostas' not in request.form
         db.session.commit()
         flash('Formulário atualizado!', 'success')
         return redirect(url_for('formularios_routes.listar_formularios'))
@@ -239,6 +242,15 @@ def preencher_formulario(formulario_id):
     formulario = Formulario.query.get_or_404(formulario_id)
 
     if request.method == 'POST':
+        if not formulario.permitir_multiplas_respostas:
+            ja_respondeu = RespostaFormulario.query.filter_by(
+                formulario_id=formulario.id,
+                usuario_id=current_user.id
+            ).first()
+            if ja_respondeu:
+                flash('Apenas uma resposta é permitida para este formulário.', 'warning')
+                return redirect(url_for('formularios_routes.listar_formularios_participante'))
+
         resposta_formulario = RespostaFormulario(
             formulario_id=formulario.id,
             usuario_id=current_user.id

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -28,6 +28,13 @@
                     <div class="form-text">Uma breve descrição sobre o propósito deste formulário.</div>
                 </div>
 
+                <div class="form-check mb-4">
+                    <input class="form-check-input" type="checkbox" id="permitir_multiplas_respostas" name="permitir_multiplas_respostas">
+                    <label class="form-check-label" for="permitir_multiplas_respostas">
+                        Permitir apenas uma resposta por usuário
+                    </label>
+                </div>
+
                 <div class="mb-4">
                     <label for="eventos" class="form-label fw-medium">Eventos Relacionados</label>
                     <select id="eventos" name="eventos" class="form-select" multiple>

--- a/templates/formulario/editar_formulario.html
+++ b/templates/formulario/editar_formulario.html
@@ -13,6 +13,10 @@
             <label for="descricao" class="form-label">Descrição</label>
             <textarea id="descricao" name="descricao" class="form-control">{{ formulario.descricao }}</textarea>
         </div>
+        <div class="form-check mb-3">
+            <input type="checkbox" class="form-check-input" id="permitir_multiplas_respostas" name="permitir_multiplas_respostas" {% if not formulario.permitir_multiplas_respostas %}checked{% endif %}>
+            <label class="form-check-label" for="permitir_multiplas_respostas">Permitir apenas uma resposta por usuário</label>
+        </div>
         <button type="submit" class="btn btn-success">Salvar Alterações</button>
     </form>
 

--- a/templates/formulario/formularios_participante.html
+++ b/templates/formulario/formularios_participante.html
@@ -22,21 +22,21 @@
                             <td class="ps-3 fw-medium">{{ formulario.nome }}</td>
                             <td class="text-secondary">{{ formulario.descricao or "Sem descrição" }}</td>
                             <td class="text-end pe-3">
+                                {% set user_resposta = formulario.respostas
+                                    | selectattr("usuario_id", "equalto", current_user.id)
+                                    | list
+                                    | first
+                                %}
                                 <div class="btn-group" role="group">
-                                    <!-- Botão de preencher -->
+                                    {% if formulario.permitir_multiplas_respostas or not user_resposta %}
                                     <a href="{{ url_for('formularios_routes.preencher_formulario', formulario_id=formulario.id) }}"
                                        class="btn btn-outline-primary btn-sm">
                                         <i class="bi bi-pencil-fill me-1"></i> Preencher
                                     </a>
+                                    {% else %}
+                                    <span class="text-muted">Já respondido</span>
+                                    {% endif %}
 
-                                    <!-- Verificar se o usuário já respondeu -->
-                                    {% set user_resposta = formulario.respostas
-                                        | selectattr("usuario_id", "equalto", current_user.id)
-                                        | list
-                                        | first 
-                                    %}
-
-                                    <!-- Se user_resposta existir, exibir botão de "Ver Feedback" -->
                                     {% if user_resposta %}
                                     <a href="{{ url_for('formularios_routes.visualizar_resposta', resposta_id=user_resposta.id) }}"
                                        class="btn btn-outline-info btn-sm ms-1">


### PR DESCRIPTION
## Summary
- allow forms to restrict users to a single submission by adding `permitir_multiplas_respostas`
- persist new checkbox in creation and edit routes and templates
- block additional submissions and show "Já respondido" when multiple responses are disabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.dia_semana')*

------
https://chatgpt.com/codex/tasks/task_e_689a537152708324a0493e916d834001