### PR TITLE
Add deletion route and UI for form responses

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -754,6 +754,51 @@ def usar_template(template_id):
     
     return render_template('usar_template.html', template=template)
 
+@formularios_routes.route('/respostas/<int:resposta_id>/deletar', methods=['POST'])
+@login_required
+def deletar_resposta(resposta_id):
+    """Permite ao cliente excluir uma resposta de seu formulário."""
+    # Garante que apenas clientes possam excluir respostas
+    if getattr(current_user, 'tipo', None) != 'cliente':
+        flash('Acesso negado!', 'danger')
+        return redirect(url_for('formularios_routes.listar_respostas'))
+
+    resposta = RespostaFormulario.query.get_or_404(resposta_id)
+
+    # Verifica se a resposta pertence a um formulário do cliente atual
+    if resposta.formulario.cliente_id != current_user.id:
+        flash('Você não tem permissão para excluir esta resposta.', 'danger')
+        return redirect(url_for('formularios_routes.listar_respostas'))
+
+    # Remove arquivos associados e registros de RespostaCampo
+    for resp_campo in list(resposta.respostas_campos):
+        if resp_campo.campo.tipo == 'file' and resp_campo.valor:
+            try:
+                if os.path.exists(resp_campo.valor):
+                    os.remove(resp_campo.valor)
+            except OSError:
+                logger.exception('Erro ao remover arquivo %s', resp_campo.valor)
+        db.session.delete(resp_campo)
+
+    # Remove diretório da resposta se estiver vazio
+    dir_path = os.path.join('uploads', 'respostas', str(resposta.id))
+    try:
+        if os.path.isdir(dir_path):
+            os.rmdir(dir_path)
+    except OSError:
+        pass
+
+    # Registra auditoria da exclusão, se aplicável
+    usuario = Usuario.query.get(getattr(current_user, 'id', None))
+    uid = usuario.id if usuario else None
+    db.session.add(AuditLog(user_id=uid, submission_id=resposta.id, event_type='delete_resposta'))
+
+    db.session.delete(resposta)
+    db.session.commit()
+
+    flash('Resposta excluída com sucesso!', 'success')
+    return redirect(url_for('formularios_routes.listar_respostas'))
+
 @formularios_routes.route('/respostas', methods=['GET'])
 @login_required
 def listar_respostas():

--- a/templates/trabalho/listar_respostas.html
+++ b/templates/trabalho/listar_respostas.html
@@ -108,9 +108,17 @@ body {
                                 <i class="bi bi-pencil-square"></i> Alterar Status
                             </button>
                         </div>
-                        <a href="{{ url_for('formularios_routes.dar_feedback_resposta_formulario', resposta_id=resposta.id) }}" class="btn btn-sm btn-primary">
-                            <i class="bi bi-eye"></i> Ver / Feedback
-                        </a>
+                        <div class="d-flex gap-2">
+                            <a href="{{ url_for('formularios_routes.dar_feedback_resposta_formulario', resposta_id=resposta.id) }}" class="btn btn-sm btn-primary">
+                                <i class="bi bi-eye"></i> Ver / Feedback
+                            </a>
+                            <form method="POST" action="{{ url_for('formularios_routes.deletar_resposta', resposta_id=resposta.id) }}" onsubmit="return confirm('Tem certeza que deseja excluir esta resposta?');">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-danger">
+                                    <i class="bi bi-trash"></i> Excluir
+                                </button>
+                            </form>
+                        </div>
                     </div>
                     
                     <!-- Hidden status form (revealed by button click) -->


### PR DESCRIPTION
## Summary
- Allow clients to delete their own form responses, cleaning associated files and logging the action
- Add delete button with CSRF protection in responses list

## Testing
- `pytest tests/test_agendamento_flow.py::TestAgendamento -q` *(fails: ModuleNotFoundError: No module named 'utils.dia_semana'; 'utils' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689a539a2ee08324b560cf76766ba32d