### PR TITLE
Handle audit log records when deleting responses

### DIFF
--- a/migrations/versions/d9126a645f16_add_cascade_to_audit_log_submission_fk.py
+++ b/migrations/versions/d9126a645f16_add_cascade_to_audit_log_submission_fk.py
@@ -1,0 +1,43 @@
+"""Add cascade to audit_log submission foreign key
+
+Revision ID: d9126a645f16
+Revises: 15b6b890ce1d
+Create Date: 2025-12-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d9126a645f16"
+down_revision = "15b6b890ce1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("audit_log") as batch_op:
+        batch_op.drop_constraint(
+            "fk_audit_log_submission_id_respostas_formulario",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_audit_log_submission_id_respostas_formulario",
+            "respostas_formulario",
+            ["submission_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("audit_log") as batch_op:
+        batch_op.drop_constraint(
+            "fk_audit_log_submission_id_respostas_formulario",
+            type_="foreignkey",
+        )
+        batch_op.create_foreign_key(
+            "fk_audit_log_submission_id_respostas_formulario",
+            "respostas_formulario",
+            ["submission_id"],
+            ["id"],
+        )

--- a/models.py
+++ b/models.py
@@ -1476,13 +1476,17 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("usuario.id"), nullable=True)
     submission_id = db.Column(
         db.Integer,
-        db.ForeignKey("respostas_formulario.id"),
+        db.ForeignKey("respostas_formulario.id", ondelete="CASCADE"),
         nullable=True,
     )
     event_type = db.Column(db.String(50), nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     usuario = db.relationship("Usuario")
+    submission = db.relationship(
+        "RespostaFormulario",
+        backref=db.backref("audit_logs", passive_deletes=True),
+    )
 
     def __repr__(self):
         return f"<AuditLog {self.user_id} {self.event_type} {self.submission_id}>"

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -1025,7 +1025,10 @@ def deletar_resposta(resposta_id):
     # Auditoria
     usuario = Usuario.query.get(getattr(current_user, 'id', None))
     uid = usuario.id if usuario else None
-    db.session.add(AuditLog(user_id=uid, submission_id=resposta.id, event_type='delete_resposta'))
+    AuditLog.query.filter_by(submission_id=resposta.id).delete()
+    db.session.add(
+        AuditLog(user_id=uid, submission_id=None, event_type='delete_resposta')
+    )
 
     db.session.delete(resposta)
     db.session.commit()

--- a/tests/test_audit_log_resposta_deletion.py
+++ b/tests/test_audit_log_resposta_deletion.py
@@ -1,0 +1,107 @@
+import os
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test")
+
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = "sqlite://"
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models import (
+    Cliente,
+    Usuario,
+    Formulario,
+    RespostaFormulario,
+    AuditLog,
+)
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome="Cli",
+            email="cli@example.com",
+            senha=generate_password_hash("123"),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+
+        participante = Usuario(
+            nome="User",
+            cpf="1",
+            email="user@example.com",
+            senha=generate_password_hash("123"),
+            formacao="x",
+            tipo="participante",
+            cliente_id=cliente.id,
+        )
+        db.session.add(participante)
+        db.session.commit()
+
+        formulario = Formulario(nome="F1", cliente_id=cliente.id)
+        db.session.add(formulario)
+        db.session.commit()
+
+        resposta = RespostaFormulario(
+            formulario_id=formulario.id,
+            usuario_id=participante.id,
+        )
+        db.session.add(resposta)
+        db.session.commit()
+
+        log = AuditLog(
+            user_id=participante.id,
+            submission_id=resposta.id,
+            event_type="test",
+        )
+        db.session.add(log)
+        db.session.commit()
+
+        app.resposta_id = resposta.id
+        app.cliente_email = cliente.email
+
+    yield app
+
+    with app.app_context():
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post(
+        "/login", data={"email": email, "senha": senha}, follow_redirects=True
+    )
+
+
+def test_delete_response_cascades_audit_logs(app, client):
+    login(client, app.cliente_email, "123")
+    resp = client.post(
+        f"/respostas/{app.resposta_id}/deletar", follow_redirects=True
+    )
+    assert resp.status_code in (200, 302)
+
+    with app.app_context():
+        assert RespostaFormulario.query.get(app.resposta_id) is None
+        assert AuditLog.query.filter_by(submission_id=app.resposta_id).count() == 0
+        log = AuditLog.query.filter_by(event_type="delete_resposta").first()
+        assert log is not None and log.submission_id is None


### PR DESCRIPTION
## Summary
- Cascade `AuditLog.submission_id` so logs tied to a response are removed when the response is deleted
- Clean up existing audit logs and record deletions without a submission reference
- Add migration and regression test for response deletion with audit logs

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Could not build url for endpoint etc.)*
- `pytest tests/test_audit_log_resposta_deletion.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689b513aefb483249a0a56533c4ac130