### PR TITLE
Fix agendamento Sala import and add edit page test

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -2624,8 +2624,8 @@ def editar_agendamento(agendamento_id):
         horarios_disponiveis.append(agendamento.horario)
     
     # Carrega as possíveis salas para visitação
-    from models import Sala  # Importa o modelo Sala (assumindo que existe)
-    salas = Sala.query.all()
+    from models import SalaVisitacao
+    salas = SalaVisitacao.query.all()
     
     # Pega as salas já selecionadas
     salas_selecionadas = []

--- a/tests/test_agendamento_flow.py
+++ b/tests/test_agendamento_flow.py
@@ -244,10 +244,6 @@ def test_editar_agendamento_shows_current_when_full(app):
         db.session.commit()
         agendamento_id = agendamento.id
         h1_id, h2_id = horario1.id, horario2.id
-        import models as models_module
-        models_module.Sala = types.SimpleNamespace(
-            query=types.SimpleNamespace(all=lambda: [])
-        )
 
     resp = client.get(f'/editar_agendamento/{agendamento_id}')
     assert resp.status_code == 200
@@ -280,10 +276,6 @@ def test_editar_agendamento_can_change_to_available_slot(app):
         db.session.commit()
         agendamento_id = agendamento.id
         h1_id, h2_id = horario1.id, horario2.id
-        import models as models_module
-        models_module.Sala = types.SimpleNamespace(
-            query=types.SimpleNamespace(all=lambda: [])
-        )
 
     resp = client.get(f'/editar_agendamento/{agendamento_id}')
     assert resp.status_code == 200
@@ -308,3 +300,28 @@ def test_editar_agendamento_can_change_to_available_slot(app):
     with app.app_context():
         agendamento_atualizado = AgendamentoVisita.query.get(agendamento_id)
         assert agendamento_atualizado.horario_id == h2_id
+
+
+def test_editar_agendamento_page_renders(app):
+    client = app.test_client()
+
+    login(client, 'prof@test', 'p123')
+
+    with app.app_context():
+        professor = Usuario.query.filter_by(email='prof@test').first()
+        horario = HorarioVisitacao.query.first()
+        agendamento = AgendamentoVisita(
+            professor_id=professor.id,
+            horario_id=horario.id,
+            escola_nome='Escola Y',
+            turma='T1',
+            nivel_ensino='Fundamental',
+            quantidade_alunos=5,
+        )
+        db.session.add(agendamento)
+        db.session.commit()
+        agendamento_id = agendamento.id
+
+    resp = client.get(f'/editar_agendamento/{agendamento_id}')
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- use `SalaVisitacao` when loading salas for editar agendamento
- cover `/editar_agendamento/<id>` rendering in tests

## Testing
- `pytest` *(fails: BuildError, AssertionError, TemplateNotFound, RuntimeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689b513c01748324a214742d64a549c5