### PR TITLE
Ensure template image references exist and test static assets

### DIFF
--- a/templates/pages/nosso-time.html
+++ b/templates/pages/nosso-time.html
@@ -71,7 +71,8 @@
         <!-- André Felippe -->
         <div class="col-md-5 col-sm-8">
             <div class="member-card">
-                <img src="/static/img/team/andre.jpg" alt="André Felippe">
+                <img src="{{ url_for('static', filename='default-profile.png') }}"
+                     alt="André Felippe">
                 <h5>André Felippe</h5>
                 <p>Desenvolvedor Full Stack e Fundador</p>
                 <div class="social-icons">
@@ -85,7 +86,8 @@
         <!-- Felipe Cabral -->
         <div class="col-md-5 col-sm-8">
             <div class="member-card">
-                <img src="/static/img/team/felipe.jpg" alt="Felipe Cabral">
+                <img src="{{ url_for('static', filename='default-profile.png') }}"
+                     alt="Felipe Cabral">
                 <h5>Felipe Cabral</h5>
                 <p>Desenvolvedor Full Stack & Fundador</p>
                 <div class="social-icons">

--- a/tests/test_static_files.py
+++ b/tests/test_static_files.py
@@ -1,0 +1,33 @@
+"""Tests for ensuring static file references in templates exist."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path("templates")
+STATIC_DIR = Path("static")
+
+
+def _extract_paths(content: str) -> set[str]:
+    """Return static file paths referenced in the given template content."""
+    direct = re.findall(r"(?:src|href)=['\"]?/static/([^'\"]+)", content)
+    via_url_for = re.findall(
+        r"url_for\(\s*['\"]static['\"]\s*,\s*filename=['\"]([^'\"]+)['\"]", content
+    )
+    return set(direct) | set(via_url_for)
+
+
+def test_static_files_exist() -> None:
+    """Ensure all static file references in templates resolve to existing files."""
+    missing: list[str] = []
+    for template in TEMPLATE_DIR.rglob("*.html"):
+        content = template.read_text(encoding="utf-8")
+        for rel_path in _extract_paths(content):
+            if any(marker in rel_path for marker in ("{{", "}}", "${")):
+                continue
+            if not (STATIC_DIR / rel_path).exists():
+                missing.append(f"{template}:{rel_path}")
+    assert not missing, f"Missing static files: {missing}"
+


### PR DESCRIPTION
## Summary
- Replace missing team member image references with default placeholder
- Add test verifying all static file references in templates exist

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: BuildError and other failures)*
- `pytest tests/test_static_files.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b513e54308324bd4b1d8b00b6cfca