### PR TITLE
Allow participant access to professor scheduling

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3637,9 +3637,11 @@ def detalhes_agendamento(agendamento_id):
 @agendamento_routes.route('/professor/meus_agendamentos')
 @login_required
 def meus_agendamentos():
-    # Apenas participantes (professores) podem acessar
-    if current_user.tipo != 'professor':
-        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
+    """Lista agendamentos do usuário para professores e participantes."""
+    # Apenas professores ou participantes podem acessar
+    if current_user.tipo not in ('professor', 'participante'):
+        msg = 'Acesso negado! Esta área é exclusiva para professores e participantes.'
+        flash(msg, 'danger')
         return redirect(url_for('auth_routes.login'))
     
     # Filtros
@@ -3702,9 +3704,11 @@ def meus_agendamentos_participante():
 @agendamento_routes.route('/professor/cancelar_agendamento/<int:agendamento_id>', methods=['GET', 'POST'])
 @login_required
 def cancelar_agendamento_professor(agendamento_id):
-    # Apenas participantes (professores) podem acessar
-    if current_user.tipo != 'professor':
-        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
+    """Permite que professores ou participantes cancelem um agendamento."""
+    # Apenas professores ou participantes podem acessar
+    if current_user.tipo not in ('professor', 'participante'):
+        msg = 'Acesso negado! Esta área é exclusiva para professores e participantes.'
+        flash(msg, 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
     
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -130,9 +130,11 @@ def horarios_disponiveis_professor(evento_id):
 @routes.route('/professor/criar_agendamento/<int:horario_id>', methods=['GET', 'POST'])
 @login_required
 def criar_agendamento_professor(horario_id):
-    # Apenas participantes (professores) podem acessar
-    if current_user.tipo != 'professor':
-        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
+    """Permite que professores ou participantes criem um agendamento."""
+    # Apenas professores ou participantes podem acessar
+    if current_user.tipo not in ('professor', 'participante'):
+        msg = 'Acesso negado! Esta área é exclusiva para professores e participantes.'
+        flash(msg, 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
     
     horario = HorarioVisitacao.query.get_or_404(horario_id)


### PR DESCRIPTION
## Summary
- Permit both professors and participants to create and manage visit schedules
- Extend professor scheduling routes to accept participant role
- Test participant flow for creating, listing and cancelling appointments

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: BuildError and other existing issues)*
- `pytest tests/test_agendamento_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_689ceb1063588324a6332b0de34f40e8