### PR TITLE
Add confirmation template for professor schedules

### DIFF
--- a/templates/professor/confirmacao_agendamento.html
+++ b/templates/professor/confirmacao_agendamento.html
@@ -1,20 +1,75 @@
+<!-- Template: professor/confirmacao_agendamento.html -->
 {% extends 'base.html' %}
 
-{% block title %}Agendamento Completo{% endblock %}
+{% block title %}Confirmar Agendamento{% endblock %}
 
 {% block content %}
 <div class="container mt-4">
-    <div class="alert alert-success">
-        <h4 class="alert-heading">Agendamento completo!</h4>
-        <p>Todos os alunos foram cadastrados. Baixe o comprovante para levar no dia da visita.</p>
+    <h2>Confirmar Agendamento</h2>
+
+    <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
+            Resumo do Agendamento
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <div class="col-md-6">
+                    <p><strong>Evento:</strong> {{ agendamento.horario.evento.nome }}</p>
+                    <p><strong>Data:</strong> {{ agendamento.horario.data.strftime('%d/%m/%Y') }}</p>
+                    <p><strong>Horário:</strong>
+                        {{ agendamento.horario.horario_inicio.strftime('%H:%M') }} -
+                        {{ agendamento.horario.horario_fim.strftime('%H:%M') }}
+                    </p>
+                </div>
+                <div class="col-md-6">
+                    <p><strong>Escola:</strong> {{ agendamento.escola_nome }}</p>
+                    <p><strong>Turma:</strong> {{ agendamento.turma }}</p>
+                    <p><strong>Quantidade de Alunos:</strong>
+                        {{ alunos|length }} / {{ agendamento.quantidade_alunos }}
+                    </p>
+                </div>
+            </div>
+        </div>
     </div>
-    <div class="d-flex gap-2 mt-3">
-        <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
-            <i class="fas fa-print"></i> Baixar Comprovante
-        </a>
-        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
-            <i class="fas fa-arrow-left"></i> Voltar aos Agendamentos
-        </a>
+
+    <div class="card mb-4">
+        <div class="card-header bg-secondary text-white">
+            Alunos
+        </div>
+        <div class="card-body">
+            {% if alunos %}
+                <ul class="list-group">
+                    {% for aluno in alunos %}
+                        <li class="list-group-item">
+                            {{ aluno.nome }}{% if aluno.cpf %} (CPF: {{ aluno.cpf }}){% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <div class="alert alert-warning">
+                    Nenhum aluno cadastrado neste agendamento.
+                </div>
+            {% endif %}
+        </div>
     </div>
+
+    <form method="post"
+          action="{{ url_for(
+            'agendamento_routes.atualizar_status_agendamento',
+            agendamento_id=agendamento.id
+          ) }}">
+        <input type="hidden" name="status" value="confirmado">
+        <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-success">
+                <i class="fas fa-check"></i> Confirmar
+            </button>
+            <a href="{{ url_for(
+                'routes.adicionar_alunos_agendamento',
+                agendamento_id=agendamento.id
+            ) }}" class="btn btn-secondary">
+                <i class="fas fa-arrow-left"></i> Voltar
+            </a>
+        </div>
+    </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add confirmation page for professor visit scheduling
- show visit summary and student list
- include confirm and back actions

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: BuildError: Could not build url for endpoint)*
- script to access `/professor/confirmacao_agendamento/<id>` returns 200


------
https://chatgpt.com/codex/tasks/task_e_689de5e75a708324a3931ca171320c1b