### PR TITLE
Enable clients to register students after scheduling

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1186,12 +1186,14 @@ def criar_agendamento():
                         try:
                             db.session.commit()
                             flash("Agendamento criado com sucesso!", "success")
-                            return redirect(
-                                url_for(
-                                    'routes.adicionar_alunos_agendamento',
-                                    agendamento_id=agendamento.id,
+                            if current_user.tipo in ('professor', 'cliente'):
+                                return redirect(
+                                    url_for(
+                                        'routes.adicionar_alunos_agendamento',
+                                        agendamento_id=agendamento.id,
+                                    )
                                 )
-                            )
+                            return redirect(url_for('dashboard_routes.dashboard'))
                         except Exception as e:
                             db.session.rollback()
                             form_erro = f"Erro ao salvar agendamento: {str(e)}"

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -362,6 +362,24 @@
         </div>
       </div>
 
+      <!-- Cadastro de Alunos -->
+      <div class="col-lg-6 col-xl-3">
+        <div class="card h-100 shadow-sm hover-shadow border-0">
+          <div class="card-body">
+            <div class="text-info mb-3">
+              <i class="bi bi-people fs-1"></i>
+            </div>
+            <h5 class="card-title fw-bold">Alunos</h5>
+            <p class="card-text text-muted">Cadastre alunos para os agendamentos</p>
+          </div>
+          <div class="card-footer bg-white border-0 pt-0">
+            <a href="{{ url_for('agendamento_routes.adicionar_alunos') }}" class="btn btn-info w-100 text-white">
+              <i class="bi bi-people me-2"></i> Cadastrar Alunos
+            </a>
+          </div>
+        </div>
+      </div>
+
       <!-- Etiquetas -->
       <div class="col-lg-6 col-xl-3">
         <div class="card h-100 shadow-sm hover-shadow border-0">


### PR DESCRIPTION
## Summary
- Allow clients to access and manage schedule student lists
- Redirect users after scheduling based on account type
- Add quick link for client student registration in dashboard

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError/IntegrityError, keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689de5dd0cac8324896a1650cf3bf252