### PR TITLE
Persist horario_id when scheduling visits

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1145,6 +1145,9 @@ def criar_agendamento():
                 if not horario:
                     form_erro = "Horário inválido."
                     flash(form_erro, "danger")
+                elif horario.evento_id != int(evento_id):
+                    form_erro = "Horário não pertence ao evento selecionado."
+                    flash(form_erro, "danger")
                 else:
                     quantidade = int(quantidade_alunos)
                     if quantidade > horario.vagas_disponiveis:
@@ -1172,6 +1175,7 @@ def criar_agendamento():
                                 professor_id = usuario.id
 
                         agendamento = AgendamentoVisita(
+                            horario_id=horario.id,
                             professor_id=professor_id,
                             cliente_id=cliente_id,
                             escola_nome=escola_nome,

--- a/tests/test_agendamento_flow.py
+++ b/tests/test_agendamento_flow.py
@@ -215,9 +215,10 @@ def test_fluxo_agendamento(app):
     with app.app_context():
         evento = Evento.query.first()
         horario = HorarioVisitacao.query.first()
+        horario_id = horario.id
 
     resp = client.post(
-        f'/professor/criar_agendamento/{horario.id}',
+        f'/professor/criar_agendamento/{horario_id}',
         data={
             'escola_nome': 'Escola X',
             'escola_codigo_inep': '',
@@ -246,6 +247,7 @@ def test_fluxo_agendamento(app):
         assert agendamento.professor_id is not None
         assert agendamento.cliente_id is None
         assert agendamento.status == 'pendente'
+        assert agendamento.horario_id == horario_id
 
 
 def test_cliente_cria_agendamento(app):
@@ -255,9 +257,10 @@ def test_cliente_cria_agendamento(app):
 
     with app.app_context():
         horario = HorarioVisitacao.query.first()
+        horario_id = horario.id
 
     resp = client.post(
-        f'/agendar_visita/{horario.id}',
+        f'/agendar_visita/{horario_id}',
         data={
             'escola_nome': 'Escola C',
             'turma': 'T1',
@@ -274,6 +277,7 @@ def test_cliente_cria_agendamento(app):
         assert agendamento.cliente_id is not None
         assert agendamento.professor_id is None
         assert agendamento.status == 'pendente'
+        assert agendamento.horario_id == horario_id
 
 
 def test_participante_agendamento_flow(app):
@@ -284,9 +288,10 @@ def test_participante_agendamento_flow(app):
     with app.app_context():
         participante = Usuario.query.filter_by(email='part@test').first()
         horario = HorarioVisitacao.query.first()
+        horario_id = horario.id
 
     resp = client.post(
-        f'/participante/criar_agendamento/{horario.id}',
+        f'/participante/criar_agendamento/{horario_id}',
         data={
             'escola_nome': 'Escola P',
             'escola_codigo_inep': '',
@@ -305,6 +310,7 @@ def test_participante_agendamento_flow(app):
             professor_id=participante.id
         ).first()
         assert agendamento is not None
+        assert agendamento.horario_id == horario_id
         agendamento_id = agendamento.id
 
     resp = client.get('/participante/meus_agendamentos')


### PR DESCRIPTION
## Summary
- validate that selected schedule belongs to the chosen event
- persist horario_id when creating AgendamentoVisita
- assert horario_id persistence in agendamento tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: BuildError, TemplateNotFound, etc.)*
- `pytest tests/test_agendamento_flow.py tests/test_visualizar_agendamento.py`

------
https://chatgpt.com/codex/tasks/task_e_689de5d04968832487a8c7c60534e92d