### PR TITLE
Adjust horario field names in PDF export

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -2519,7 +2519,7 @@ def exportar_agendamentos_pdf():
             agendamento.escola_nome,
             agendamento.professor.nome if agendamento.professor else "-",
             agendamento.horario.data.strftime('%d/%m/%Y'),
-            f"{agendamento.horario.hora_inicio} - {agendamento.horario.hora_fim}",
+            f"{agendamento.horario.horario_inicio} - {agendamento.horario.horario_fim}",
             agendamento.turma,
             agendamento.status.capitalize(),
         ])


### PR DESCRIPTION
## Summary
- fix agendamento PDF export to use `horario_inicio`/`horario_fim`

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: 46 failed, 83 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689df5dfdd288324ab0a42fe24f77339