### PR TITLE
Add is_professor helper to Cliente

### DIFF
--- a/models.py
+++ b/models.py
@@ -613,6 +613,10 @@ class Cliente(db.Model, UserMixin):
     def is_admin(self):
         return self.tipo == "admin"
 
+    def is_professor(self):
+        """Indica se o cliente é um professor."""
+        return False
+
 
 class LinkCadastro(db.Model):
     __tablename__ = "link_cadastro"

--- a/templates/agendamento/agendar_visita.html
+++ b/templates/agendamento/agendar_visita.html
@@ -5,7 +5,7 @@
     <h2>Agendar Visita</h2>
     <p class="text-muted">
         Você está agendando como
-        {{ 'Professor' if current_user.is_professor() else 'Cliente' }}.
+        {{ 'Professor' if current_user.tipo == 'professor' else 'Cliente' }}.
     </p>
     <p><strong>Data:</strong> {{ horario.data }}</p>
     <p><strong>Horário:</strong> {{ horario.horario_inicio }} - {{ horario.horario_fim }}</p>
@@ -13,9 +13,9 @@
 
     <form method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        {% if current_user.is_professor() %}
+        {% if current_user.tipo == 'professor' %}
         <input type="hidden" name="professor_id" value="{{ current_user.id }}">
-        {% elif current_user.is_cliente() %}
+        {% elif current_user.tipo == 'cliente' %}
         <input type="hidden" name="cliente_id" value="{{ current_user.id }}">
         {% endif %}
         <div class="mb-3">

--- a/templates/agendamento/criar_agendamento.html
+++ b/templates/agendamento/criar_agendamento.html
@@ -14,7 +14,7 @@
 
   <p class="text-muted mb-4">
     Você está agendando como
-    {{ 'Professor' if current_user.is_professor() else 'Cliente' }}.
+    {{ 'Professor' if current_user.tipo == 'professor' else 'Cliente' }}.
   </p>
 
   <div class="card shadow">
@@ -27,10 +27,10 @@
 
       <form method="POST" action="{{ url_for('agendamento_routes.criar_agendamento') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          {% if current_user.is_professor() %}
+          {% if current_user.tipo == 'professor' %}
           <input type="hidden" name="professor_id" value="{{ current_user.id }}">
           <input type="hidden" name="usuario_id" value="{{ current_user.id }}">
-          {% elif current_user.is_cliente() %}
+          {% elif current_user.tipo == 'cliente' %}
           <input type="hidden" name="cliente_id" value="{{ current_user.id }}">
           {% endif %}
         <div class="row">


### PR DESCRIPTION
## Summary
- Add `is_professor` helper returning False in `Cliente`
- Use `current_user.tipo` when referencing user roles in agendamento templates

## Testing
- `pytest` *(fails: tests/test_agendamento_confirmacao.py::test_professor_pode_confirmar_agendamento, tests/test_agendamento_confirmacao.py::test_cliente_pode_confirmar_agendamento, tests/test_agendamento_confirmacao.py::test_email_enviado_quando_confirmado, tests/test_agendamento_confirmacao.py::test_email_nao_enviado_para_outros_status)*

------
https://chatgpt.com/codex/tasks/task_e_689df5dee878832488db4321511acc79