### PR TITLE
Add client agendamento listing

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3734,6 +3734,36 @@ def meus_agendamentos_participante():
     )
 
 
+@agendamento_routes.route('/cliente/meus_agendamentos')
+@login_required
+def meus_agendamentos_cliente():
+    """Lista agendamentos do cliente logado."""
+    if current_user.tipo != 'cliente':
+        flash('Acesso negado! Esta área é exclusiva para clientes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    status = request.args.get('status')
+
+    query = AgendamentoVisita.query.filter_by(cliente_id=current_user.id)
+    if status:
+        query = query.filter(AgendamentoVisita.status == status)
+
+    agendamentos = query.join(
+        HorarioVisitacao, AgendamentoVisita.horario_id == HorarioVisitacao.id
+    ).order_by(
+        HorarioVisitacao.data,
+        HorarioVisitacao.horario_inicio
+    ).all()
+
+    return render_template(
+        'cliente/meus_agendamentos.html',
+        agendamentos=agendamentos,
+        status_filtro=status,
+        today=date.today,
+        hoje=date.today()
+    )
+
+
 @agendamento_routes.route('/professor/cancelar_agendamento/<int:agendamento_id>', methods=['GET', 'POST'])
 @login_required
 def cancelar_agendamento_professor(agendamento_id):

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -233,7 +233,7 @@ def adicionar_alunos_agendamento(agendamento_id):
         redirect_dest = url_for('agendamento_routes.meus_agendamentos')
     else:  # cliente
         pertence = agendamento.cliente_id == current_user.id
-        redirect_dest = url_for('dashboard_routes.dashboard')
+        redirect_dest = url_for('agendamento_routes.meus_agendamentos_cliente')
 
     if not pertence:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')

--- a/templates/cliente/meus_agendamentos.html
+++ b/templates/cliente/meus_agendamentos.html
@@ -1,0 +1,139 @@
+<!-- Template: cliente/meus_agendamentos.html -->
+{% extends 'base.html' %}
+
+{% block title %}Meus Agendamentos{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row mb-4">
+        <div class="col">
+            <h2 class="mb-4 border-bottom pb-2">Meus Agendamentos</h2>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-primary text-white">
+                    <i class="fas fa-filter me-2"></i>Filtrar
+                </div>
+                <div class="card-body">
+                    <form method="GET"
+                          action="{{ url_for('agendamento_routes.meus_agendamentos_cliente') }}"
+                          class="row g-2 align-items-center">
+                        <div class="col-md-4">
+                            <select name="status" class="form-select">
+                                <option value="">Todos os status</option>
+                                <option value="pendente"
+                                        {% if status_filtro == 'pendente' %}selected{% endif %}>
+                                    Pendentes
+                                </option>
+                                <option value="confirmado"
+                                        {% if status_filtro == 'confirmado' %}selected{% endif %}>
+                                    Confirmados
+                                </option>
+                                <option value="cancelado"
+                                        {% if status_filtro == 'cancelado' %}selected{% endif %}>
+                                    Cancelados
+                                </option>
+                                <option value="realizado"
+                                        {% if status_filtro == 'realizado' %}selected{% endif %}>
+                                    Realizados
+                                </option>
+                            </select>
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-search me-1"></i>Filtrar
+                            </button>
+                        </div>
+                        {% if status_filtro %}
+                        <div class="col-auto">
+                            <a href="{{ url_for('agendamento_routes.meus_agendamentos_cliente') }}"
+                               class="btn btn-outline-secondary">
+                                <i class="fas fa-times me-1"></i>Limpar
+                            </a>
+                        </div>
+                        {% endif %}
+                    </form>
+                </div>
+            </div>
+
+            {% if agendamentos %}
+            <div class="card shadow-sm">
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th>Evento</th>
+                                    <th>Data</th>
+                                    <th>Horário</th>
+                                    <th>Escola</th>
+                                    <th>Turma</th>
+                                    <th>Alunos</th>
+                                    <th>Status</th>
+                                    <th>Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for agendamento in agendamentos %}
+                                {% set horario = agendamento.horario %}
+                                {% set hoje = hoje or today %}
+                                <tr class="
+                                    {% if agendamento.status == 'cancelado' %}table-danger{% endif %}
+                                    {% if agendamento.status == 'realizado' %}table-success{% endif %}
+                                    {% if horario.data and horario.data < hoje and
+                                          agendamento.status == 'confirmado' %}table-warning{% endif %}">
+                                    <td>{{ horario.evento.nome }}</td>
+                                    <td>{{ horario.data.strftime('%d/%m/%Y') }}</td>
+                                    <td>{{ horario.horario_inicio.strftime('%H:%M') }}</td>
+                                    <td>{{ agendamento.escola_nome }}</td>
+                                    <td>{{ agendamento.turma }}</td>
+                                    <td>{{ agendamento.quantidade_alunos }}</td>
+                                    <td>
+                                        {% if agendamento.status == 'pendente' %}
+                                        <span class="badge rounded-pill bg-warning text-dark">
+                                            Pendente
+                                        </span>
+                                        {% elif agendamento.status == 'confirmado' %}
+                                        <span class="badge rounded-pill bg-primary">
+                                            Confirmado
+                                        </span>
+                                        {% elif agendamento.status == 'cancelado' %}
+                                        <span class="badge rounded-pill bg-danger">Cancelado</span>
+                                        {% elif agendamento.status == 'realizado' %}
+                                        <span class="badge rounded-pill bg-success">Realizado</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="d-flex flex-wrap justify-content-center gap-1">
+                                            <a href="{{ url_for('agendamento_routes.detalhes_agendamento',
+                                                                 agendamento_id=agendamento.id) }}"
+                                               class="btn btn-sm btn-outline-info" title="Detalhes">
+                                                <i class="fas fa-info-circle me-1"></i>Detalhes
+                                            </a>
+                                            {% if agendamento.status in ['pendente', 'confirmado'] %}
+                                            <a href="{{ url_for('routes.adicionar_alunos_agendamento',
+                                                                 agendamento_id=agendamento.id) }}"
+                                               class="btn btn-sm btn-outline-success"
+                                               title="Adicionar alunos">
+                                                <i class="fas fa-user-plus me-1"></i>Adicionar
+                                            </a>
+                                            {% endif %}
+                                        </div>
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            {% else %}
+            <div class="alert alert-warning shadow-sm">
+                <i class="fas fa-exclamation-triangle me-2"></i>
+                Não há agendamentos para exibir.
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -761,6 +761,10 @@
           <a href="{{ url_for('dashboard_routes.dashboard_agendamentos') }}" class="btn btn-secondary mt-2 w-100">
             <i class="bi bi-journal-bookmark me-2"></i> Agendamentos
           </a>
+          <a href="{{ url_for('agendamento_routes.meus_agendamentos_cliente') }}"
+             class="btn btn-outline-secondary mt-2 w-100">
+            <i class="bi bi-calendar-week me-2"></i> Meus Agendamentos
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `/cliente/meus_agendamentos` route to list client visits
- reuse new `cliente/meus_agendamentos.html` template with link to add students
- expose link from client dashboard and update student form redirects

## Testing
- `pytest` *(fails: BuildError, TemplateNotFound, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689dfbb557288324a13df29729b13cd8