### PR TITLE
Add cliente cancelation route and templates

### DIFF
--- a/templates/cliente/cancelar_agendamento.html
+++ b/templates/cliente/cancelar_agendamento.html
@@ -1,0 +1,58 @@
+<!-- Template: cliente/cancelar_agendamento.html -->
+{% extends 'base.html' %}
+
+{% block title %}Cancelar Agendamento{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Cancelar Agendamento</h2>
+    <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
+            Detalhes do Agendamento
+        </div>
+        <div class="card-body">
+            <p><strong>Evento:</strong> {{ horario.evento.nome }}</p>
+            <p><strong>Data:</strong> {{ horario.data.strftime('%d/%m/%Y') }}</p>
+            <p><strong>Horário:</strong> {{ horario.horario_inicio.strftime('%H:%M') }}
+                às {{ horario.horario_fim.strftime('%H:%M') }}</p>
+            <p><strong>Escola:</strong> {{ agendamento.escola_nome }}</p>
+            <p><strong>Turma:</strong> {{ agendamento.turma }}</p>
+            <p><strong>Quantidade de Alunos:</strong>
+                {{ agendamento.quantidade_alunos }}</p>
+        </div>
+    </div>
+
+    {% if prazo_limite %}
+    <div class="alert alert-info">
+        O prazo limite para cancelamento é
+        {{ prazo_limite.strftime('%d/%m/%Y %H:%M') }}.
+    </div>
+    {% endif %}
+
+    <div class="card mb-4">
+        <div class="card-header bg-danger text-white">
+            <i class="fas fa-exclamation-triangle"></i>
+            Confirmação de Cancelamento
+        </div>
+        <div class="card-body">
+            <p>Tem certeza que deseja cancelar este agendamento?
+               Esta ação não pode ser desfeita.</p>
+            <form method="POST"
+                  action="{{ url_for('agendamento_routes.cancelar_agendamento_cliente',
+                                    agendamento_id=agendamento.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="mt-4 d-flex gap-2">
+                    <button type="submit" class="btn btn-danger">
+                        <i class="fas fa-times"></i> Confirmar Cancelamento
+                    </button>
+                    <a href="{{ url_for('agendamento_routes.meus_agendamentos_cliente') }}"
+                       class="btn btn-secondary">
+                        <i class="fas fa-chevron-left"></i> Voltar
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/cliente/meus_agendamentos.html
+++ b/templates/cliente/meus_agendamentos.html
@@ -1,0 +1,80 @@
+<!-- Template: cliente/meus_agendamentos.html -->
+{% extends 'base.html' %}
+
+{% block title %}Meus Agendamentos{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h2 class="mb-4 border-bottom pb-2">Meus Agendamentos</h2>
+
+    {% if agendamentos %}
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead class="table-dark">
+                <tr>
+                    <th>Evento</th>
+                    <th>Data</th>
+                    <th>Horário</th>
+                    <th>Professor</th>
+                    <th>Escola</th>
+                    <th>Turma</th>
+                    <th>Alunos</th>
+                    <th>Status</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for agendamento in agendamentos %}
+                {% set horario = agendamento.horario %}
+                <tr class="
+                    {% if agendamento.status == 'cancelado' %}table-danger{% endif %}
+                    {% if agendamento.status == 'realizado' %}table-success{% endif %}
+                    {% if horario.data and horario.data < hoje and agendamento.status == 'confirmado' %}
+                        table-warning{% endif %}">
+                    <td>{{ horario.evento.nome }}</td>
+                    <td>{{ horario.data.strftime('%d/%m/%Y') }}</td>
+                    <td>{{ horario.horario_inicio.strftime('%H:%M') }}</td>
+                    <td>{{ agendamento.professor.nome if agendamento.professor else '-' }}</td>
+                    <td>{{ agendamento.escola_nome }}</td>
+                    <td>{{ agendamento.turma }}</td>
+                    <td>{{ agendamento.quantidade_alunos }}</td>
+                    <td>
+                        {% if agendamento.status == 'pendente' %}
+                            <span class="badge rounded-pill bg-warning text-dark">Pendente</span>
+                        {% elif agendamento.status == 'confirmado' %}
+                            <span class="badge rounded-pill bg-primary">Confirmado</span>
+                        {% elif agendamento.status == 'cancelado' %}
+                            <span class="badge rounded-pill bg-danger">Cancelado</span>
+                        {% elif agendamento.status == 'realizado' %}
+                            <span class="badge rounded-pill bg-success">Realizado</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        <div class="d-flex flex-wrap justify-content-center gap-1">
+                            <a href="{{ url_for('agendamento_routes.detalhes_agendamento',
+                                                 agendamento_id=agendamento.id) }}"
+                               class="btn btn-sm btn-outline-info" title="Detalhes">
+                                <i class="fas fa-info-circle me-1"></i>Detalhes
+                            </a>
+                            {% if agendamento.status in ['pendente', 'confirmado'] %}
+                            <a href="{{ url_for('agendamento_routes.cancelar_agendamento_cliente',
+                                                 agendamento_id=agendamento.id) }}"
+                               class="btn btn-sm btn-outline-danger" title="Cancelar">
+                                <i class="fas fa-times me-1"></i>Cancelar
+                            </a>
+                            {% endif %}
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <div class="alert alert-warning">
+        <i class="fas fa-exclamation-triangle me-2"></i>Não há agendamentos para exibir.
+    </div>
+    {% endif %}
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add cliente endpoints to list and cancel agendamentos
- create templates for cliente schedule listing and cancel confirmation

## Testing
- `pytest` *(fails: BuildError, Missing templates, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689dfbb68adc8324aa941a48f76239bd