### PR TITLE
Import AgendamentoVisita in PDF service

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -2504,6 +2504,7 @@ def gerar_pdf_comprovante_agendamento(agendamento, horario, evento, salas, aluno
     """
     
     # 1) Obter agendamentos do professor ou do mesmo cliente para o relatório
+    from models import AgendamentoVisita
     from sqlalchemy import or_
 
     agendamentos = AgendamentoVisita.query.filter(


### PR DESCRIPTION
## Summary
- import `AgendamentoVisita` within `gerar_pdf_comprovante_agendamento` before querying

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4' initially; after installing beautifulsoup4, multiple test failures remain)*

------
https://chatgpt.com/codex/tasks/task_e_689e3d4d356c832487d2cb4fe28d2495