### PR TITLE
Import FPDF in pdf service

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -1,6 +1,7 @@
 from flask_login import login_required
 from utils import external_url, determinar_turno
 from utils.dia_semana import dia_semana
+from fpdf import FPDF
 import logging
 import psutil
 import os


### PR DESCRIPTION
## Summary
- import FPDF for comprovante PDF generation
- confirm FPDF already listed as dependency

## Testing
- `pytest` *(fails: BuildError, AssertionError, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689e3d52d0ec83248a02e990e00b1722