### PR TITLE
Notify revisor status changes via email

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -42,6 +42,7 @@ from models import (
     Submission,
     Usuario,
 )
+from tasks import send_email_task
 from services.pdf_service import gerar_revisor_details_pdf
 
 # Extensões permitidas para upload de arquivos
@@ -286,6 +287,16 @@ def approve(cand_id: int):
         db.session.add(Assignment(submission_id=submission_id, reviewer_id=reviewer.id))
 
     db.session.commit()
+    if cand.email:
+        send_email_task.delay(
+            cand.email,
+            cand.nome or "",
+            "Processo Seletivo de Revisores",
+            "Atualização de status da candidatura",
+            "",
+            template_path="emails/revisor_status_change.html",
+            template_context={"status": cand.status, "codigo": cand.codigo},
+        )
     msg = "Candidatura aprovada"
     if request.is_json:
         resp = {"success": True}
@@ -307,6 +318,16 @@ def reject(cand_id: int):
     cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
     cand.status = "rejeitado"
     db.session.commit()
+    if cand.email:
+        send_email_task.delay(
+            cand.email,
+            cand.nome or "",
+            "Processo Seletivo de Revisores",
+            "Atualização de status da candidatura",
+            "",
+            template_path="emails/revisor_status_change.html",
+            template_context={"status": cand.status, "codigo": cand.codigo},
+        )
     if request.is_json:
         return jsonify({"success": True})
     return redirect(url_for("dashboard_routes.dashboard_cliente"))
@@ -323,6 +344,16 @@ def advance(cand_id: int):
     if cand.etapa_atual < cand.process.num_etapas:
         cand.etapa_atual += 1
     db.session.commit()
+    if cand.email:
+        send_email_task.delay(
+            cand.email,
+            cand.nome or "",
+            "Processo Seletivo de Revisores",
+            "Atualização de status da candidatura",
+            "",
+            template_path="emails/revisor_status_change.html",
+            template_context={"status": cand.status, "codigo": cand.codigo},
+        )
     if request.is_json:
         return jsonify({"success": True, "etapa_atual": cand.etapa_atual})
     return redirect(url_for("dashboard_routes.dashboard_cliente"))

--- a/templates/emails/revisor_status_change.html
+++ b/templates/emails/revisor_status_change.html
@@ -1,0 +1,13 @@
+<!-- Template: emails/revisor_status_change.html -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Status da Candidatura</title>
+</head>
+<body>
+    <p>Olá!</p>
+    <p>O status da sua candidatura agora é <strong>{{ status }}</strong>.</p>
+    <p>Guarde seu código: <strong>{{ codigo }}</strong>.</p>
+</body>
+</html>

--- a/tests/test_revisor_email_notifications.py
+++ b/tests/test_revisor_email_notifications.py
@@ -1,0 +1,161 @@
+import os
+import sys
+import types
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
+from config import Config
+
+# Stubs for optional dependencies
+mercadopago_stub = types.ModuleType('mercadopago')
+mercadopago_stub.SDK = lambda *a, **k: None
+sys.modules.setdefault('mercadopago', mercadopago_stub)
+
+pdf_stub = types.ModuleType('services.pdf_service')
+pdf_stub.gerar_pdf_respostas = lambda *a, **k: None
+pdf_stub.gerar_comprovante_pdf = lambda *a, **k: ''
+pdf_stub.gerar_certificados_pdf = lambda *a, **k: ''
+pdf_stub.gerar_certificado_personalizado = lambda *a, **k: ''
+pdf_stub.gerar_pdf_comprovante_agendamento = lambda *a, **k: ''
+pdf_stub.gerar_pdf_inscritos_pdf = lambda *a, **k: ''
+pdf_stub.gerar_lista_frequencia_pdf = lambda *a, **k: ''
+pdf_stub.gerar_pdf_feedback = lambda *a, **k: ''
+pdf_stub.gerar_etiquetas = lambda *a, **k: None
+pdf_stub.gerar_lista_frequencia = lambda *a, **k: None
+pdf_stub.gerar_certificados = lambda *a, **k: None
+pdf_stub.gerar_evento_qrcode_pdf = lambda *a, **k: None
+pdf_stub.gerar_qrcode_token = lambda *a, **k: None
+pdf_stub.gerar_programacao_evento_pdf = lambda *a, **k: None
+pdf_stub.gerar_placas_oficinas_pdf = lambda *a, **k: None
+pdf_stub.exportar_checkins_pdf_opcoes = lambda *a, **k: None
+pdf_stub.gerar_revisor_details_pdf = lambda *a, **k: None
+sys.modules.setdefault('services.pdf_service', pdf_stub)
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models import (
+    Cliente,
+    Formulario,
+    CampoFormulario,
+    RevisorProcess,
+    RevisorCandidatura,
+)
+import tasks
+import routes.revisor_routes as rr
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SECRET_KEY='test')
+    templates_path = os.path.join(os.path.dirname(__file__), '..', 'templates')
+    app.template_folder = templates_path
+
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome='Cli', email='cli@test', senha=generate_password_hash('123')
+        )
+        db.session.add(cliente)
+        db.session.commit()
+        form = Formulario(nome='Cand', cliente_id=cliente.id)
+        db.session.add(form)
+        db.session.commit()
+        campo_email = CampoFormulario(
+            formulario_id=form.id, nome='email', tipo='text'
+        )
+        campo_nome = CampoFormulario(
+            formulario_id=form.id, nome='nome', tipo='text'
+        )
+        db.session.add_all([campo_email, campo_nome])
+        db.session.commit()
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=3,
+            exibir_para_participantes=True,
+        )
+        db.session.add(proc)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post(
+        '/login', data={'email': email, 'senha': senha}, follow_redirects=False
+    )
+
+
+def create_candidate(app, email='cand@test'):
+    with app.app_context():
+        proc = RevisorProcess.query.first()
+        cand = RevisorCandidatura(
+            process_id=proc.id, nome='Cand', email=email
+        )
+        db.session.add(cand)
+        db.session.commit()
+        return cand.id, cand.codigo, cand.email
+
+
+def patch_email(monkeypatch):
+    calls = []
+
+    def fake_delay(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(tasks.send_email_task, 'delay', fake_delay)
+    monkeypatch.setattr(rr.send_email_task, 'delay', fake_delay)
+    return calls
+
+
+def test_approve_sends_email(client, app, monkeypatch):
+    cand_id, codigo, email = create_candidate(app)
+    calls = patch_email(monkeypatch)
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/revisor/approve/{cand_id}', json={})
+    assert resp.status_code == 200
+    assert calls
+    args, kwargs = calls[0]
+    assert args[0] == email
+    assert kwargs['template_path'] == 'emails/revisor_status_change.html'
+    assert kwargs['template_context']['status'] == 'aprovado'
+    assert kwargs['template_context']['codigo'] == codigo
+
+
+def test_reject_sends_email(client, app, monkeypatch):
+    cand_id, codigo, email = create_candidate(app, email='rej@test')
+    calls = patch_email(monkeypatch)
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/revisor/reject/{cand_id}', json={})
+    assert resp.status_code == 200
+    assert calls
+    args, kwargs = calls[0]
+    assert args[0] == email
+    assert kwargs['template_context']['status'] == 'rejeitado'
+    assert kwargs['template_context']['codigo'] == codigo
+
+
+def test_advance_sends_email(client, app, monkeypatch):
+    cand_id, codigo, email = create_candidate(app, email='adv@test')
+    calls = patch_email(monkeypatch)
+    login(client, 'cli@test', '123')
+    resp = client.post(f'/revisor/advance/{cand_id}', json={})
+    assert resp.status_code == 200
+    assert calls
+    args, kwargs = calls[0]
+    assert args[0] == email
+    assert kwargs['template_context']['status'] == 'pendente'
+    assert kwargs['template_context']['codigo'] == codigo


### PR DESCRIPTION
## Summary
- notify reviewer candidates about approval, rejection or advancement
- add email template for reviewer status updates
- test reviewer email notifications by stubbing `send_email_task`

## Testing
- `pip install -r requirements-dev.txt`
- `pip install celery`
- `pip install beautifulsoup4`
- `pytest` *(fails: tests/test_password_reset.py::test_password_reset_flow, tests/test_pdf_routes_admin.py::test_gerar_certificado_individual_admin_get, tests/test_peer_review_flow.py::test_submission_and_reviewer_flow, tests/test_populate_script.py::test_criar_agendamentos_com_vagas, tests/test_populate_script.py::test_criar_agendamentos_respeita_limite_maximo, tests/test_professor_routes_access.py::test_qrcode_agendamento_access[prof@test], tests/test_professor_routes_access.py::test_qrcode_agendamento_access[part@test], tests/test_professor_routes_access.py::test_qrcode_agendamento_access[cli@test], tests/test_professor_routes_access.py::test_qrcode_agendamento_access[user@test], tests/test_register_public_cliente.py::test_registrar_cliente_sucesso, tests/test_reviewer_applications.py::test_dashboard_applications_visible_for_cliente, tests/test_reviewer_applications.py::test_update_application_requires_permission, tests/test_reviewer_applications.py::test_submit_application_and_visibility, tests/test_reviewer_applications.py::test_revisor_approval_without_email, tests/test_revisor_process.py::test_application_and_approval_flow, tests/test_revisor_process.py::test_progress_pdf_download, tests/test_revisor_process.py::test_dashboard_lists_candidaturas_and_status_update, tests/test_submission_only.py::test_registration_shows_submission_only_type, tests/test_superadmin_dashboard.py::test_superadmin_login_and_dashboard and 38 more failures)*
- `pytest tests/test_revisor_email_notifications.py`

------
https://chatgpt.com/codex/tasks/task_e_689e4ae4d5688324b436a765d3ad2828