### PR TITLE
Show approved reviewer codes in client dashboard

### DIFF
--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -33,6 +33,7 @@ from .dashboard_routes import dashboard_routes
 @dashboard_routes.route('/dashboard_cliente')
 @login_required
 def dashboard_cliente():
+    """Renderiza o painel do cliente com estatísticas e candidaturas."""
     if current_user.tipo != 'cliente':
         return redirect(url_for('dashboard_routes.dashboard'))
 
@@ -237,6 +238,16 @@ def dashboard_cliente():
         .all()
     )
 
+    revisor_candidaturas_aprovadas = (
+        RevisorCandidatura.query
+        .join(RevisorProcess, RevisorCandidatura.process_id == RevisorProcess.id)
+        .filter(
+            RevisorProcess.cliente_id == current_user.id,
+            RevisorCandidatura.status == 'aprovado',
+        )
+        .all()
+    )
+
     return render_template(
         'dashboard_cliente.html',
         usuario=current_user,
@@ -262,7 +273,8 @@ def dashboard_cliente():
         finance_data=finance_data,
         valor_caixa=valor_caixa,
         reviewer_apps=reviewer_apps,
-        revisor_candidaturas=revisor_candidaturas
+        revisor_candidaturas=revisor_candidaturas,
+        revisor_candidaturas_aprovadas=revisor_candidaturas_aprovadas,
     )
     
 def obter_configuracao_do_cliente(cliente_id):

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1538,6 +1538,37 @@
           {% endfor %}
         </tbody>
       </table>
+
+    <h5 class="fw-bold mt-4">Candidaturas Aprovadas</h5>
+    <input
+      type="text"
+      id="searchAprovados"
+      class="form-control mb-3"
+      placeholder="Buscar por nome ou email"
+    >
+    <table class="table table-sm">
+      <thead>
+        <tr><th>Nome</th><th>Código</th><th>Ações</th></tr>
+      </thead>
+      <tbody id="listaAprovados">
+        {% for cand in revisor_candidaturas_aprovadas %}
+        <tr>
+          <td>{{ cand.nome or cand.email }}</td>
+          <td class="codigo">{{ cand.codigo }}</td>
+          <td>
+            <button
+              class="btn btn-sm btn-outline-secondary copiar-codigo"
+              data-codigo="{{ cand.codigo }}"
+            >
+              Copiar código
+            </button>
+          </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">Nenhum candidato aprovado.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
   <!-- /ABA 6: REVISORES -->
 <!-- Mantendo a integração com o script original sem modificações -->
@@ -1577,6 +1608,24 @@
   }
   if (typeof URL_EXPORTAR_FINANCEIRO === 'undefined') {
     window.URL_EXPORTAR_FINANCEIRO = "{{ url_for('relatorio_pdf_routes.exportar_financeiro') }}";
+  }
+
+  document.querySelectorAll('.copiar-codigo').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const codigo = btn.getAttribute('data-codigo');
+      navigator.clipboard.writeText(codigo);
+    });
+  });
+
+  const searchInput = document.getElementById('searchAprovados');
+  if (searchInput) {
+    searchInput.addEventListener('keyup', () => {
+      const term = searchInput.value.toLowerCase();
+      document.querySelectorAll('#listaAprovados tr').forEach((row) => {
+        const text = row.innerText.toLowerCase();
+        row.style.display = text.includes(term) ? '' : 'none';
+      });
+    });
   }
 </script>
 {% endblock %}{% endblock %}


### PR DESCRIPTION
## Summary
- Filter reviewer candidaturas by status 'aprovado' and expose list on dashboard
- Display approved candidaturas with copyable codes and search filter

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: assert '<b>Alice</b>' == 'Alice', TemplateNotFound, BuildError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e4adf5d1c8324b800b27d24453880