### PR TITLE
Add Celery dependency with optional fallback

### DIFF
--- a/requirements
+++ b/requirements
@@ -4,6 +4,7 @@ bidict==0.23.1
 bleach==6.2.0
 blinker==1.9.0
 cachetools==5.5.2
+celery>=5.3,<6
 certifi==2024.12.14
 chardet==5.2.0
 charset-normalizer==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ bidict==0.23.1
 bleach==6.2.0
 blinker==1.9.0
 cachetools==5.5.2
+celery>=5.3,<6
 certifi==2024.12.14
 chardet==5.2.0
 charset-normalizer==3.4.1

--- a/tasks.py
+++ b/tasks.py
@@ -1,52 +1,67 @@
 import os
 
-from celery import Celery
-from celery.signals import worker_process_init
+try:
+    from celery import Celery
+    from celery.signals import worker_process_init
+except ImportError:  # pragma: no cover - optional dependency
+    Celery = None
+    worker_process_init = None
 
 from app import create_app
 
 
-def create_celery() -> Celery:
-    """Factory for the Celery application.
+if Celery:
+    def create_celery() -> Celery:
+        """Factory for the Celery application.
 
-    The Flask application is created only when the worker process initializes,
-    avoiding a global application instance at import time.
-    """
+        The Flask application is created only when the worker process initializes,
+        avoiding a global application instance at import time.
+        """
 
-    celery = Celery(
-        __name__,
-        broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
-        backend=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
-    )
+        celery = Celery(
+            __name__,
+            broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+            backend=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+        )
 
-    app = None
+        app = None
 
-    @worker_process_init.connect
-    def init_flask_app(**_: object) -> None:
-        nonlocal app
-        app = create_app()
+        @worker_process_init.connect
+        def init_flask_app(**_: object) -> None:
+            nonlocal app
+            app = create_app()
 
-    class FlaskTask(celery.Task):
-        def __call__(self, *args, **kwargs):
-            with app.app_context():
-                return self.run(*args, **kwargs)
+        class FlaskTask(celery.Task):
+            def __call__(self, *args, **kwargs):
+                with app.app_context():
+                    return self.run(*args, **kwargs)
 
-    celery.Task = FlaskTask
-    return celery
+        celery.Task = FlaskTask
+        return celery
 
+    celery = create_celery()
 
-celery = create_celery()
+    @celery.task
+    def send_email_task(*args, **kwargs):
+        from utils import enviar_email
 
+        enviar_email(*args, **kwargs)
 
-@celery.task
-def send_email_task(*args, **kwargs):
-    from utils import enviar_email
+    @celery.task
+    def gerar_comprovante_task(*args, **kwargs):
+        from services.pdf_service import gerar_comprovante_pdf
 
-    enviar_email(*args, **kwargs)
+        return gerar_comprovante_pdf(*args, **kwargs)
+else:
+    celery = None
 
+    def send_email_task(*args, **kwargs):
+        """Synchronous email sending fallback."""
+        from utils import enviar_email
 
-@celery.task
-def gerar_comprovante_task(*args, **kwargs):
-    from services.pdf_service import gerar_comprovante_pdf
+        enviar_email(*args, **kwargs)
 
-    return gerar_comprovante_pdf(*args, **kwargs)
+    def gerar_comprovante_task(*args, **kwargs):
+        from services.pdf_service import gerar_comprovante_pdf
+
+        return gerar_comprovante_pdf(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add celery dependency to requirements files
- allow tasks to run synchronously when Celery is unavailable

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: assert b'requisitos' in b'<!DOCTYPE html>...', others)*

------
https://chatgpt.com/codex/tasks/task_e_689e50a6d2d883249bea89b6bda7e57f