### PR TITLE
Link revisor process to events

### DIFF
--- a/models.py
+++ b/models.py
@@ -135,6 +135,20 @@ usuario_clientes = db.Table(
     db.Column("cliente_id", db.Integer, db.ForeignKey("cliente.id")),
 )
 
+# Association table linking RevisorProcess and Evento
+revisor_process_evento_association = db.Table(
+    "revisor_process_evento_association",
+    db.Column(
+        "revisor_process_id",
+        db.Integer,
+        db.ForeignKey("revisor_process.id"),
+        primary_key=True,
+    ),
+    db.Column(
+        "evento_id", db.Integer, db.ForeignKey("evento.id"), primary_key=True
+    ),
+)
+
 
 class Ministrante(db.Model, UserMixin):
     __tablename__ = "ministrante"
@@ -1799,6 +1813,12 @@ class RevisorProcess(db.Model):
         "Cliente", backref=db.backref("revisor_processes", lazy=True)
     )
     formulario = db.relationship("Formulario")
+    eventos = db.relationship(
+        "Evento",
+        secondary=revisor_process_evento_association,
+        backref=db.backref("revisor_processes", lazy=True),
+        lazy=True,
+    )
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<RevisorProcess id={self.id} cliente={self.cliente_id}>"

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -143,8 +143,12 @@ def criar_formulario():
             cliente_id=current_user.id,
         )
 
-        if evento_ids:
-            eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
+        eventos_sel = (
+            Evento.query.filter(Evento.id.in_(evento_ids)).all()
+            if evento_ids
+            else []
+        )
+        if eventos_sel:
             novo_formulario.eventos = eventos_sel
 
         db.session.add(novo_formulario)
@@ -156,11 +160,15 @@ def criar_formulario():
             ).first()
             if not processo:
                 processo = RevisorProcess(
-                    cliente_id=current_user.id, formulario_id=novo_formulario.id
+                    cliente_id=current_user.id,
+                    formulario_id=novo_formulario.id,
+                    eventos=eventos_sel,
                 )
                 db.session.add(processo)
             else:
                 processo.formulario_id = novo_formulario.id
+                if eventos_sel:
+                    processo.eventos = eventos_sel
             db.session.commit()
 
         flash("Formulário criado com sucesso!", "success")

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -39,6 +39,7 @@ from models import (
     RevisorCandidaturaEtapa,
     RevisorEtapa,
     RevisorProcess,
+    revisor_process_evento_association,
     Submission,
     Usuario,
 )
@@ -215,8 +216,15 @@ def select_event():
 
     eventos_proc = (
         db.session.query(Evento, RevisorProcess)
-        .join(Cliente, Cliente.id == Evento.cliente_id)
-        .join(RevisorProcess, RevisorProcess.cliente_id == Cliente.id)
+        .join(
+            revisor_process_evento_association,
+            revisor_process_evento_association.c.evento_id == Evento.id,
+        )
+        .join(
+            RevisorProcess,
+            RevisorProcess.id
+            == revisor_process_evento_association.c.revisor_process_id,
+        )
         .filter(
             Evento.status == "ativo",
             Evento.publico.is_(True),

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -49,7 +49,10 @@
                     <label for="eventos" class="form-label fw-medium">Eventos Relacionados</label>
                     <select id="eventos" name="eventos" class="form-select" multiple>
                         {% for ev in eventos %}
-                            <option value="{{ ev.id }}">{{ ev.nome }}</option>
+                            <option value="{{ ev.id }}"
+                                {% if ev.id|string in request.form.getlist('eventos') %}selected{% endif %}>
+                                {{ ev.nome }}
+                            </option>
                         {% endfor %}
                     </select>
                     <div class="form-text">Segure Ctrl para selecionar vários eventos</div>

--- a/tests/test_formulario_vinculo_revisor.py
+++ b/tests/test_formulario_vinculo_revisor.py
@@ -9,7 +9,7 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
 
 from app import create_app
 from extensions import db
-from models import Cliente, Formulario, RevisorProcess
+from models import Cliente, Formulario, RevisorProcess, Evento
 
 
 @pytest.fixture
@@ -24,6 +24,14 @@ def app():
             nome='Cli', email='cli@test', senha=generate_password_hash('123')
         )
         db.session.add(cliente)
+        db.session.commit()
+        evento = Evento(
+            cliente_id=cliente.id,
+            nome='E1',
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add(evento)
         db.session.commit()
     yield app
 
@@ -41,9 +49,11 @@ def login(client, email, senha):
 
 def test_form_creation_links_revisor_process(client, app):
     login(client, 'cli@test', '123')
+    with app.app_context():
+        evento = Evento.query.first()
     resp = client.post(
         '/formularios/novo',
-        data={'nome': 'F1', 'vincular_processo': 'on'},
+        data={'nome': 'F1', 'vincular_processo': 'on', 'eventos': str(evento.id)},
         follow_redirects=True,
     )
     assert resp.status_code == 200
@@ -53,4 +63,5 @@ def test_form_creation_links_revisor_process(client, app):
         proc = RevisorProcess.query.filter_by(cliente_id=form.cliente_id).first()
         assert proc is not None
         assert proc.formulario_id == form.id
+        assert evento.id in [e.id for e in proc.eventos]
 

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -48,6 +48,7 @@ from models import (
     Usuario,
     Submission,
     Assignment,
+    Evento,
 )
 from app import create_app
 import routes.dashboard_cliente  # noqa: F401
@@ -81,6 +82,14 @@ def app():
         campo_nome = CampoFormulario(formulario_id=form.id, nome="nome", tipo="text")
         db.session.add_all([campo_email, campo_nome])
         db.session.commit()
+        evento = Evento(
+            cliente_id=cliente.id,
+            nome="E1",
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add(evento)
+        db.session.commit()
         now = datetime.utcnow()
         proc = RevisorProcess(
             cliente_id=cliente.id,
@@ -90,6 +99,7 @@ def app():
             availability_end=now + timedelta(days=1),
             exibir_para_participantes=True,
         )
+        proc.eventos.append(evento)
         db.session.add(proc)
         db.session.commit()
         sub = Submission(title="T", locator="loc", code_hash="x")

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -37,34 +37,31 @@ def app():
         e2 = Evento(cliente_id=c2.id, nome='E2', inscricao_gratuita=True, publico=True)
         db.session.add_all([e1, e2])
         db.session.commit()
-        db.session.add(
-            RevisorProcess(
-                cliente_id=c1.id,
-                formulario_id=f1.id,
-                num_etapas=1,
-                availability_start=date.today() - timedelta(days=1),
-                availability_end=date.today() + timedelta(days=1),
-                exibir_para_participantes=True,
-            )
+        proc1 = RevisorProcess(
+            cliente_id=c1.id,
+            formulario_id=f1.id,
+            num_etapas=1,
+            availability_start=date.today() - timedelta(days=1),
+            availability_end=date.today() + timedelta(days=1),
+            exibir_para_participantes=True,
+            eventos=[e1],
         )
-        db.session.add(
-            RevisorProcess(
-                cliente_id=c2.id,
-                formulario_id=f2.id,
-                num_etapas=1,
-                availability_start=date.today() - timedelta(days=3),
-                availability_end=date.today() - timedelta(days=1),
-                exibir_para_participantes=True,
-            )
+        proc2 = RevisorProcess(
+            cliente_id=c2.id,
+            formulario_id=f2.id,
+            num_etapas=1,
+            availability_start=date.today() - timedelta(days=3),
+            availability_end=date.today() - timedelta(days=1),
+            exibir_para_participantes=True,
+            eventos=[e2],
         )
-        db.session.add(
-            RevisorProcess(
-                cliente_id=c1.id,
-                formulario_id=f1.id,
-                num_etapas=1,
-                exibir_para_participantes=False,
-            )
+        proc3 = RevisorProcess(
+            cliente_id=c1.id,
+            formulario_id=f1.id,
+            num_etapas=1,
+            exibir_para_participantes=False,
         )
+        db.session.add_all([proc1, proc2, proc3])
         db.session.commit()
     yield app
 


### PR DESCRIPTION
## Summary
- add many-to-many relationship between RevisorProcess and Evento
- persist selected events when linking forms to reviewer processes
- query reviewer processes via new event association

## Testing
- `pytest tests/test_formulario_vinculo_revisor.py -q`
- `pytest tests/test_revisor_process_extra.py::test_eligible_events_route -q`
- `pytest tests/test_revisor_process.py::test_application_and_approval_flow -q` (fails: AttributeError: 'NoneType' object has no attribute 'Redis')

------
https://chatgpt.com/codex/tasks/task_e_689e72a4263083248f6fe03bfc254e72