### PR TITLE
Associate revisor process with events and filter selection

### DIFF
--- a/models.py
+++ b/models.py
@@ -1788,6 +1788,7 @@ class RevisorProcess(db.Model):
     formulario_id = db.Column(
         db.Integer, db.ForeignKey("formularios.id"), nullable=True
     )
+    evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
 
     # Controle de disponibilidade do processo
@@ -1799,6 +1800,9 @@ class RevisorProcess(db.Model):
         "Cliente", backref=db.backref("revisor_processes", lazy=True)
     )
     formulario = db.relationship("Formulario")
+    evento = db.relationship(
+        "Evento", backref=db.backref("revisor_processes", lazy=True)
+    )
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<RevisorProcess id={self.id} cliente={self.cliente_id}>"

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -215,8 +215,7 @@ def select_event():
 
     eventos_proc = (
         db.session.query(Evento, RevisorProcess)
-        .join(Cliente, Cliente.id == Evento.cliente_id)
-        .join(RevisorProcess, RevisorProcess.cliente_id == Cliente.id)
+        .join(RevisorProcess, RevisorProcess.evento_id == Evento.id)
         .filter(
             Evento.status == "ativo",
             Evento.publico.is_(True),
@@ -386,13 +385,19 @@ def eligible_events():
 
     eventos = (
         Evento.query
-        .join(RevisorProcess, Evento.cliente_id == RevisorProcess.cliente_id)
+        .join(RevisorProcess, RevisorProcess.evento_id == Evento.id)
         .filter(
             Evento.status == "ativo",
             Evento.publico.is_(True),
             RevisorProcess.exibir_para_participantes.is_(True),
-            or_(RevisorProcess.availability_start.is_(None), RevisorProcess.availability_start <= hoje),
-            or_(RevisorProcess.availability_end.is_(None), RevisorProcess.availability_end >= hoje),
+            or_(
+                RevisorProcess.availability_start.is_(None),
+                RevisorProcess.availability_start <= hoje,
+            ),
+            or_(
+                RevisorProcess.availability_end.is_(None),
+                RevisorProcess.availability_end >= hoje,
+            ),
         )
         .distinct()
         .all()

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -45,6 +45,7 @@ def app():
                 availability_start=date.today() - timedelta(days=1),
                 availability_end=date.today() + timedelta(days=1),
                 exibir_para_participantes=True,
+                evento_id=e1.id,
             )
         )
         db.session.add(
@@ -55,6 +56,7 @@ def app():
                 availability_start=date.today() - timedelta(days=3),
                 availability_end=date.today() - timedelta(days=1),
                 exibir_para_participantes=True,
+                evento_id=e2.id,
             )
         )
         db.session.add(
@@ -63,6 +65,7 @@ def app():
                 formulario_id=f1.id,
                 num_etapas=1,
                 exibir_para_participantes=False,
+                evento_id=e1.id,
             )
         )
         db.session.commit()

--- a/tests/test_revisor_select_event_filter.py
+++ b/tests/test_revisor_select_event_filter.py
@@ -1,0 +1,79 @@
+import os
+from datetime import date, timedelta
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+from config import Config
+from flask import Flask
+from extensions import db, login_manager, csrf
+from models import Cliente, Formulario, RevisorProcess, Evento
+from routes.revisor_routes import revisor_routes, select_event
+from flask import Blueprint
+from unittest.mock import patch
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+
+@pytest.fixture
+def app():
+    templates_path = os.path.join(os.path.dirname(__file__), '..', 'templates')
+    app = Flask(__name__, template_folder=templates_path)
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options('sqlite://')
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def _load_user(user_id):  # pragma: no cover
+        return None
+
+    db.init_app(app)
+    csrf.init_app(app)
+    app.register_blueprint(revisor_routes)
+    evento_routes = Blueprint('evento_routes', __name__)
+
+    @evento_routes.route('/')
+    def home():  # pragma: no cover
+        return 'home'
+
+    app.register_blueprint(evento_routes)
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='C', email='c@test', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+        form = Formulario(nome='F', cliente_id=cliente.id)
+        db.session.add(form)
+        db.session.commit()
+        linked = Evento(cliente_id=cliente.id, nome='Linked', inscricao_gratuita=True, publico=True)
+        unlinked = Evento(cliente_id=cliente.id, nome='Unlinked', inscricao_gratuita=True, publico=True)
+        db.session.add_all([linked, unlinked])
+        db.session.commit()
+        db.session.add(
+            RevisorProcess(
+                cliente_id=cliente.id,
+                formulario_id=form.id,
+                num_etapas=1,
+                availability_start=date.today() - timedelta(days=1),
+                availability_end=date.today() + timedelta(days=1),
+                exibir_para_participantes=True,
+                evento_id=linked.id,
+            )
+        )
+        db.session.commit()
+    yield app
+
+
+def test_only_linked_events_are_listed(app):
+    with app.test_request_context('/processo_seletivo'):
+        with patch('routes.revisor_routes.render_template') as rt:
+            rt.side_effect = lambda tpl, **ctx: ctx
+            ctx = select_event()
+    eventos = [item['evento'].nome for item in ctx['eventos']]
+    assert 'Linked' in eventos
+    assert 'Unlinked' not in eventos


### PR DESCRIPTION
## Summary
- add `evento_id` relationship on `RevisorProcess`
- show only events tied to a `RevisorProcess`
- cover selection filtering with tests

## Testing
- `pytest` *(fails: 63 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e73e780c0832483b3b7511c5d28e7