### PR TITLE
Clarify reviewer process event relation

### DIFF
--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -45,21 +45,24 @@
                     <input type="datetime-local" id="data_fim" name="data_fim" class="form-control">
                 </div>
 
-                <div class="mb-4">
+                <div class="form-check mb-4">
+                    <input class="form-check-input" type="checkbox" id="vincular_processo" name="vincular_processo">
+                    <label class="form-check-label" for="vincular_processo">
+                        Vincular ao processo seletivo de revisores
+                    </label>
+                </div>
+
+                <div class="mb-4" id="eventos_group">
                     <label for="eventos" class="form-label fw-medium">Eventos Relacionados</label>
                     <select id="eventos" name="eventos" class="form-select" multiple>
                         {% for ev in eventos %}
                             <option value="{{ ev.id }}">{{ ev.nome }}</option>
                         {% endfor %}
                     </select>
-                    <div class="form-text">Segure Ctrl para selecionar vários eventos</div>
-                </div>
-
-                <div class="form-check mb-4">
-                    <input class="form-check-input" type="checkbox" id="vincular_processo" name="vincular_processo">
-                    <label class="form-check-label" for="vincular_processo">
-                        Vincular ao processo seletivo de revisores
-                    </label>
+                    <div class="form-text">
+                        Selecione os eventos onde o processo seletivo de revisores será aplicado.
+                        Segure Ctrl para selecionar vários eventos.
+                    </div>
                 </div>
                 
                 <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
@@ -76,9 +79,27 @@
     
     <div class="mt-4 text-center text-muted">
         <small>
-            <i class="bi bi-info-circle me-1"></i> 
+            <i class="bi bi-info-circle me-1"></i>
             Após criar o formulário, você poderá adicionar campos personalizados.
         </small>
     </div>
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const vincularProcesso = document.getElementById('vincular_processo');
+        const eventosGroup = document.getElementById('eventos_group');
+
+        function toggleEventos() {
+            if (vincularProcesso.checked) {
+                eventosGroup.style.display = '';
+            } else {
+                eventosGroup.style.display = 'none';
+            }
+        }
+
+        vincularProcesso.addEventListener('change', toggleEventos);
+        toggleEventos();
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Clarify that 'Eventos Relacionados' sets where reviewer selection applies
- Show related events selector only when linking to reviewer process

## Testing
- `pytest` *(fails: module 'routes' has no attribute 'dashboard_cliente_previa' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e73ea2d94832497c1d824959b7a3d