### PR TITLE
Link test events to reviewer process

### DIFF
--- a/tests/test_assign_by_filters.py
+++ b/tests/test_assign_by_filters.py
@@ -23,6 +23,8 @@ from models import (
     Usuario,
     Assignment,
     AuditLog,
+    Formulario,
+    Evento,
 )
 
 
@@ -45,7 +47,20 @@ def app():
                 cliente_id=cliente.id, max_trabalhos_por_revisor=2
             )
         )
-        proc = RevisorProcess(cliente_id=cliente.id)
+        form = Formulario(nome='F', cliente_id=cliente.id)
+        db.session.add(form)
+        db.session.commit()
+        event = Evento(
+            cliente_id=cliente.id,
+            nome='E1',
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add(event)
+        db.session.commit()
+        form.eventos.append(event)
+        db.session.commit()
+        proc = RevisorProcess(cliente_id=cliente.id, formulario_id=form.id)
         db.session.add(proc)
         db.session.flush()
         db.session.add(

--- a/tests/test_reviewer_applications.py
+++ b/tests/test_reviewer_applications.py
@@ -66,6 +66,7 @@ from models import (
     CampoFormulario,
     RevisorProcess,
     RevisorCandidatura,
+    Evento,
 )
 from routes.auth_routes import auth_routes
 
@@ -167,6 +168,16 @@ def test_revisor_approval_without_email(client, app):
         cliente = Cliente.query.filter_by(email='cli@test').first()
         form = Formulario(nome='Form', cliente_id=cliente.id)
         db.session.add(form)
+        db.session.commit()
+        event = Evento(
+            cliente_id=cliente.id,
+            nome='E1',
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add(event)
+        db.session.commit()
+        form.eventos.append(event)
         db.session.commit()
         campo_nome = CampoFormulario(formulario_id=form.id, nome='nome', tipo='text')
         db.session.add(campo_nome)

--- a/tests/test_revisor_email_notifications.py
+++ b/tests/test_revisor_email_notifications.py
@@ -47,6 +47,7 @@ from models import (
     CampoFormulario,
     RevisorProcess,
     RevisorCandidatura,
+    Evento,
 )
 import tasks
 import routes.revisor_routes as rr
@@ -68,6 +69,16 @@ def app():
         db.session.commit()
         form = Formulario(nome='Cand', cliente_id=cliente.id)
         db.session.add(form)
+        db.session.commit()
+        event = Evento(
+            cliente_id=cliente.id,
+            nome='E1',
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add(event)
+        db.session.commit()
+        form.eventos.append(event)
         db.session.commit()
         campo_email = CampoFormulario(
             formulario_id=form.id, nome='email', tipo='text'

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -48,6 +48,7 @@ from models import (
     Usuario,
     Submission,
     Assignment,
+    Evento,
 )
 from app import create_app
 import routes.dashboard_cliente  # noqa: F401
@@ -76,6 +77,16 @@ def app():
         db.session.commit()
         form = Formulario(nome="Cand", cliente_id=cliente.id)
         db.session.add(form)
+        db.session.commit()
+        event = Evento(
+            cliente_id=cliente.id,
+            nome="E1",
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add(event)
+        db.session.commit()
+        form.eventos.append(event)
         db.session.commit()
         campo_email = CampoFormulario(formulario_id=form.id, nome="email", tipo="text")
         campo_nome = CampoFormulario(formulario_id=form.id, nome="nome", tipo="text")

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -37,6 +37,9 @@ def app():
         e2 = Evento(cliente_id=c2.id, nome='E2', inscricao_gratuita=True, publico=True)
         db.session.add_all([e1, e2])
         db.session.commit()
+        e1.formularios.append(f1)
+        e2.formularios.append(f2)
+        db.session.commit()
         db.session.add(
             RevisorProcess(
                 cliente_id=c1.id,
@@ -86,8 +89,20 @@ def test_process_creation_with_dates(app):
 
 def test_visibility_flag_filters(app):
     with app.app_context():
-        visible = RevisorProcess.query.filter_by(exibir_para_participantes=True).all()
-        hidden = RevisorProcess.query.filter_by(exibir_para_participantes=False).all()
+        visible = (
+            RevisorProcess.query
+            .join(RevisorProcess.formulario)
+            .join(Formulario.eventos)
+            .filter(RevisorProcess.exibir_para_participantes.is_(True))
+            .all()
+        )
+        hidden = (
+            RevisorProcess.query
+            .join(RevisorProcess.formulario)
+            .join(Formulario.eventos)
+            .filter(RevisorProcess.exibir_para_participantes.is_(False))
+            .all()
+        )
         assert len(visible) == 2
         assert len(hidden) == 1
 


### PR DESCRIPTION
## Summary
- Associate test events with `RevisorProcess` fixtures
- Scope visibility queries to events linked to a process

## Testing
- `pytest` *(fails: tests/test_evento_arquivar.py, tests/test_evento_submissao.py, tests/test_formulario_eventos.py, ...)*

------
https://chatgpt.com/codex/tasks/task_e_689e73ed5e8083248856d63b9996be17