### PR TITLE
Use bracketed name for event selection in form

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Para oferecer acessibilidade em Libras e suporte a pessoas cegas:
 
 - Verifique se todas as imagens possuem um texto alternativo significativo (`alt`).
 
+## Formulários
+
+Ao criar um formulário, o campo de seleção de eventos relacionados usa o atributo
+`name="eventos[]"` para permitir a seleção múltipla. No back-end, continue
+obtendo os IDs selecionados com `request.form.getlist("eventos")`.
+
 ## Programacao em PDF
 
 Use a rota `/gerar_folder_evento/<evento_id>` para baixar a programacao do evento no formato de folder. Esta rota gera um PDF em modo paisagem com duas colunas, facilitando a impressao frente e verso.

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -47,7 +47,7 @@
 
                 <div class="mb-4">
                     <label for="eventos" class="form-label fw-medium">Eventos Relacionados</label>
-                    <select id="eventos" name="eventos" class="form-select" multiple>
+                    <select id="eventos" name="eventos[]" class="form-select" multiple>
                         {% for ev in eventos %}
                             <option value="{{ ev.id }}">{{ ev.nome }}</option>
                         {% endfor %}

--- a/tests/test_formulario_eventos.py
+++ b/tests/test_formulario_eventos.py
@@ -44,8 +44,30 @@ def test_atribuir_eventos(client, app):
         ev2 = Evento.query.filter_by(nome='E2').first()
 
     login(client, 'cli@test', '123')
-    resp = client.post(f'/formularios/{form.id}/eventos', data={'eventos': [ev1.id, ev2.id]}, follow_redirects=True)
+    resp = client.post(
+        f'/formularios/{form.id}/eventos',
+        data={'eventos': [ev1.id, ev2.id]},
+        follow_redirects=True,
+    )
     assert resp.status_code == 200
     with app.app_context():
         form = Formulario.query.get(form.id)
+        assert {e.id for e in form.eventos} == {ev1.id, ev2.id}
+
+
+def test_criar_formulario_com_eventos(client, app):
+    with app.app_context():
+        ev1 = Evento.query.filter_by(nome='E1').first()
+        ev2 = Evento.query.filter_by(nome='E2').first()
+
+    login(client, 'cli@test', '123')
+    resp = client.post(
+        '/formularios/novo',
+        data={'nome': 'F2', 'eventos[]': [ev1.id, ev2.id]},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        form = Formulario.query.filter_by(nome='F2').first()
+        assert form is not None
         assert {e.id for e in form.eventos} == {ev1.id, ev2.id}


### PR DESCRIPTION
## Summary
- allow multi-select events in form with `name="eventos[]"`
- document bracketed event selection and keep backend collection via `request.form.getlist("eventos")`
- test form creation with multiple event IDs

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: bs4 missing initially; then 60 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e73f4dbac8324a22ca5d9d67cf492