### PR TITLE
Document event selection for review forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Gmail.
 
 `RECAPTCHA_PUBLIC_KEY` e `RECAPTCHA_PRIVATE_KEY` devem conter as chaves obtidas no [Google reCAPTCHA](https://www.google.com/recaptcha/admin). Sem valores válidos, o CAPTCHA não funcionará em produção.
 
+## Formulários e processo de revisão
+
+Ao criar um formulário ligado ao processo de revisão, utilize o campo
+**Evento** para selecionar o evento específico. Quando um processo lida com
+múltiplos eventos, essa seleção é obrigatória e define em qual deles o
+formulário operará. O vínculo limita o processo ao evento escolhido;
+demais eventos não poderão usar esse formulário. Se necessário atender
+outros eventos, crie formulários separados para cada um.
+
 ## Conflito com pacotes `config`
 
 Alguns ambientes podem ter instalado um pacote externo chamado `config`,


### PR DESCRIPTION
## Summary
- clarify how to select a specific event when creating a review form
- note that linking a form to an event restricts the process to that event

## Testing
- `pytest` *(fails: 59 failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e73fa84948324996a93a844145b20