### PR TITLE
Add revisor process-event association migration

### DIFF
--- a/migrations/versions/aa9e8e464c3b_create_revisor_process_evento_association.py
+++ b/migrations/versions/aa9e8e464c3b_create_revisor_process_evento_association.py
@@ -1,0 +1,27 @@
+"""create revisor_process_evento_association table
+
+Revision ID: aa9e8e464c3b
+Revises: 15b6b890ce1d
+Create Date: 2025-02-14 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "aa9e8e464c3b"
+down_revision = "15b6b890ce1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "revisor_process_evento_association",
+        sa.Column("process_id", sa.Integer, sa.ForeignKey("revisor_process.id"), primary_key=True),
+        sa.Column("evento_id", sa.Integer, sa.ForeignKey("evento.id"), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("revisor_process_evento_association")

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -37,6 +37,7 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
 from flask import Flask
 from flask import render_template
 from extensions import db, login_manager
+from flask_migrate import upgrade
 
 from datetime import datetime, timedelta
 from models import (
@@ -68,7 +69,10 @@ def app():
 
 
     with app.app_context():
-        db.create_all()
+        try:
+            upgrade(revision="heads")
+        except SystemExit:
+            db.create_all()
         cliente = Cliente(
             nome="Cli", email="cli@test", senha=generate_password_hash("123")
         )

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -7,7 +7,8 @@ Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
 Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
 
 from flask import Flask
-from extensions import db, login_manager
+from extensions import db, login_manager, migrate
+from flask_migrate import upgrade
 
 from models import Cliente, Formulario, RevisorProcess, Evento
 from routes.revisor_routes import revisor_routes
@@ -22,9 +23,13 @@ def app():
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options('sqlite://')
     login_manager.init_app(app)
     db.init_app(app)
+    migrate.init_app(app, db)
     app.register_blueprint(revisor_routes)
     with app.app_context():
-        db.create_all()
+        try:
+            upgrade(revision="heads")
+        except SystemExit:
+            db.create_all()
         c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
         c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
         db.session.add_all([c1, c2])


### PR DESCRIPTION
## Summary
- add Alembic migration for `revisor_process_evento_association`
- run database migrations in revisor process tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `GOOGLE_CLIENT_ID=1 GOOGLE_CLIENT_SECRET=1 SECRET_KEY=test pytest tests/test_revisor_process.py tests/test_revisor_process_extra.py` *(fails: AttributeError / routing errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e73fd72108324ab0ec27f3ea10f0f