### PR TITLE
Enable event linking in revisor config

### DIFF
--- a/models.py
+++ b/models.py
@@ -1778,6 +1778,14 @@ class Assignment(db.Model):
     reviewer = db.relationship("Usuario", backref=db.backref("assignments", lazy=True))
 
 
+# Associação N:N entre processos de revisor e eventos
+revisor_process_evento = db.Table(
+    "revisor_process_evento",
+    db.Column("process_id", db.Integer, db.ForeignKey("revisor_process.id"), primary_key=True),
+    db.Column("evento_id", db.Integer, db.ForeignKey("evento.id"), primary_key=True),
+)
+
+
 class RevisorProcess(db.Model):
     """Configura um processo seletivo de revisores."""
 
@@ -1799,6 +1807,11 @@ class RevisorProcess(db.Model):
         "Cliente", backref=db.backref("revisor_processes", lazy=True)
     )
     formulario = db.relationship("Formulario")
+    eventos = db.relationship(
+        "Evento",
+        secondary=revisor_process_evento,
+        backref=db.backref("revisor_processes", lazy=True),
+    )
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<RevisorProcess id={self.id} cliente={self.cliente_id}>"

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -79,6 +79,9 @@ def config_revisor():
     formularios: List[Formulario] = Formulario.query.filter_by(
         cliente_id=current_user.id  # type: ignore[attr-defined]
     ).all()
+    eventos: List[Evento] = Evento.query.filter_by(
+        cliente_id=current_user.id  # type: ignore[attr-defined]
+    ).all()
 
     if request.method == "POST":
         # --- coleta de dados do formulário -----------------------------------
@@ -89,6 +92,7 @@ def config_revisor():
         end_raw = request.form.get("availability_end")
         exibir_val = request.form.get("exibir_participantes")
         exibir_para_participantes = exibir_val in {"on", "1", "true"}
+        evento_ids = [int(e) for e in request.form.getlist("eventos_ids")]
 
         # --- parse de datas ---------------------------------------------------
         def _parse_dt(raw: str | None) -> datetime | None:
@@ -110,6 +114,14 @@ def config_revisor():
         processo.availability_start = start_dt
         processo.availability_end = end_dt
         processo.exibir_para_participantes = exibir_para_participantes
+        processo.eventos = (
+            Evento.query.filter(
+                Evento.id.in_(evento_ids),
+                Evento.cliente_id == current_user.id,  # type: ignore[attr-defined]
+            ).all()
+            if evento_ids
+            else []
+        )
         db.session.commit()
 
         # --- (re)cria etapas --------------------------------------------------
@@ -123,8 +135,14 @@ def config_revisor():
         return redirect(url_for("revisor_routes.config_revisor"))
 
     etapas: List[RevisorEtapa] = processo.etapas if processo else []  # type: ignore[index]
+    selected_event_ids = [e.id for e in processo.eventos] if processo else []
     return render_template(
-        "revisor/config.html", processo=processo, formularios=formularios, etapas=etapas
+        "revisor/config.html",
+        processo=processo,
+        formularios=formularios,
+        etapas=etapas,
+        eventos=eventos,
+        selected_event_ids=selected_event_ids,
     )
 
 

--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -27,6 +27,14 @@
       </select>
     </div>
     <div class="mb-3">
+      <label class="form-label">Eventos vinculados</label>
+      <select class="form-select" name="eventos_ids" multiple>
+        {% for ev in eventos %}
+        <option value="{{ ev.id }}" {% if ev.id in selected_event_ids %}selected{% endif %}>{{ ev.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
       <label class="form-label">Número de Etapas</label>
       <input type="number" class="form-control" name="num_etapas" value="{{ processo.num_etapas if processo else 1 }}">
     </div>

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -20,6 +20,7 @@ def app():
     app.config['WTF_CSRF_ENABLED'] = False
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options('sqlite://')
+    app.jinja_env.globals['csrf_token'] = lambda: ''
     login_manager.init_app(app)
     db.init_app(app)
     app.register_blueprint(revisor_routes)
@@ -131,4 +132,32 @@ def test_config_route_saves_availability(client, app):
         proc = RevisorProcess.query.filter_by(cliente_id=cliente.id).first()
         assert proc.availability_start.date() == start
         assert proc.availability_end.date() == end
+
+
+def test_config_route_saves_eventos(client, app):
+    with app.app_context():
+        cliente = Cliente.query.filter_by(email='c1@test').first()
+        formulario = Formulario.query.filter_by(cliente_id=cliente.id).first()
+        evento = Evento.query.filter_by(cliente_id=cliente.id).first()
+
+        from flask_login import login_user, logout_user
+
+        with client:
+            with app.test_request_context():
+                login_user(cliente)
+            resp = client.post(
+                '/config_revisor',
+                data={
+                    'formulario_id': formulario.id,
+                    'num_etapas': 1,
+                    'stage_name': ['Etapa 1'],
+                    'eventos_ids': [evento.id],
+                },
+            )
+            with app.test_request_context():
+                logout_user()
+
+        assert resp.status_code in (302, 200)
+        proc = RevisorProcess.query.filter_by(cliente_id=cliente.id).first()
+        assert [e.id for e in proc.eventos] == [evento.id]
 


### PR DESCRIPTION
## Summary
- link events to reviewer processes via new association
- expose linked events in reviewer process config and persist selection
- add integration test for saving associated events

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; BuildError for several routes)*
- `SECRET_KEY=dev GOOGLE_CLIENT_ID=x GOOGLE_CLIENT_SECRET=y pytest tests/test_revisor_process_extra.py -k test_config_route_saves_eventos`

------
https://chatgpt.com/codex/tasks/task_e_689e7402d5d88324802fd694bbf6049c