### PR TITLE
Handle event selection on form edit

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -188,6 +188,12 @@ def editar_formulario(formulario_id):
         flash("Você não tem permissão para editar este formulário.", "danger")
         return redirect(url_for("formularios_routes.listar_formularios"))
 
+    eventos_disponiveis = (
+        Evento.query.filter_by(cliente_id=current_user.id).all()
+        if current_user.tipo == "cliente"
+        else Evento.query.all()
+    )
+
     if request.method == "POST":
         formulario.nome = request.form.get("nome")
         formulario.descricao = request.form.get("descricao")
@@ -203,11 +209,20 @@ def editar_formulario(formulario_id):
             datetime.strptime(data_fim_str, "%Y-%m-%dT%H:%M") if data_fim_str else None
         )
 
+        evento_ids = request.form.getlist("eventos")
+        formulario.eventos = (
+            Evento.query.filter(Evento.id.in_(evento_ids)).all()
+            if evento_ids
+            else []
+        )
+
         db.session.commit()
         flash("Formulário atualizado com sucesso!", "success")
         return redirect(url_for("formularios_routes.listar_formularios"))
 
-    return render_template("editar_formulario.html", formulario=formulario)
+    return render_template(
+        "editar_formulario.html", formulario=formulario, eventos=eventos_disponiveis
+    )
 
 
 @formularios_routes.route("/formularios/<int:formulario_id>/deletar", methods=["POST"])

--- a/templates/formulario/editar_formulario.html
+++ b/templates/formulario/editar_formulario.html
@@ -22,6 +22,14 @@
             <label for="data_fim" class="form-label">Data de Fim</label>
             <input type="datetime-local" id="data_fim" name="data_fim" class="form-control" value="{{ formulario.data_fim.strftime('%Y-%m-%dT%H:%M') if formulario.data_fim else '' }}">
         </div>
+        <div class="mb-3">
+            <label for="eventos" class="form-label">Eventos Relacionados</label>
+            <select id="eventos" name="eventos" class="form-select" multiple>
+                {% for ev in eventos %}
+                    <option value="{{ ev.id }}" {% if ev in formulario.eventos %}selected{% endif %}>{{ ev.nome }}</option>
+                {% endfor %}
+            </select>
+        </div>
         <button type="submit" class="btn btn-success">Salvar Alterações</button>
     </form>
 

--- a/tests/test_formulario_eventos.py
+++ b/tests/test_formulario_eventos.py
@@ -49,3 +49,24 @@ def test_atribuir_eventos(client, app):
     with app.app_context():
         form = Formulario.query.get(form.id)
         assert {e.id for e in form.eventos} == {ev1.id, ev2.id}
+
+
+def test_editar_formulario_persiste_eventos(client, app):
+    with app.app_context():
+        form = Formulario.query.first()
+        ev1 = Evento.query.filter_by(nome='E1').first()
+        ev2 = Evento.query.filter_by(nome='E2').first()
+        form.eventos.append(ev1)
+        db.session.commit()
+        form_id = form.id
+
+    login(client, 'cli@test', '123')
+    resp = client.post(
+        f'/formularios/{form_id}/editar',
+        data={'nome': 'F1 edit', 'descricao': 'desc', 'eventos': [ev1.id, ev2.id]},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        form = Formulario.query.get(form_id)
+        assert {e.id for e in form.eventos} == {ev1.id, ev2.id}


### PR DESCRIPTION
## Summary
- load available events when editing forms and persist selection
- show related events as selected in edit form template
- test editing forms keeps event associations

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 60 failed, 88 passed)*
- `SECRET_KEY=testkey GOOGLE_CLIENT_ID=a GOOGLE_CLIENT_SECRET=b pytest tests/test_formulario_eventos.py::test_editar_formulario_persiste_eventos -q`


------
https://chatgpt.com/codex/tasks/task_e_689e740c36248324af20cb952eae1783