### PR TITLE
Show event select only when linking reviewer process

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -119,7 +119,7 @@ def criar_formulario():
         descricao = request.form.get("descricao")
         data_inicio_str = request.form.get("data_inicio")
         data_fim_str = request.form.get("data_fim")
-        evento_ids = request.form.getlist("eventos")
+        evento_id = request.form.get("evento_relacionado")
         vincular_processo = "vincular_processo" in request.form
 
         # Checkbox marcado => True; ausente => False
@@ -143,9 +143,13 @@ def criar_formulario():
             cliente_id=current_user.id,
         )
 
-        if evento_ids:
-            eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
-            novo_formulario.eventos = eventos_sel
+        if evento_id:
+            evento = Evento.query.get(int(evento_id))
+            if evento:
+                novo_formulario.eventos = [evento]
+            evento_id = int(evento_id)
+        else:
+            evento_id = None
 
         db.session.add(novo_formulario)
         db.session.commit()
@@ -156,11 +160,14 @@ def criar_formulario():
             ).first()
             if not processo:
                 processo = RevisorProcess(
-                    cliente_id=current_user.id, formulario_id=novo_formulario.id
+                    cliente_id=current_user.id,
+                    formulario_id=novo_formulario.id,
+                    evento_id=evento_id,
                 )
                 db.session.add(processo)
             else:
                 processo.formulario_id = novo_formulario.id
+                processo.evento_id = evento_id
             db.session.commit()
 
         flash("Formulário criado com sucesso!", "success")

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -45,23 +45,23 @@
                     <input type="datetime-local" id="data_fim" name="data_fim" class="form-control">
                 </div>
 
-                <div class="mb-4">
-                    <label for="eventos" class="form-label fw-medium">Eventos Relacionados</label>
-                    <select id="eventos" name="eventos" class="form-select" multiple>
-                        {% for ev in eventos %}
-                            <option value="{{ ev.id }}">{{ ev.nome }}</option>
-                        {% endfor %}
-                    </select>
-                    <div class="form-text">Segure Ctrl para selecionar vários eventos</div>
-                </div>
-
                 <div class="form-check mb-4">
                     <input class="form-check-input" type="checkbox" id="vincular_processo" name="vincular_processo">
                     <label class="form-check-label" for="vincular_processo">
                         Vincular ao processo seletivo de revisores
                     </label>
                 </div>
-                
+
+                <div class="mb-4 d-none" id="evento_relacionado_container">
+                    <label for="evento_relacionado" class="form-label fw-medium">Evento Relacionado</label>
+                    <select id="evento_relacionado" name="evento_relacionado" class="form-select">
+                        <option value="" selected>Selecione um evento</option>
+                        {% for ev in eventos %}
+                            <option value="{{ ev.id }}">{{ ev.nome }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
                 <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
                     <a href="{{ url_for('formularios_routes.listar_formularios') }}" class="btn btn-light me-md-2">
                         Cancelar
@@ -79,6 +79,31 @@
             <i class="bi bi-info-circle me-1"></i> 
             Após criar o formulário, você poderá adicionar campos personalizados.
         </small>
-    </div>
 </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const checkbox = document.getElementById('vincular_processo');
+    const container = document.getElementById('evento_relacionado_container');
+    const select = document.getElementById('evento_relacionado');
+
+    function toggleEvento() {
+        if (checkbox.checked) {
+            container.classList.remove('d-none');
+        } else {
+            container.classList.add('d-none');
+            if (select) {
+                select.value = '';
+            }
+        }
+    }
+
+    checkbox.addEventListener('change', toggleEvento);
+    toggleEvento();
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Only display event selector when linking form to reviewer process
- Use single `evento_relacionado` field when creating forms

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py and others)*
- `SECRET_KEY=test GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy pytest tests/test_formulario_vinculo_revisor.py`

------
https://chatgpt.com/codex/tasks/task_e_689f96e63cf8832486b5ed9332c381a5