### PR TITLE
Persist RevisorProcess events via association table

### DIFF
--- a/models.py
+++ b/models.py
@@ -1840,10 +1840,7 @@ class RevisorProcess(db.Model):
     )
     formulario = db.relationship("Formulario")
     eventos = db.relationship(
-        "Evento",
-        primaryjoin="RevisorProcess.cliente_id == foreign(Evento.cliente_id)",
-        viewonly=True,
-        lazy="selectin",
+        "Evento", secondary=revisor_process_evento_association, lazy="selectin"
     )
 
 

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -143,6 +143,7 @@ def criar_formulario():
             cliente_id=current_user.id,
         )
 
+        eventos_sel: list[Evento] = []
         if evento_ids:
             eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
             novo_formulario.eventos = eventos_sel
@@ -158,9 +159,13 @@ def criar_formulario():
                 processo = RevisorProcess(
                     cliente_id=current_user.id, formulario_id=novo_formulario.id
                 )
+                if eventos_sel:
+                    processo.eventos = eventos_sel
                 db.session.add(processo)
             else:
                 processo.formulario_id = novo_formulario.id
+                if eventos_sel:
+                    processo.eventos = eventos_sel
             db.session.commit()
 
         flash("Formulário criado com sucesso!", "success")

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -39,6 +39,7 @@ from models import (
     RevisorCandidaturaEtapa,
     RevisorEtapa,
     RevisorProcess,
+    revisor_process_evento_association,
     Submission,
     Usuario,
 )
@@ -215,8 +216,15 @@ def select_event():
 
     eventos_proc = (
         db.session.query(Evento, RevisorProcess)
-        .join(Cliente, Cliente.id == Evento.cliente_id)
-        .join(RevisorProcess, RevisorProcess.cliente_id == Cliente.id)
+        .join(
+            revisor_process_evento_association,
+            Evento.id == revisor_process_evento_association.c.evento_id,
+        )
+        .join(
+            RevisorProcess,
+            revisor_process_evento_association.c.revisor_process_id
+            == RevisorProcess.id,
+        )
         .filter(
             Evento.status == "ativo",
             Evento.publico.is_(True),


### PR DESCRIPTION
## Summary
- Store reviewer process events via explicit association table
- Link selected events to RevisorProcess when creating forms
- Query /processo_seletivo using the process-event association

## Testing
- `python -m pip install -r requirements-dev.txt`
- `python -m pip install beautifulsoup4`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py and tests/test_revisor_process_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_689f96e4897c832481a63f52fcbbaa12