### PR TITLE
Add submission form fields and validations

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -120,6 +120,8 @@ def criar_formulario():
         data_inicio_str = request.form.get("data_inicio")
         data_fim_str = request.form.get("data_fim")
         evento_ids = request.form.getlist("eventos")
+        is_submission_form = "is_submission_form" in request.form
+        evento_submissao_id = request.form.get("evento_submissao")
         vincular_processo = "vincular_processo" in request.form
 
         # Checkbox marcado => True; ausente => False
@@ -141,9 +143,19 @@ def criar_formulario():
             data_fim=data_fim,
             permitir_multiplas_respostas=permitir_multiplas,
             cliente_id=current_user.id,
+            is_submission_form=is_submission_form,
         )
 
-        if evento_ids:
+        if is_submission_form:
+            if not evento_submissao_id:
+                flash("Selecione um evento para submissão.", "danger")
+                return render_template(
+                    "criar_formulario.html", eventos=eventos_disponiveis
+                )
+            evento_sub = Evento.query.get(int(evento_submissao_id))
+            if evento_sub:
+                novo_formulario.eventos = [evento_sub]
+        elif evento_ids:
             eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
             novo_formulario.eventos = eventos_sel
 

--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -56,6 +56,23 @@
                 </div>
 
                 <div class="form-check mb-4">
+                    <input class="form-check-input" type="checkbox" id="is_submission_form" name="is_submission_form">
+                    <label class="form-check-label" for="is_submission_form">
+                        Formulário para submissão de trabalhos
+                    </label>
+                </div>
+
+                <div class="mb-4">
+                    <label for="evento_submissao" class="form-label fw-medium">Evento para submissão</label>
+                    <select id="evento_submissao" name="evento_submissao" class="form-select">
+                        <option value="">Selecione um evento</option>
+                        {% for ev in eventos %}
+                            <option value="{{ ev.id }}">{{ ev.nome }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="form-check mb-4">
                     <input class="form-check-input" type="checkbox" id="vincular_processo" name="vincular_processo">
                     <label class="form-check-label" for="vincular_processo">
                         Vincular ao processo seletivo de revisores


### PR DESCRIPTION
## Summary
- allow marking forms as submission forms and link them to events
- validate submission forms when creating and toggling submission features
- ensure work submission route respects configured submission forms

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_689f96e473c48324bc21effb6a0757da