### PR TITLE
Add submission form selection to client config

### DIFF
--- a/static/js/dashboard_cliente.js
+++ b/static/js/dashboard_cliente.js
@@ -312,6 +312,23 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     });
   }
+
+  const selectFormulario = document.getElementById('selectFormularioSubmissao');
+  if (selectFormulario) {
+    selectFormulario.addEventListener('change', function() {
+      const url = this.dataset.updateUrl;
+      if (!url) return;
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken
+        },
+        credentials: 'include',
+        body: JSON.stringify({ formulario_id: this.value || null })
+      });
+    });
+  }
 });
 
 // Funções auxiliares

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -36,6 +36,17 @@
       </div>
       <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
         <div>
+          <h6 class="mb-0 fw-semibold">Formulário de Submissão</h6>
+        </div>
+        <select id="selectFormularioSubmissao" class="form-select w-auto" data-update-url="{{ url_for('config_cliente_routes.set_formulario_submissao') }}">
+          <option value="" {% if not config_cliente.formulario_submissao_id %}selected{% endif %}>Padrão</option>
+          {% for formulario in formularios %}
+          <option value="{{ formulario.id }}" {% if config_cliente.formulario_submissao_id == formulario.id %}selected{% endif %}>{{ formulario.nome }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="config-item d-flex justify-content-between align-items-center p-3 border-bottom">
+        <div>
           <h6 class="mb-0 fw-semibold">Modelo de Revisão</h6>
         </div>
         <select id="selectReviewModel" class="form-select w-auto" data-update-url="{{ url_for('config_cliente_routes.set_review_model') }}">


### PR DESCRIPTION
## Summary
- allow clients to choose submission form
- list available submission forms on submission settings page
- persist selected submission form via new endpoint

## Testing
- `pytest tests/test_config_cliente_review.py`
- `pytest` *(fails: SyntaxError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_689fb7f2d88483249684ddca81264c4c