### PR TITLE
Extract submission config JS and add toggle handler

### DIFF
--- a/static/js/config_submissao.js
+++ b/static/js/config_submissao.js
@@ -1,0 +1,75 @@
+/* global atualizarBotao, csrfToken */
+(function () {
+  const REVISAO_CONFIGS = window.REVISAO_CONFIGS || {};
+
+  const formRevisao = document.getElementById('formRevisaoConfig');
+  const selectEventoRevisao = document.getElementById('selectEventoRevisao');
+  const inputNumeroRevisores = document.getElementById('inputNumeroRevisores');
+  const inputPrazoRevisao = document.getElementById('inputPrazoRevisao');
+  const selectModeloBlind = document.getElementById('selectModeloBlind');
+
+  function carregarConfig(id) {
+    const cfg = REVISAO_CONFIGS[id] || {};
+    inputNumeroRevisores.value = cfg.numero_revisores || 2;
+    inputPrazoRevisao.value = cfg.prazo_revisao ? cfg.prazo_revisao.split('T')[0] : '';
+    selectModeloBlind.value = cfg.modelo_blind || 'single';
+  }
+
+  if (selectEventoRevisao) {
+    carregarConfig(selectEventoRevisao.value);
+    selectEventoRevisao.addEventListener('change', () => carregarConfig(selectEventoRevisao.value));
+  }
+
+  formRevisao?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const eventoId = selectEventoRevisao.value;
+    const payload = {
+      numero_revisores: parseInt(inputNumeroRevisores.value, 10),
+      modelo_blind: selectModeloBlind.value,
+    };
+    if (inputPrazoRevisao.value) {
+      payload.prazo_revisao = inputPrazoRevisao.value;
+    }
+    const resp = await fetch(`/revisao_config/${eventoId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (resp.ok) {
+      REVISAO_CONFIGS[eventoId] = payload;
+      alert('Configuração de revisão atualizada');
+    } else {
+      alert('Erro ao salvar configuração');
+    }
+  });
+
+  document.querySelectorAll('.btn-toggle').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const url = btn.dataset.toggleUrl;
+      if (!url) return;
+      try {
+        const resp = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': csrfToken,
+          },
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.success) {
+            atualizarBotao(btn, data.value);
+          } else {
+            alert(data.message || 'Erro ao atualizar');
+          }
+        } else {
+          alert('Erro ao processar solicitação');
+        }
+      } catch (err) {
+        console.error('Erro de rede', err);
+      }
+    });
+  });
+})();

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -129,49 +129,10 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/dashboard_cliente.js') }}"></script>
 <script>
   window.URL_CONFIG_CLIENTE_ATUAL = "{{ url_for('config_cliente_routes.configuracao_cliente_atual') }}";
-  const REVISAO_CONFIGS = {{ revisao_configs|tojson }};
-  const formRevisao = document.getElementById('formRevisaoConfig');
-  const selectEventoRevisao = document.getElementById('selectEventoRevisao');
-  const inputNumeroRevisores = document.getElementById('inputNumeroRevisores');
-  const inputPrazoRevisao = document.getElementById('inputPrazoRevisao');
-  const selectModeloBlind = document.getElementById('selectModeloBlind');
-
-  function carregarConfig(id) {
-    const cfg = REVISAO_CONFIGS[id] || {};
-    inputNumeroRevisores.value = cfg.numero_revisores || 2;
-    inputPrazoRevisao.value = cfg.prazo_revisao ? cfg.prazo_revisao.split('T')[0] : '';
-    selectModeloBlind.value = cfg.modelo_blind || 'single';
-  }
-
-  if (selectEventoRevisao) {
-    carregarConfig(selectEventoRevisao.value);
-    selectEventoRevisao.addEventListener('change', () => carregarConfig(selectEventoRevisao.value));
-  }
-
-  formRevisao?.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const eventoId = selectEventoRevisao.value;
-    const payload = {
-      numero_revisores: parseInt(inputNumeroRevisores.value, 10),
-      modelo_blind: selectModeloBlind.value,
-    };
-    if (inputPrazoRevisao.value) {
-      payload.prazo_revisao = inputPrazoRevisao.value;
-    }
-    const resp = await fetch(`/revisao_config/${eventoId}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (resp.ok) {
-      REVISAO_CONFIGS[eventoId] = payload;
-      alert('Configuração de revisão atualizada');
-    } else {
-      alert('Erro ao salvar configuração');
-    }
-  });
+  window.REVISAO_CONFIGS = {{ revisao_configs|tojson }};
 </script>
+<script src="{{ url_for('static', filename='js/dashboard_cliente.js') }}"></script>
+<script src="{{ url_for('static', filename='js/config_submissao.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move inline script from config_submissao.html into new static/js/config_submissao.js
- add generic .btn-toggle handler to POST with CSRF and refresh button state
- include new script and config variables in template

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_689fc5a7040c8324bbbd9c0420f4dd4e