### PR TITLE
Refactor revisor process helpers

### DIFF
--- a/tests/test_revisor_helpers.py
+++ b/tests/test_revisor_helpers.py
@@ -1,0 +1,102 @@
+import os
+from datetime import date
+
+import pytest
+from flask import Flask, request
+
+from extensions import db
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "y")
+from config import Config
+from models import Cliente, Formulario, RevisorProcess
+from utils.revisor_helpers import (
+    parse_revisor_form,
+    recreate_stages,
+    update_revisor_process,
+)
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_ENGINE_OPTIONS=Config.build_engine_options("sqlite://"),
+    )
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+    yield app
+
+
+def _create_cliente_formulario():
+    cliente = Cliente(nome="Cli", email="cli@test", senha="x")
+    db.session.add(cliente)
+    db.session.commit()
+    form = Formulario(nome="Form", cliente_id=cliente.id)
+    db.session.add(form)
+    db.session.commit()
+    return cliente, form
+
+
+def test_parse_revisor_form(app):
+    with app.test_request_context(
+        method="POST",
+        data={
+            "formulario_id": 1,
+            "num_etapas": 2,
+            "stage_name": ["Etapa 1", "Etapa 2"],
+            "availability_start": "2024-01-10",
+            "availability_end": "2024-01-20",
+            "exibir_participantes": "on",
+        },
+    ):
+        dados = parse_revisor_form(request)
+    assert dados["formulario_id"] == 1
+    assert dados["num_etapas"] == 2
+    assert dados["stage_names"] == ["Etapa 1", "Etapa 2"]
+    assert dados["availability_start"].date() == date(2024, 1, 10)
+    assert dados["availability_end"].date() == date(2024, 1, 20)
+    assert dados["exibir_para_participantes"] is True
+
+
+def test_update_and_recreate_stages(app):
+    with app.app_context():
+        cliente, form = _create_cliente_formulario()
+        processo = RevisorProcess(cliente_id=cliente.id)
+        db.session.add(processo)
+        db.session.commit()
+
+        with app.test_request_context(
+            method="POST",
+            data={
+                "formulario_id": form.id,
+                "num_etapas": 2,
+                "stage_name": ["E1", "E2"],
+                "exibir_participantes": "on",
+            },
+        ):
+            dados = parse_revisor_form(request)
+        update_revisor_process(processo, dados)
+        recreate_stages(processo, dados["stage_names"])
+        db.session.refresh(processo)
+        assert processo.num_etapas == 2
+        assert [e.nome for e in processo.etapas] == ["E1", "E2"]
+
+        with app.test_request_context(
+            method="POST",
+            data={
+                "formulario_id": form.id,
+                "num_etapas": 1,
+                "stage_name": ["Novo"],
+            },
+        ):
+            dados2 = parse_revisor_form(request)
+        update_revisor_process(processo, dados2)
+        recreate_stages(processo, dados2["stage_names"])
+        db.session.refresh(processo)
+        assert processo.num_etapas == 1
+        assert [e.nome for e in processo.etapas] == ["Novo"]

--- a/utils/revisor_helpers.py
+++ b/utils/revisor_helpers.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from flask import Request
+
+from extensions import db
+from models import RevisorEtapa, RevisorProcess
+
+
+def parse_revisor_form(req: Request) -> Dict[str, Any]:
+    """Extracts and normalizes form data for reviewer process configuration."""
+    formulario_id = req.form.get("formulario_id", type=int)
+    num_etapas = req.form.get("num_etapas", type=int, default=1)
+    stage_names: List[str] = req.form.getlist("stage_name")
+    start_raw = req.form.get("availability_start")
+    end_raw = req.form.get("availability_end")
+    exibir_val = req.form.get("exibir_participantes")
+    exibir_para_participantes = exibir_val in {"on", "1", "true"}
+
+    def _parse_dt(raw: str | None) -> datetime | None:
+        try:
+            return datetime.strptime(raw, "%Y-%m-%d") if raw else None
+        except ValueError:
+            return None
+
+    return {
+        "formulario_id": formulario_id,
+        "num_etapas": num_etapas,
+        "stage_names": stage_names,
+        "availability_start": _parse_dt(start_raw),
+        "availability_end": _parse_dt(end_raw),
+        "exibir_para_participantes": exibir_para_participantes,
+    }
+
+
+def update_revisor_process(processo: RevisorProcess, dados: Dict[str, Any]) -> None:
+    """Updates a reviewer process with parsed data."""
+    processo.formulario_id = dados.get("formulario_id")
+    processo.num_etapas = dados.get("num_etapas")
+    processo.availability_start = dados.get("availability_start")
+    processo.availability_end = dados.get("availability_end")
+    processo.exibir_para_participantes = dados.get("exibir_para_participantes")
+    db.session.commit()
+
+
+def recreate_stages(processo: RevisorProcess, stage_names: List[str]) -> None:
+    """Recreates stages for the given reviewer process."""
+    RevisorEtapa.query.filter_by(process_id=processo.id).delete()
+    for idx, nome in enumerate(stage_names, start=1):
+        if nome:
+            db.session.add(RevisorEtapa(process_id=processo.id, numero=idx, nome=nome))
+    db.session.commit()


### PR DESCRIPTION
## Summary
- extract helper functions to parse forms, update processes and recreate stages
- use helpers in reviewer configuration route
- add unit tests for new helper functions

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py and tests/test_formulario_eventos.py)*
- `pytest tests/test_revisor_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_689fc5aaad8083248a6662fd15ef214a