### PR TITLE
Add fallback loading for Html5Qrcode in check-in templates

### DIFF
--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -19,7 +19,10 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://unpkg.com/html5-qrcode@2.3.8/dist/html5-qrcode.min.js"></script>
+<script
+    src="https://unpkg.com/html5-qrcode@2.3.8/dist/html5-qrcode.min.js"
+    defer
+    crossorigin="anonymous"></script>
 
 <script>
 document.addEventListener("DOMContentLoaded", async function () {
@@ -28,21 +31,26 @@ document.addEventListener("DOMContentLoaded", async function () {
     const scannedList = document.getElementById('scanned-list');
     let scanner;
 
-    try {
-        scanner = new Html5Qrcode('qr-video');
-        const cameras = await Html5Qrcode.getCameras();
-        const cameraId = cameras.find(cam => cam.label.toLowerCase().includes('back'))?.id || cameras[0].id;
+    if (window.Html5Qrcode) {
+        try {
+            scanner = new Html5Qrcode('qr-video');
+            const cameras = await Html5Qrcode.getCameras();
+            const cameraId = cameras.find(cam => cam.label.toLowerCase().includes('back'))?.id || cameras[0].id;
 
-        await scanner.start(
-            cameraId,
-            { fps: 10, qrbox: 250 },
-            onScanSuccess,
-            onScanError
-        );
+            await scanner.start(
+                cameraId,
+                { fps: 10, qrbox: 250 },
+                onScanSuccess,
+                onScanError
+            );
 
-        statusElement.textContent = '✅ Câmera ativa. Aponte para o QR Code!';
-    } catch (error) {
-        statusElement.innerHTML = `<span class="text-danger">Erro ao iniciar câmera: ${error.message}</span>`;
+            statusElement.textContent = '✅ Câmera ativa. Aponte para o QR Code!';
+        } catch (error) {
+            statusElement.innerHTML = `<span class="text-danger">Erro ao iniciar câmera: ${error.message}</span>`;
+        }
+    } else {
+        statusElement.innerHTML = '<span class="text-danger">Biblioteca de QR Code não carregada.</span>';
+        return;
     }
 
     async function onScanSuccess(decodedText) {
@@ -86,7 +94,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     window.addEventListener('beforeunload', () => {
-        if(scanner) scanner.stop();
+        if (scanner) scanner.stop();
     });
 });
 </script>

--- a/templates/checkin/scan_qr.html
+++ b/templates/checkin/scan_qr.html
@@ -129,7 +129,10 @@
 </style>
 
 <!-- QR Scanner -->
-<script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
+<script
+  src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"
+  defer
+  crossorigin="anonymous"></script>
 <!-- Socket.IO -->
 <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
 
@@ -263,48 +266,52 @@
      * 2) Depois chamamos o DOMContentLoaded, usando as funções definidas acima
      */
     document.addEventListener("DOMContentLoaded", async function () {
-        // Carrega check-ins anteriores antes de iniciar
-        await carregarCheckinsAnteriores();
-    
         const statusElement = document.getElementById('qr-status');
         const resultElement = document.getElementById('qr-result');
-    
-        try {
-            scanner = new Html5Qrcode('qr-video');
-    
-            const config = {
-                fps: 15,
-                qrbox: { width: 400, height: 400 },
-                aspectRatio: 1.0,
-                disableFlip: false
-            };
-    
-            const cameraId = await Html5Qrcode.getCameras()
-                .then(devices => devices.find(d => d.label.includes('back'))?.id || null);
-    
-            await scanner.start(
-                cameraId || { facingMode: 'environment' },
-                config,
-                onScanSuccess,
-                onScanError
-            );
-    
-            statusElement.innerHTML = '<i class="bi bi-camera-video-fill me-2 text-success"></i><span>Aponte para o QR Code</span>';
-            
-        } catch (error) {
-            console.error('Erro na câmera:', error);
-            statusElement.innerHTML = '<i class="bi bi-exclamation-triangle-fill me-2 text-danger"></i><span>Erro ao acessar a câmera. Verifique as permissões.</span>';
-            resultElement.innerHTML = `<div class="alert alert-danger">
-                <div class="d-flex align-items-center">
-                    <i class="bi bi-x-circle-fill me-2 fs-5"></i>
-                    <div>${error.message}</div>
-                </div>
-            </div>`;
+
+        if (window.Html5Qrcode) {
+            // Carrega check-ins anteriores antes de iniciar
+            await carregarCheckinsAnteriores();
+
+            try {
+                scanner = new Html5Qrcode('qr-video');
+
+                const config = {
+                    fps: 15,
+                    qrbox: { width: 400, height: 400 },
+                    aspectRatio: 1.0,
+                    disableFlip: false
+                };
+
+                const cameraId = await Html5Qrcode.getCameras()
+                    .then(devices => devices.find(d => d.label.includes('back'))?.id || null);
+
+                await scanner.start(
+                    cameraId || { facingMode: 'environment' },
+                    config,
+                    onScanSuccess,
+                    onScanError
+                );
+
+                statusElement.innerHTML = '<i class="bi bi-camera-video-fill me-2 text-success"></i><span>Aponte para o QR Code</span>';
+
+            } catch (error) {
+                console.error('Erro na câmera:', error);
+                statusElement.innerHTML = '<i class="bi bi-exclamation-triangle-fill me-2 text-danger"></i><span>Erro ao acessar a câmera. Verifique as permissões.</span>';
+                resultElement.innerHTML = `<div class="alert alert-danger">
+                    <div class="d-flex align-items-center">
+                        <i class="bi bi-x-circle-fill me-2 fs-5"></i>
+                        <div>${error.message}</div>
+                    </div>
+                </div>`;
+            }
+
+            window.addEventListener('beforeunload', () => {
+                if (scanner) scanner.stop();
+            });
+        } else {
+            statusElement.innerHTML = '<i class="bi bi-exclamation-triangle-fill me-2 text-danger"></i><span>Biblioteca de QR Code não carregada.</span>';
         }
-    
-        window.addEventListener('beforeunload', () => {
-            if (scanner) scanner.stop();
-        });
     });
     
     const cliente_id = "{{ current_user.id }}";  // Renderiza o ID do cliente


### PR DESCRIPTION
## Summary
- defer Html5Qrcode script loading with anonymous cross-origin
- handle missing Html5Qrcode library in QR check-in templates

## Testing
- `pip install -r requirements-dev.txt`
- `pip install bs4`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py, tests/test_revisor_process_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_689fc85033308324a625daa072a2f4c4