### PR TITLE
Add reusable QR scanner module

### DIFF
--- a/static/js/qr_scanner.js
+++ b/static/js/qr_scanner.js
@@ -1,0 +1,116 @@
+// Module to handle QR code scanning using Html5Qrcode
+// Provides initScanner(containerId, onSuccess) and stopScanner()
+
+let html5QrCode = null;
+let currentCameraId = null;
+const scanHistory = [];
+let historyListEl = null;
+let errorEl = null;
+let cameraSelectEl = null;
+
+async function startScanner(cameraId, onSuccess) {
+  if (!html5QrCode) return;
+  if (html5QrCode.isScanning) {
+    await html5QrCode.stop();
+  }
+  await html5QrCode.start(
+    { deviceId: { exact: cameraId } },
+    { fps: 10, qrbox: 250 },
+    (decodedText) => {
+      scanHistory.unshift(decodedText);
+      if (historyListEl) {
+        const li = document.createElement('li');
+        li.textContent = decodedText;
+        li.className = 'list-group-item';
+        historyListEl.prepend(li);
+      }
+      if (onSuccess) onSuccess(decodedText);
+    },
+    () => {}
+  );
+  currentCameraId = cameraId;
+}
+
+export async function initScanner(containerId, onSuccess) {
+  const container = document.getElementById(containerId);
+  if (!container) {
+    throw new Error(`Container ${containerId} não encontrado`);
+  }
+
+  html5QrCode = new Html5Qrcode(containerId);
+
+  // Error element
+  errorEl = document.getElementById(`${containerId}-error`);
+  if (!errorEl) {
+    errorEl = document.createElement('div');
+    errorEl.id = `${containerId}-error`;
+    errorEl.className = 'text-danger mt-2';
+    container.parentNode.insertBefore(errorEl, container.nextSibling);
+  } else {
+    errorEl.textContent = '';
+  }
+
+  // History list
+  historyListEl = document.getElementById(`${containerId}-history`);
+  if (!historyListEl) {
+    historyListEl = document.createElement('ul');
+    historyListEl.id = `${containerId}-history`;
+    historyListEl.className = 'list-group w-100 mt-3';
+    container.parentNode.insertBefore(historyListEl, errorEl.nextSibling);
+  } else {
+    historyListEl.innerHTML = '';
+  }
+
+  // Camera select
+  cameraSelectEl = document.getElementById(`${containerId}-camera`);
+  if (!cameraSelectEl) {
+    cameraSelectEl = document.createElement('select');
+    cameraSelectEl.id = `${containerId}-camera`;
+    cameraSelectEl.className = 'form-select mb-2';
+    container.parentNode.insertBefore(cameraSelectEl, container);
+  } else {
+    cameraSelectEl.innerHTML = '';
+  }
+
+  try {
+    const cameras = await Html5Qrcode.getCameras();
+    if (!cameras || cameras.length === 0) {
+      errorEl.textContent = 'Nenhuma câmera encontrada.';
+      return;
+    }
+    cameras.forEach((cam) => {
+      const option = document.createElement('option');
+      option.value = cam.id;
+      option.text = cam.label;
+      cameraSelectEl.appendChild(option);
+    });
+    cameraSelectEl.addEventListener('change', (e) => {
+      startScanner(e.target.value, onSuccess);
+    });
+    await startScanner(cameraSelectEl.value || cameras[0].id, onSuccess);
+  } catch (err) {
+    if (err && err.name === 'NotAllowedError') {
+      errorEl.textContent = 'Permissão de câmera negada.';
+    } else {
+      errorEl.textContent = `Erro ao acessar câmera: ${err.message || err}`;
+    }
+    throw err;
+  }
+}
+
+export async function stopScanner() {
+  if (html5QrCode) {
+    try {
+      await html5QrCode.stop();
+      html5QrCode.clear();
+    } catch (err) {
+      // ignore
+    }
+    html5QrCode = null;
+  }
+}
+
+export function getScanHistory() {
+  return [...scanHistory];
+}
+

--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -10,8 +10,6 @@
     <div id="scan-status" class="mt-3 text-muted">Inicializando...</div>
     <div id="scan-result" class="mt-3"></div>
 
-    <ul id="scanned-list" class="list-group w-100 mt-3"></ul>
-
     <a href="{{ url_for('dashboard_routes.dashboard_cliente') }}" class="btn btn-secondary mt-3">
         <i class="bi bi-arrow-left"></i> Voltar
     </a>
@@ -20,44 +18,21 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/html5-qrcode@2.3.8/dist/html5-qrcode.min.js"></script>
+<script type="module">
+import { initScanner, stopScanner } from "{{ url_for('static', filename='js/qr_scanner.js') }}";
 
-<script>
-document.addEventListener("DOMContentLoaded", async function () {
+document.addEventListener('DOMContentLoaded', async () => {
     const statusElement = document.getElementById('scan-status');
     const scanResult = document.getElementById('scan-result');
-    const scannedList = document.getElementById('scanned-list');
-    let scanner;
 
-    try {
-        scanner = new Html5Qrcode('qr-video');
-        const cameras = await Html5Qrcode.getCameras();
-        const cameraId = cameras.find(cam => cam.label.toLowerCase().includes('back'))?.id || cameras[0].id;
-
-        await scanner.start(
-            cameraId,
-            { fps: 10, qrbox: 250 },
-            onScanSuccess,
-            onScanError
-        );
-
-        statusElement.textContent = '✅ Câmera ativa. Aponte para o QR Code!';
-    } catch (error) {
-        statusElement.innerHTML = `<span class="text-danger">Erro ao iniciar câmera: ${error.message}</span>`;
-    }
-
-    async function onScanSuccess(decodedText) {
+    async function handleScan(decodedText) {
         scanResult.innerHTML = `<div class="alert alert-success">QR Lido: ${decodedText}</div>`;
-
-        const item = document.createElement('li');
-        item.classList.add('list-group-item');
-        item.textContent = decodedText;
-        scannedList.prepend(item);
 
         let token;
         try {
             const url = new URL(decodedText);
             token = url.searchParams.get('token');
-        } catch (err) {
+        } catch {
             token = decodedText;
         }
 
@@ -81,13 +56,14 @@ document.addEventListener("DOMContentLoaded", async function () {
         }
     }
 
-    function onScanError(errorMessage) {
-        // Removido para não poluir console.
+    try {
+        await initScanner('qr-video', handleScan);
+        statusElement.textContent = '✅ Câmera ativa. Aponte para o QR Code!';
+    } catch (err) {
+        statusElement.innerHTML = `<span class="text-danger">${err.message || err}</span>`;
     }
 
-    window.addEventListener('beforeunload', () => {
-        if(scanner) scanner.stop();
-    });
+    window.addEventListener('beforeunload', stopScanner);
 });
 </script>
 {% endblock %}

--- a/templates/checkin/scan_qr.html
+++ b/templates/checkin/scan_qr.html
@@ -133,12 +133,13 @@
 <!-- Socket.IO -->
 <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
 
-<script>
+<script type="module">
+import { initScanner, stopScanner } from "{{ url_for('static', filename='js/qr_scanner.js') }}";
+
     /**
      * 1) Primeiro definimos as variáveis e funções
      */
-    
-    let scanner = null;
+
     const checkinsRegistrados = new Set(); // Evita duplicar a mesma pessoa+oficina
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
     
@@ -265,32 +266,13 @@
     document.addEventListener("DOMContentLoaded", async function () {
         // Carrega check-ins anteriores antes de iniciar
         await carregarCheckinsAnteriores();
-    
+
         const statusElement = document.getElementById('qr-status');
         const resultElement = document.getElementById('qr-result');
-    
+
         try {
-            scanner = new Html5Qrcode('qr-video');
-    
-            const config = {
-                fps: 15,
-                qrbox: { width: 400, height: 400 },
-                aspectRatio: 1.0,
-                disableFlip: false
-            };
-    
-            const cameraId = await Html5Qrcode.getCameras()
-                .then(devices => devices.find(d => d.label.includes('back'))?.id || null);
-    
-            await scanner.start(
-                cameraId || { facingMode: 'environment' },
-                config,
-                onScanSuccess,
-                onScanError
-            );
-    
+            await initScanner('qr-video', onScanSuccess);
             statusElement.innerHTML = '<i class="bi bi-camera-video-fill me-2 text-success"></i><span>Aponte para o QR Code</span>';
-            
         } catch (error) {
             console.error('Erro na câmera:', error);
             statusElement.innerHTML = '<i class="bi bi-exclamation-triangle-fill me-2 text-danger"></i><span>Erro ao acessar a câmera. Verifique as permissões.</span>';
@@ -301,10 +283,8 @@
                 </div>
             </div>`;
         }
-    
-        window.addEventListener('beforeunload', () => {
-            if (scanner) scanner.stop();
-        });
+
+        window.addEventListener('beforeunload', stopScanner);
     });
     
     const cliente_id = "{{ current_user.id }}";  // Renderiza o ID do cliente


### PR DESCRIPTION
## Summary
- add modular QR code scanner with camera selection, permission error handling, and scan history
- integrate module into QR check-in templates for initialization and cleanup

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_689fc8518b9c8324ba8424e03ee4d51a