### PR TITLE
Split review config script from submission settings

### DIFF
--- a/static/js/config_revisao.js
+++ b/static/js/config_revisao.js
@@ -1,0 +1,48 @@
+/* global csrfToken */
+(function () {
+  const REVISAO_CONFIGS = window.REVISAO_CONFIGS || {};
+
+  const formRevisao = document.getElementById('formRevisaoConfig');
+  const selectEventoRevisao = document.getElementById('selectEventoRevisao');
+  const inputNumeroRevisores = document.getElementById('inputNumeroRevisores');
+  const inputPrazoRevisao = document.getElementById('inputPrazoRevisao');
+  const selectModeloBlind = document.getElementById('selectModeloBlind');
+
+  function carregarConfig(id) {
+    const cfg = REVISAO_CONFIGS[id] || {};
+    inputNumeroRevisores.value = cfg.numero_revisores || 2;
+    inputPrazoRevisao.value = cfg.prazo_revisao ? cfg.prazo_revisao.split('T')[0] : '';
+    selectModeloBlind.value = cfg.modelo_blind || 'single';
+  }
+
+  if (selectEventoRevisao) {
+    carregarConfig(selectEventoRevisao.value);
+    selectEventoRevisao.addEventListener('change', () => carregarConfig(selectEventoRevisao.value));
+  }
+
+  formRevisao?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const eventoId = selectEventoRevisao.value;
+    const payload = {
+      numero_revisores: parseInt(inputNumeroRevisores.value, 10),
+      modelo_blind: selectModeloBlind.value,
+    };
+    if (inputPrazoRevisao.value) {
+      payload.prazo_revisao = inputPrazoRevisao.value;
+    }
+    const resp = await fetch(`/revisao_config/${eventoId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (resp.ok) {
+      REVISAO_CONFIGS[eventoId] = payload;
+      alert('Configuração de revisão atualizada');
+    } else {
+      alert('Erro ao salvar configuração');
+    }
+  });
+})();

--- a/static/js/config_submissao.js
+++ b/static/js/config_submissao.js
@@ -1,52 +1,6 @@
 
 /* global atualizarBotao, csrfToken */
 (function () {
-  const REVISAO_CONFIGS = window.REVISAO_CONFIGS || {};
-
-  const formRevisao = document.getElementById('formRevisaoConfig');
-  const selectEventoRevisao = document.getElementById('selectEventoRevisao');
-  const inputNumeroRevisores = document.getElementById('inputNumeroRevisores');
-  const inputPrazoRevisao = document.getElementById('inputPrazoRevisao');
-  const selectModeloBlind = document.getElementById('selectModeloBlind');
-
-  function carregarConfig(id) {
-    const cfg = REVISAO_CONFIGS[id] || {};
-    inputNumeroRevisores.value = cfg.numero_revisores || 2;
-    inputPrazoRevisao.value = cfg.prazo_revisao ? cfg.prazo_revisao.split('T')[0] : '';
-    selectModeloBlind.value = cfg.modelo_blind || 'single';
-  }
-
-  if (selectEventoRevisao) {
-    carregarConfig(selectEventoRevisao.value);
-    selectEventoRevisao.addEventListener('change', () => carregarConfig(selectEventoRevisao.value));
-  }
-
-  formRevisao?.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const eventoId = selectEventoRevisao.value;
-    const payload = {
-      numero_revisores: parseInt(inputNumeroRevisores.value, 10),
-      modelo_blind: selectModeloBlind.value,
-    };
-    if (inputPrazoRevisao.value) {
-      payload.prazo_revisao = inputPrazoRevisao.value;
-    }
-    const resp = await fetch(`/revisao_config/${eventoId}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrfToken,
-      },
-      body: JSON.stringify(payload),
-    });
-    if (resp.ok) {
-      REVISAO_CONFIGS[eventoId] = payload;
-      alert('Configuração de revisão atualizada');
-    } else {
-      alert('Erro ao salvar configuração');
-    }
-  });
-
   document.querySelectorAll('.btn-toggle').forEach((btn) => {
     btn.addEventListener('click', async () => {
       const url = btn.dataset.toggleUrl;

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -221,48 +221,7 @@
 <script src="{{ url_for('static', filename='js/dashboard_cliente.js') }}"></script>
 <script>
   window.URL_CONFIG_CLIENTE_ATUAL = "{{ url_for('config_cliente_routes.configuracao_cliente_atual') }}";
-  const REVISAO_CONFIGS = {{ revisao_configs|tojson }};
-
-  const formRevisao = document.getElementById('formRevisaoConfig');
-  const selectEventoRevisao = document.getElementById('selectEventoRevisao');
-  const inputNumeroRevisores = document.getElementById('inputNumeroRevisores');
-  const inputPrazoRevisao = document.getElementById('inputPrazoRevisao');
-  const selectModeloBlind = document.getElementById('selectModeloBlind');
-
-  function carregarConfig(id) {
-    const cfg = REVISAO_CONFIGS[id] || {};
-    inputNumeroRevisores.value = cfg.numero_revisores || 2;
-    inputPrazoRevisao.value = cfg.prazo_revisao ? cfg.prazo_revisao.split('T')[0] : '';
-    selectModeloBlind.value = cfg.modelo_blind || 'single';
-  }
-
-  if (selectEventoRevisao) {
-    carregarConfig(selectEventoRevisao.value);
-    selectEventoRevisao.addEventListener('change', () => carregarConfig(selectEventoRevisao.value));
-  }
-
-  formRevisao?.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const eventoId = selectEventoRevisao.value;
-    const payload = {
-      numero_revisores: parseInt(inputNumeroRevisores.value, 10),
-      modelo_blind: selectModeloBlind.value,
-    };
-    if (inputPrazoRevisao.value) {
-      payload.prazo_revisao = inputPrazoRevisao.value;
-    }
-    const resp = await fetch(`/revisao_config/${eventoId}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (resp.ok) {
-      REVISAO_CONFIGS[eventoId] = payload;
-      alert('Configuração de revisão atualizada');
-    } else {
-      alert('Erro ao salvar configuração');
-    }
-  });
+  window.REVISAO_CONFIGS = {{ revisao_configs|tojson }};
 
   // ---------------- Distribuição de Trabalhos ----------------
   document.querySelectorAll('.gerar-codigos').forEach((btn) => {
@@ -346,4 +305,5 @@
 </script>
 
 <script src="{{ url_for('static', filename='js/config_submissao.js') }}"></script>
+<script src="{{ url_for('static', filename='js/config_revisao.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract review configuration logic into new `config_revisao.js`
- keep `config_submissao.js` focused on generic toggle actions
- expose review configs globally and load new script in template

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py)*

------
https://chatgpt.com/codex/tasks/task_e_689fec1a8d608324ab7306032adb40e9