### PR TITLE
Handle event_id joins in revisor select event query

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -5,6 +5,7 @@ submetam formulários, acompanhem o andamento e que administradores aprovem
 candidaturas. Também expõe endpoints para listar eventos elegíveis a partir
 da perspectiva de participantes.
 """
+
 from __future__ import annotations
 
 import os
@@ -52,12 +53,14 @@ from utils.revisor_helpers import (
 )
 
 # Extensões permitidas para upload de arquivos
-ALLOWED_EXTENSIONS = {'.pdf', '.png', '.jpg', '.jpeg', '.doc', '.docx'}
+ALLOWED_EXTENSIONS = {".pdf", ".png", ".jpg", ".jpeg", ".doc", ".docx"}
 
 # -----------------------------------------------------------------------------
 # Blueprint
 # -----------------------------------------------------------------------------
-revisor_routes = Blueprint("revisor_routes", __name__, template_folder="../templates/revisor")
+revisor_routes = Blueprint(
+    "revisor_routes", __name__, template_folder="../templates/revisor"
+)
 
 
 @revisor_routes.record_once
@@ -161,14 +164,18 @@ def submit_application(process_id: int):
 
 @revisor_routes.route("/revisor/progress/<codigo>")
 def progress(codigo: str):
-    cand: RevisorCandidatura = RevisorCandidatura.query.filter_by(codigo=codigo).first_or_404()
+    cand: RevisorCandidatura = RevisorCandidatura.query.filter_by(
+        codigo=codigo
+    ).first_or_404()
     pdf_url = url_for("revisor_routes.progress_pdf", codigo=codigo)
     return render_template("revisor/progress.html", candidatura=cand, pdf_url=pdf_url)
 
 
 @revisor_routes.route("/revisor/progress/<codigo>/pdf")
 def progress_pdf(codigo: str):
-    cand: RevisorCandidatura = RevisorCandidatura.query.filter_by(codigo=codigo).first_or_404()
+    cand: RevisorCandidatura = RevisorCandidatura.query.filter_by(
+        codigo=codigo
+    ).first_or_404()
     return gerar_revisor_details_pdf(cand)
 
 
@@ -189,14 +196,17 @@ def select_event():
 
     eventos_proc = (
         db.session.query(Evento, RevisorProcess)
-        .join(
+        .outerjoin(
             revisor_process_evento_association,
             Evento.id == revisor_process_evento_association.c.evento_id,
         )
         .join(
             RevisorProcess,
-            revisor_process_evento_association.c.revisor_process_id
-            == RevisorProcess.id,
+            or_(
+                revisor_process_evento_association.c.revisor_process_id
+                == RevisorProcess.id,
+                RevisorProcess.evento_id == Evento.id,
+            ),
         )
         .filter(
             Evento.status == "ativo",
@@ -215,7 +225,11 @@ def select_event():
     )
 
     registros = [
-        {"evento": ev, "processo": proc, "status": "Aberto" if proc.is_available() else "Encerrado"}
+        {
+            "evento": ev,
+            "processo": proc,
+            "status": "Aberto" if proc.is_available() else "Encerrado",
+        }
         for ev, proc in eventos_proc
     ]
 
@@ -233,17 +247,26 @@ def approve(cand_id: int):
 
     cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
 
-    config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=cand.process.cliente_id).first()
+    config_cli = ConfiguracaoCliente.query.filter_by(
+        cliente_id=cand.process.cliente_id
+    ).first()
     if config_cli:
         aprovados = (
-            RevisorCandidatura.query
-            .join(RevisorProcess, RevisorCandidatura.process_id == RevisorProcess.id)
-            .filter(RevisorProcess.cliente_id == cand.process.cliente_id, RevisorCandidatura.status == 'aprovado')
+            RevisorCandidatura.query.join(
+                RevisorProcess, RevisorCandidatura.process_id == RevisorProcess.id
+            )
+            .filter(
+                RevisorProcess.cliente_id == cand.process.cliente_id,
+                RevisorCandidatura.status == "aprovado",
+            )
             .count()
         )
-        if config_cli.limite_revisores is not None and aprovados >= config_cli.limite_revisores:
-            flash('Limite de revisores atingido.', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        if (
+            config_cli.limite_revisores is not None
+            and aprovados >= config_cli.limite_revisores
+        ):
+            flash("Limite de revisores atingido.", "danger")
+            return redirect(url_for("dashboard_routes.dashboard_cliente"))
     cand.status = "aprovado"
     cand.etapa_atual = cand.process.num_etapas  # type: ignore[attr-defined]
 
@@ -267,7 +290,9 @@ def approve(cand_id: int):
 
     # Se informado, cria assignment imediato
     submission_id: int | None = (
-        request.json.get("submission_id") if request.is_json else request.form.get("submission_id", type=int)
+        request.json.get("submission_id")
+        if request.is_json
+        else request.form.get("submission_id", type=int)
     )
     if submission_id and reviewer:
         db.session.add(Assignment(submission_id=submission_id, reviewer_id=reviewer.id))
@@ -366,14 +391,21 @@ def eligible_events():
     hoje = date.today()
 
     eventos = (
-        Evento.query
-        .join(RevisorProcess, Evento.cliente_id == RevisorProcess.cliente_id)
+        Evento.query.join(
+            RevisorProcess, Evento.cliente_id == RevisorProcess.cliente_id
+        )
         .filter(
             Evento.status == "ativo",
             Evento.publico.is_(True),
             RevisorProcess.exibir_para_participantes.is_(True),
-            or_(RevisorProcess.availability_start.is_(None), RevisorProcess.availability_start <= hoje),
-            or_(RevisorProcess.availability_end.is_(None), RevisorProcess.availability_end >= hoje),
+            or_(
+                RevisorProcess.availability_start.is_(None),
+                RevisorProcess.availability_start <= hoje,
+            ),
+            or_(
+                RevisorProcess.availability_end.is_(None),
+                RevisorProcess.availability_end >= hoje,
+            ),
         )
         .distinct()
         .all()

--- a/tests/test_revisor_select_event_filter.py
+++ b/tests/test_revisor_select_event_filter.py
@@ -3,9 +3,9 @@ from datetime import date, timedelta
 import pytest
 from werkzeug.security import generate_password_hash
 
-os.environ.setdefault('SECRET_KEY', 'test')
-os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
-os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
 from config import Config
 from flask import Flask
 from extensions import db, login_manager, csrf
@@ -14,18 +14,20 @@ from routes.revisor_routes import revisor_routes, select_event
 from flask import Blueprint
 from unittest.mock import patch
 
-Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
-Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+Config.SQLALCHEMY_DATABASE_URI = "sqlite://"
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
 
 
 @pytest.fixture
 def app():
-    templates_path = os.path.join(os.path.dirname(__file__), '..', 'templates')
+    templates_path = os.path.join(os.path.dirname(__file__), "..", "templates")
     app = Flask(__name__, template_folder=templates_path)
-    app.config['TESTING'] = True
-    app.config['WTF_CSRF_ENABLED'] = False
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options('sqlite://')
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = Config.build_engine_options("sqlite://")
     login_manager.init_app(app)
 
     @login_manager.user_loader
@@ -35,45 +37,87 @@ def app():
     db.init_app(app)
     csrf.init_app(app)
     app.register_blueprint(revisor_routes)
-    evento_routes = Blueprint('evento_routes', __name__)
+    evento_routes = Blueprint("evento_routes", __name__)
 
-    @evento_routes.route('/')
+    @evento_routes.route("/")
     def home():  # pragma: no cover
-        return 'home'
+        return "home"
 
     app.register_blueprint(evento_routes)
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='C', email='c@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome="C", email="c@test", senha=generate_password_hash("123"))
         db.session.add(cliente)
         db.session.commit()
-        form = Formulario(nome='F', cliente_id=cliente.id)
+        form = Formulario(nome="F", cliente_id=cliente.id)
         db.session.add(form)
         db.session.commit()
-        linked = Evento(cliente_id=cliente.id, nome='Linked', inscricao_gratuita=True, publico=True)
-        unlinked = Evento(cliente_id=cliente.id, nome='Unlinked', inscricao_gratuita=True, publico=True)
-        db.session.add_all([linked, unlinked])
-        db.session.commit()
-        db.session.add(
-            RevisorProcess(
-                cliente_id=cliente.id,
-                formulario_id=form.id,
-                num_etapas=1,
-                availability_start=date.today() - timedelta(days=1),
-                availability_end=date.today() + timedelta(days=1),
-                exibir_para_participantes=True,
-                evento_id=linked.id,
-            )
+        linked_direct = Evento(
+            cliente_id=cliente.id,
+            nome="LinkedDirect",
+            inscricao_gratuita=True,
+            publico=True,
         )
+        linked_assoc = Evento(
+            cliente_id=cliente.id,
+            nome="LinkedAssoc",
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        unlinked = Evento(
+            cliente_id=cliente.id,
+            nome="Unlinked",
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        inactive = Evento(
+            cliente_id=cliente.id,
+            nome="Inactive",
+            inscricao_gratuita=True,
+            publico=True,
+        )
+        db.session.add_all([linked_direct, linked_assoc, unlinked, inactive])
+        db.session.commit()
+        proc_direct = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            availability_start=date.today() - timedelta(days=1),
+            availability_end=date.today() + timedelta(days=1),
+            exibir_para_participantes=True,
+            evento_id=linked_direct.id,
+        )
+        proc_assoc = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            availability_start=date.today() - timedelta(days=1),
+            availability_end=date.today() + timedelta(days=1),
+            exibir_para_participantes=True,
+        )
+        proc_inactive = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            availability_start=date.today() - timedelta(days=3),
+            availability_end=date.today() - timedelta(days=1),
+            exibir_para_participantes=True,
+            evento_id=inactive.id,
+        )
+        db.session.add_all([proc_direct, proc_assoc, proc_inactive])
+        db.session.commit()
+        proc_assoc.eventos.append(linked_assoc)
         db.session.commit()
     yield app
 
 
 def test_only_linked_events_are_listed(app):
-    with app.test_request_context('/processo_seletivo'):
-        with patch('routes.revisor_routes.render_template') as rt:
+    with app.test_request_context("/processo_seletivo"):
+        with patch("routes.revisor_routes.render_template") as rt:
             rt.side_effect = lambda tpl, **ctx: ctx
             ctx = select_event()
-    eventos = [item['evento'].nome for item in ctx['eventos']]
-    assert 'Linked' in eventos
-    assert 'Unlinked' not in eventos
+    eventos = [item["evento"].nome for item in ctx["eventos"]]
+    assert "LinkedDirect" in eventos
+    assert "LinkedAssoc" in eventos
+    assert "Unlinked" not in eventos
+    assert "Inactive" not in eventos


### PR DESCRIPTION
## Summary
- include `RevisorProcess.evento_id` joins when listing reviewer processes
- test event selection via association table and direct `evento_id`

## Testing
- `pytest` *(fails: SyntaxError in tests/test_revisor_process_extra.py)*
- `pytest tests/test_revisor_select_event_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_689fec3372248324ae5f1082dc96a286