### PR TITLE
Include credentials in submission config fetch

### DIFF
--- a/static/js/config_submissao.js
+++ b/static/js/config_submissao.js
@@ -21,6 +21,7 @@
           headers: {
             'X-CSRFToken': csrfToken,
           },
+          credentials: 'include',
         });
         if (resp.ok) {
           const data = await resp.json();
@@ -30,7 +31,8 @@
             alert(data.message || 'Erro ao atualizar');
           }
         } else {
-          alert('Erro ao processar solicitação');
+          const data = await resp.json().catch(() => null);
+          alert(data?.message || 'Erro ao processar solicitação');
         }
       } catch (err) {
         console.error('Erro de rede', err);


### PR DESCRIPTION
## Summary
- send credentials with submission toggle requests
- show server error message when toggle fails

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py line 65)*

------
https://chatgpt.com/codex/tasks/task_e_689ff377c83c8324ae184c42f069b767