### PR TITLE
Handle Formulario deletion for RevisorProcess

### DIFF
--- a/migrations/versions/a16bd5bf6b16_add_ondelete_to_revisor_process_.py
+++ b/migrations/versions/a16bd5bf6b16_add_ondelete_to_revisor_process_.py
@@ -1,0 +1,47 @@
+"""Add ondelete to revisor_process formulario
+
+Revision ID: a16bd5bf6b16
+Revises: 25eb3573df18
+Create Date: 2025-08-16 03:00:16.552968
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a16bd5bf6b16'
+down_revision = '25eb3573df18'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk_revisor_process_formulario_id_formularios",
+        "revisor_process",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk_revisor_process_formulario_id_formularios"),
+        "revisor_process",
+        "formularios",
+        ["formulario_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_revisor_process_formulario_id_formularios"),
+        "revisor_process",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_revisor_process_formulario_id_formularios",
+        "revisor_process",
+        "formularios",
+        ["formulario_id"],
+        ["id"],
+    )

--- a/models.py
+++ b/models.py
@@ -1826,7 +1826,9 @@ class RevisorProcess(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)
     formulario_id = db.Column(
-        db.Integer, db.ForeignKey("formularios.id"), nullable=True
+        db.Integer,
+        db.ForeignKey("formularios.id", ondelete="SET NULL"),
+        nullable=True,
     )
     evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
@@ -1839,7 +1841,10 @@ class RevisorProcess(db.Model):
     cliente = db.relationship(
         "Cliente", backref=db.backref("revisor_processes", lazy=True)
     )
-    formulario = db.relationship("Formulario")
+    formulario = db.relationship(
+        "Formulario",
+        backref=db.backref("revisor_processes", passive_deletes=True),
+    )
     eventos = db.relationship(
         "Evento", secondary=revisor_process_evento_association, lazy="selectin"
     )


### PR DESCRIPTION
## Summary
- allow removing Formulario without breaking RevisorProcess by adding ON DELETE SET NULL
- add backref with passive deletes for Formulario.revisor_processes
- create migration for updated foreign key

## Testing
- `pip install -r requirements-dev.txt`
- `flask --app app db migrate -m "Add ondelete to revisor_process formulario"` *(fails: Target database is not up to date)*
- `flask --app app db upgrade` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*
- custom sqlite script deleting Formulario prints `formulario_id after deletion: None`


------
https://chatgpt.com/codex/tasks/task_e_689ff38011188324bbaa3cd63e3f163e