### PR TITLE
Handle optional file and author data on submission

### DIFF
--- a/models.py
+++ b/models.py
@@ -1718,11 +1718,13 @@ class Submission(db.Model):
     status = db.Column(db.String(50), nullable=True)
     area_id = db.Column(db.Integer, nullable=True)
     author_id = db.Column(db.Integer, db.ForeignKey("usuario.id"), nullable=True)
+    evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     attributes = db.Column(db.JSON, default=dict)  # metadados importados
 
     # relationships
     author = db.relationship("Usuario", backref=db.backref("submissions", lazy=True))
+    evento = db.relationship("Evento", backref=db.backref("submissions", lazy=True))
 
     # ------------------------------------------------------------------
     # utility

--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -1,8 +1,10 @@
-from flask import Blueprint, request, jsonify, abort
+from flask import Blueprint, request, jsonify, abort, current_app
+import os
 import uuid
 import secrets
 from datetime import datetime, timedelta
 from werkzeug.security import generate_password_hash
+from werkzeug.utils import secure_filename
 from models import Submission, Review, Assignment, ConfiguracaoCliente, AuditLog
 from extensions import db
 from services.mailjet_service import send_via_mailjet
@@ -15,6 +17,9 @@ def create_submission():
     title = request.form.get('title')
     content = request.form.get('content')
     email = request.form.get('email')
+    author_id = request.form.get('author_id', type=int)
+    evento_id = request.form.get('evento_id', type=int)
+    uploaded_file = request.files.get('file')
 
     if not title or not email:
         return jsonify({'error': 'title and email required'}), 400
@@ -23,9 +28,36 @@ def create_submission():
     raw_code = secrets.token_urlsafe(8)[:8]
     code_hash = generate_password_hash(raw_code)
 
-    submission = Submission(title=title, content=content,
-                            locator=locator, code_hash=code_hash)
+    file_path = None
+    if uploaded_file and uploaded_file.filename:
+        filename = secure_filename(uploaded_file.filename)
+        uploads_dir = current_app.config.get(
+            'UPLOAD_FOLDER', 'static/uploads/submissions'
+        )
+        os.makedirs(uploads_dir, exist_ok=True)
+        unique_name = f"{uuid.uuid4().hex}_{filename}"
+        file_path = os.path.join(uploads_dir, unique_name)
+        uploaded_file.save(file_path)
+
+    submission = Submission(
+        title=title,
+        content=content,
+        locator=locator,
+        code_hash=code_hash,
+        file_path=file_path,
+        author_id=author_id,
+        evento_id=evento_id,
+    )
     db.session.add(submission)
+    db.session.commit()
+
+    db.session.add(
+        AuditLog(
+            user_id=author_id,
+            submission_id=submission.id,
+            event_type="submission",
+        )
+    )
     db.session.commit()
 
     try:


### PR DESCRIPTION
## Summary
- allow create_submission to accept author, event, and file upload
- store file path, author_id, evento_id in Submission
- log submission creation in AuditLog

## Testing
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ff7b0ca2c8324a33a692cbe89ca5a