### PR TITLE
Handle email send failures with logging and client feedback

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -10,6 +10,7 @@ from werkzeug.security import generate_password_hash
 from extensions import db
 from services.mailjet_service import send_via_mailjet
 from services.pdf_service import gerar_pdf_relatorio_agendamentos
+from mailjet_rest.client import ApiError
 import logging
 
 from utils.arquivo_utils import arquivo_permitido
@@ -183,8 +184,8 @@ class NotificacaoAgendamento:
         """Função interna para enviar email de forma assíncrona."""
         try:
             send_via_mailjet(to_email=dest, subject=subject, html=html)
-        except Exception:
-            pass
+        except ApiError as exc:
+            logger.exception("Erro ao enviar email de agendamento: %s", exc)
     
     @staticmethod
     def processar_lembretes_diarios():

--- a/routes/certificado_routes.py
+++ b/routes/certificado_routes.py
@@ -7,12 +7,15 @@ from services.pdf_service import gerar_certificado_personalizado  # ajuste confo
 
 import os
 from datetime import datetime
+import logging
 
 certificado_routes = Blueprint(
     'certificado_routes',
     __name__,
     template_folder="../templates/certificado"
 )
+
+logger = logging.getLogger(__name__)
 
 
 @certificado_routes.route('/templates_certificado', methods=['GET', 'POST'])
@@ -230,8 +233,8 @@ def preview_certificado():
         for f in temp_files:
             try:
                 os.remove(f)
-            except Exception:
-                pass
+            except OSError as exc:
+                logger.exception("Erro ao remover arquivo temporário %s", f)
         return response
 
     return send_file(pdf_path, mimetype="application/pdf")

--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -6,8 +6,12 @@ from werkzeug.security import generate_password_hash
 from models import Submission, Review, Assignment, ConfiguracaoCliente, AuditLog
 from extensions import db
 from services.mailjet_service import send_via_mailjet
+from mailjet_rest.client import ApiError
+import logging
 
 submission_routes = Blueprint('submission_routes', __name__)
+
+logger = logging.getLogger(__name__)
 
 
 @submission_routes.route('/submissions', methods=['POST'])
@@ -34,8 +38,9 @@ def create_submission():
             subject='Submission Access Code',
             text=f'Locator: {locator}\nAccess code: {raw_code}'
         )
-    except Exception:
-        pass
+    except ApiError as exc:
+        logger.exception("Erro ao enviar código de acesso para %s", email)
+        return jsonify({'error': 'falha ao enviar email'}), 500
 
     return jsonify({'locator': locator, 'code': raw_code}), 201
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,5 +1,9 @@
 import importlib
+import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     import utils  # Preload real utils package before tests may stub it
-except Exception:
-    pass
+except ImportError as exc:
+    logger.exception("Falha ao pré-carregar pacote utils: %s", exc)


### PR DESCRIPTION
## Summary
- log Mailjet send failures and return error when submission email fails
- record background notification email issues
- log cleanup and import errors instead of silently swallowing them

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; SyntaxError in tests/test_formulario_eventos.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ff7b575f083248c50db7e71c69670