### PR TITLE
Handle separate reviewer fields in submission review

### DIFF
--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -61,12 +61,13 @@ def add_review(locator):
     if not submission.check_code(code):
         abort(401)
 
-    reviewer = request.form.get('reviewer')
-    comment = request.form.get('comment')
+    reviewer_id = request.form.get("reviewer_id")
+    reviewer_name = request.form.get("reviewer_name")
+    comment = request.form.get("comment")
 
     review = Review(
         submission_id=submission.id,
-        reviewer_name=reviewer,
+        reviewer_name=reviewer_name,
         comments=comment,
     )
     db.session.add(review)
@@ -79,7 +80,9 @@ def add_review(locator):
 
     assignment = Assignment(
         submission_id=submission.id,
-        reviewer_id=int(reviewer) if reviewer and str(reviewer).isdigit() else None,
+        reviewer_id=int(reviewer_id)
+        if reviewer_id and str(reviewer_id).isdigit()
+        else None,
         deadline=datetime.utcnow() + timedelta(days=prazo_dias),
     )
     db.session.add(assignment)

--- a/tests/test_submission_reviews.py
+++ b/tests/test_submission_reviews.py
@@ -1,0 +1,64 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ["SECRET_KEY"] = "test"
+os.environ["GOOGLE_CLIENT_ID"] = "dummy"
+os.environ["GOOGLE_CLIENT_SECRET"] = "dummy"
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Submission, Usuario, Review, Assignment
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        reviewer = Usuario(
+            nome='Reviewer',
+            cpf='1',
+            email='rev@test',
+            senha=generate_password_hash('123'),
+            formacao='X',
+            tipo='professor',
+        )
+        sub = Submission(
+            title='T',
+            locator='loc1',
+            code_hash=generate_password_hash('code'),
+        )
+        db.session.add_all([reviewer, sub])
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_add_review_separate_fields(client, app):
+    resp = client.post(
+        '/submissions/loc1/reviews',
+        data={
+            'code': 'code',
+            'reviewer_id': 1,
+            'reviewer_name': 'Prof',
+            'comment': 'Good',
+        },
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        review = Review.query.first()
+        assignment = Assignment.query.first()
+        assert review.reviewer_name == 'Prof'
+        assert review.reviewer_id is None
+        assert assignment.reviewer_id == 1


### PR DESCRIPTION
## Summary
- accept distinct `reviewer_id` and `reviewer_name` on review submission
- use reviewer id only when creating assignments
- add test covering separate reviewer fields

## Testing
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*
- `pytest tests/test_submission_reviews.py`


------
https://chatgpt.com/codex/tasks/task_e_689ff7bc857483249cab883f73c39b7e