### PR TITLE
Require auth for submission review code list

### DIFF
--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify, abort
+from flask_login import current_user
 import uuid
 import secrets
 from datetime import datetime, timedelta
@@ -98,7 +99,12 @@ def add_review(locator):
 
 @submission_routes.route('/submissions/<locator>/codes')
 def list_review_codes(locator):
+    """Return review access codes for a submission when authorized."""
+    code = request.args.get('code')
     submission = Submission.query.filter_by(locator=locator).first_or_404()
+    if not (current_user.is_authenticated or submission.check_code(code)):
+        abort(401)
+
     reviews = Review.query.filter_by(submission_id=submission.id).all()
     return jsonify({
         'locator': locator,

--- a/tests/test_peer_review_flow.py
+++ b/tests/test_peer_review_flow.py
@@ -135,6 +135,9 @@ def test_control_endpoints_and_dashboard_auth(client, app):
     assert resp.status_code == 200
 
     resp = client.get(f'/submissions/{locator}/codes')
+    assert resp.status_code == 401
+
+    resp = client.get(f'/submissions/{locator}/codes?code={code}')
     assert resp.status_code == 200
     assert resp.get_json()['locator'] == locator
 


### PR DESCRIPTION
## Summary
- enforce authentication or author code to access submission review codes
- adjust peer review flow test for new authorization requirement

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*
- `SECRET_KEY=secret GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy pytest tests/test_peer_review_flow.py -k control_endpoints_and_dashboard_auth -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff7c05b78832480fffcc77f1f1242