### PR TITLE
Validate required fields and block duplicate reviewer emails

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -139,22 +139,38 @@ def submit_application(process_id: int):
         email: str | None = None
 
         for campo in formulario.campos:  # type: ignore[attr-defined]
-            raw_val = request.form.get(str(campo.id))
-            valor: Any = raw_val
-            if campo.tipo == "file" and f"file_{campo.id}" in request.files:
-                arquivo = request.files[f"file_{campo.id}"]
-                if arquivo.filename:
+            key = str(campo.id)
+            valor: Any = None
+            is_required = getattr(campo, "obrigatorio", False)
+
+            if campo.tipo == "file":
+                file_key = f"file_{campo.id}"
+                arquivo = request.files.get(file_key)
+                if is_required and (not arquivo or not arquivo.filename):
+                    flash(f"O campo {campo.nome} é obrigatório.", "danger")
+                    return redirect(request.url)
+                if arquivo and arquivo.filename:
                     filename = secure_filename(arquivo.filename)
                     ext = os.path.splitext(filename)[1].lower()
                     if ext not in ALLOWED_EXTENSIONS:
                         flash("Extensão de arquivo não permitida.", "danger")
                         return redirect(request.url)
-                    unique_name = f"{uuid.uuid4().hex}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}{ext}"
+                    unique_name = (
+                        f"{uuid.uuid4().hex}_"
+                        f"{datetime.utcnow().strftime('%Y%m%d%H%M%S')}{ext}"
+                    )
                     dir_path = os.path.join("uploads", "candidaturas", str(process_id))
                     os.makedirs(dir_path, exist_ok=True)
                     path = os.path.join(dir_path, unique_name)
                     arquivo.save(path)
                     valor = path
+            else:
+                raw_val = request.form.get(key)
+                if is_required and not raw_val:
+                    flash(f"O campo {campo.nome} é obrigatório.", "danger")
+                    return redirect(request.url)
+                valor = raw_val
+
             respostas[campo.nome] = valor
 
             low = campo.nome.lower()
@@ -162,6 +178,15 @@ def submit_application(process_id: int):
                 nome = valor  # type: ignore[assignment]
             elif low == "email":
                 email = valor  # type: ignore[assignment]
+
+        if email and RevisorCandidatura.query.filter_by(
+            process_id=process_id, email=email
+        ).first():
+            flash(
+                "Já existe uma candidatura com este e-mail para este processo.",
+                "danger",
+            )
+            return redirect(request.url)
 
         candidatura = RevisorCandidatura(
             process_id=process_id,


### PR DESCRIPTION
## Summary
- ensure required revisor form fields are present in submissions
- prevent duplicate reviewer applications with same email per process
- test required-field and duplicate-email validations

## Testing
- `pip install -r requirements-dev.txt`
- `SECRET_KEY=test GOOGLE_CLIENT_ID=1 GOOGLE_CLIENT_SECRET=1 pytest tests/test_revisor_process.py::test_missing_required_field tests/test_revisor_process.py::test_duplicate_email`

------
https://chatgpt.com/codex/tasks/task_e_689ff7c1d2f483249c94c60d26f72e27