### PR TITLE
Handle empty reviewer process list and verify event visibility

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -233,6 +233,7 @@ def progress_query():
 # -----------------------------------------------------------------------------
 @revisor_routes.route("/processo_seletivo")
 def select_event():
+    """Lista eventos com processo seletivo visível a participantes."""
     now = datetime.utcnow()
 
     processos = (
@@ -278,6 +279,12 @@ def select_event():
                         "status": "Aberto" if proc.is_available() else "Encerrado",
                     }
                 )
+
+    if not registros:
+        flash(
+            "Nenhum processo seletivo de revisores disponível no momento.",
+            "info",
+        )
 
     return render_template("revisor/select_event.html", eventos=registros)
 


### PR DESCRIPTION
## Summary
- flash info alert when no reviewer processes are available to participants
- ensure tests create active public events and verify process availability flags

## Testing
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*
- `pytest tests/test_revisor_select_event_filter.py tests/test_revisor_process_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68a08b3071208324b871dce6b8219629