### PR TITLE
Add reviewer evaluation route with rubric support

### DIFF
--- a/models.py
+++ b/models.py
@@ -1578,6 +1578,18 @@ class RevisaoConfig(db.Model):
     )
 
 
+class Barema(db.Model):
+    """Define os critérios de avaliação para um evento."""
+
+    __tablename__ = "barema"
+
+    id = db.Column(db.Integer, primary_key=True)
+    evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=False)
+    requisitos = db.Column(db.JSON, nullable=False)
+
+    evento = db.relationship("Evento", backref=db.backref("barema", uselist=False))
+
+
 class ConfiguracaoCertificadoEvento(db.Model):
     """Regras personalizadas para emissão de certificados em eventos."""
 

--- a/templates/revisor/avaliacao.html
+++ b/templates/revisor/avaliacao.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h3>Avaliar Trabalho</h3>
+  <h5 class="mb-4">{{ submission.title }}</h5>
+  {% if submission.file_path %}
+  <iframe src="{{ url_for('static', filename=submission.file_path) }}" width="100%" height="600"></iframe>
+  {% elif submission.content %}
+  <div class="border p-3 mb-4">{{ submission.content|safe }}</div>
+  {% endif %}
+  <form method="POST">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    {% if barema and barema.requisitos %}
+      {% for requisito, max_nota in barema.requisitos.items() %}
+      <div class="mb-3">
+        <label class="form-label">{{ requisito }} (0-{{ max_nota }})</label>
+        <input type="number" class="form-control" name="{{ requisito }}" min="0" max="{{ max_nota }}" value="{{ review.scores[requisito] if review and review.scores }}">
+      </div>
+      {% endfor %}
+    {% else %}
+      <p>Não há barema cadastrado para este evento.</p>
+    {% endif %}
+    <button class="btn btn-primary">Salvar</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `Barema` model to store evaluation criteria per event
- introduce `/revisor/avaliar/<submission_id>` route for reviewers and save scores
- create evaluation template with rubric form and submission preview

## Testing
- `python -m pip install -r requirements-dev.txt`
- `python -m pip install beautifulsoup4`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py line 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b4914c08324ade3d935f8344ab8