### PR TITLE
Add ranking endpoint for submission scores

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -29,6 +29,7 @@ from werkzeug.security import generate_password_hash
 from werkzeug.utils import secure_filename
 
 from extensions import db
+from sqlalchemy import func, desc
 from sqlalchemy.orm import selectinload
 from models import (
     Assignment,
@@ -44,6 +45,7 @@ from models import (
     RevisorProcess,
     revisor_process_evento_association,
     Submission,
+    Review,
     Usuario,
 )
 from tasks import send_email_task
@@ -488,3 +490,50 @@ def eligible_events():
     )
 
     return jsonify([{"id": e.id, "nome": e.nome} for e in eventos])
+
+
+@revisor_routes.route("/ranking_trabalhos")
+@login_required
+def ranking_trabalhos():
+    """Lista trabalhos com a soma das notas recebidas.
+
+    Permite ordenar por qualquer campo de ``Submission`` através do
+    parâmetro de query ``ordenar_por``. Quando não informado, ordena pelo
+    total de notas (``total_nota``) de forma decrescente.
+    """
+
+    if current_user.tipo not in ("cliente", "admin", "superadmin"):
+        flash("Acesso negado!", "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
+
+    ordenar_por = request.args.get("ordenar_por", "total_nota")
+
+    notas_sub = (
+        db.session.query(
+            Review.submission_id.label("sub_id"),
+            func.coalesce(func.sum(Review.note), 0).label("total_nota"),
+        )
+        .group_by(Review.submission_id)
+        .subquery()
+    )
+
+    query = (
+        db.session.query(Submission, notas_sub.c.total_nota)
+        .outerjoin(notas_sub, Submission.id == notas_sub.c.sub_id)
+    )
+
+    if ordenar_por != "total_nota" and hasattr(Submission, ordenar_por):
+        query = query.order_by(getattr(Submission, ordenar_por))
+    else:
+        ordenar_por = "total_nota"
+        query = query.order_by(desc(notas_sub.c.total_nota))
+
+    resultados = [
+        {"submission": sub, "total_nota": nota or 0} for sub, nota in query.all()
+    ]
+
+    return render_template(
+        "revisor/ranking.html",
+        resultados=resultados,
+        ordenar_por=ordenar_por,
+    )

--- a/templates/revisor/ranking.html
+++ b/templates/revisor/ranking.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Ranking de Trabalhos{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1 class="h3 mb-4">Ranking de Trabalhos</h1>
+  <p class="text-muted">Ordenado por: {{ ordenar_por }}</p>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Título</th>
+        <th>Total de Notas</th>
+        {% if ordenar_por != 'total_nota' %}
+        <th>{{ ordenar_por|capitalize }}</th>
+        {% endif %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in resultados %}
+      <tr>
+        <td>{{ item.submission.title }}</td>
+        <td>{{ '%.2f'|format(item.total_nota) }}</td>
+        {% if ordenar_por != 'total_nota' %}
+        <td>{{ item.submission|attribute(ordenar_por) }}</td>
+        {% endif %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/ranking_trabalhos` endpoint aggregating review scores and allowing sorting
- create ranking template displaying total scores and chosen sort field

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b4cf2d483248ed2b07e47f4f0f4