### PR TITLE
Track reviewer for submission reviews

### DIFF
--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -81,8 +81,13 @@ def add_review(locator):
     reviewer_name = request.form.get("reviewer_name")
     comment = request.form.get("comment")
 
+    reviewer_id_val = (
+        int(reviewer_id) if reviewer_id and str(reviewer_id).isdigit() else None
+    )
+
     review = Review(
         submission_id=submission.id,
+        reviewer_id=reviewer_id_val,
         reviewer_name=reviewer_name,
         comments=comment,
     )
@@ -96,9 +101,7 @@ def add_review(locator):
 
     assignment = Assignment(
         submission_id=submission.id,
-        reviewer_id=int(reviewer_id)
-        if reviewer_id and str(reviewer_id).isdigit()
-        else None,
+        reviewer_id=reviewer_id_val,
         deadline=datetime.utcnow() + timedelta(days=prazo_dias),
     )
     db.session.add(assignment)
@@ -132,7 +135,8 @@ def list_review_codes(locator):
                 'access_code': r.access_code,
                 'started_at': r.started_at.isoformat() if r.started_at else None,
                 'finished_at': r.finished_at.isoformat() if r.finished_at else None,
-                'duration_seconds': r.duration_seconds
+                'duration_seconds': r.duration_seconds,
+                'reviewer_name': r.reviewer.nome if r.reviewer else r.reviewer_name,
             }
             for r in reviews
         ]

--- a/templates/peer_review/dashboard_reviewer.html
+++ b/templates/peer_review/dashboard_reviewer.html
@@ -4,11 +4,12 @@
   <h3>Trabalhos para Revisão</h3>
   <p>Prazo: {{ config.prazo_revisao.strftime('%d/%m/%Y') if config and config.prazo_revisao else 'N/A' }}</p>
   <table class="table table-striped">
-    <thead><tr><th>Título</th><th>Status</th><th>Prazo</th></tr></thead>
+    <thead><tr><th>Título</th><th>Revisor</th><th>Status</th><th>Prazo</th></tr></thead>
     <tbody>
       {% for a in assignments %}
       <tr>
         <td>{{ a.submission.title }}</td>
+        <td>{{ a.reviewer.nome if a.reviewer else '' }}</td>
         <td>{{ 'Concluída' if a.completed else 'Pendente' }}</td>
         <td>{{ a.deadline.strftime('%d/%m/%Y') if a.deadline else '' }}</td>
       </tr>

--- a/tests/test_review_tracking.py
+++ b/tests/test_review_tracking.py
@@ -49,3 +49,4 @@ def test_review_timing(client, app):
     data = resp.get_json()
     assert data['locator'] == 'loc1'
     assert data['reviews'][0]['access_code'] == 'revcode'
+    assert 'reviewer_name' in data['reviews'][0]

--- a/tests/test_submission_reviews.py
+++ b/tests/test_submission_reviews.py
@@ -60,5 +60,5 @@ def test_add_review_separate_fields(client, app):
         review = Review.query.first()
         assignment = Assignment.query.first()
         assert review.reviewer_name == 'Prof'
-        assert review.reviewer_id is None
+        assert review.reviewer_id == 1
         assert assignment.reviewer_id == 1


### PR DESCRIPTION
## Summary
- record `reviewer_id` when adding submission reviews
- expose reviewer names in review progress endpoint
- show reviewer names in reviewer dashboard

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b5090608324af1e50e29bb4b2fa