### PR TITLE
Rename Barema models for clarity

### DIFF
--- a/migrations/versions/97ff1ac3c1dc_add_barema_models.py
+++ b/migrations/versions/97ff1ac3c1dc_add_barema_models.py
@@ -1,4 +1,4 @@
-"""add barema models
+"""add processo_barema and evento_barema models
 
 Revision ID: 97ff1ac3c1dc
 Revises: a16bd5bf6b16
@@ -19,14 +19,14 @@ depends_on = None
 
 def upgrade():
     op.create_table(
-        "barema",
+        "processo_barema",
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("process_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(["process_id"], ["revisor_process.id"]),
         sa.UniqueConstraint("process_id"),
     )
     op.create_table(
-        "barema_requisito",
+        "processo_barema_requisito",
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("barema_id", sa.Integer(), nullable=False),
         sa.Column("nome", sa.String(length=255), nullable=False),
@@ -35,10 +35,19 @@ def upgrade():
             "pontuacao_min", sa.Numeric(5, 2), nullable=False, server_default="0"
         ),
         sa.Column("pontuacao_max", sa.Numeric(5, 2), nullable=False),
-        sa.ForeignKeyConstraint(["barema_id"], ["barema.id"]),
+        sa.ForeignKeyConstraint(["barema_id"], ["processo_barema.id"]),
+    )
+    op.create_table(
+        "evento_barema",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("evento_id", sa.Integer(), nullable=False),
+        sa.Column("requisitos", sa.JSON(), nullable=False),
+        sa.ForeignKeyConstraint(["evento_id"], ["evento.id"]),
+        sa.UniqueConstraint("evento_id"),
     )
 
 
 def downgrade():
-    op.drop_table("barema_requisito")
-    op.drop_table("barema")
+    op.drop_table("evento_barema")
+    op.drop_table("processo_barema_requisito")
+    op.drop_table("processo_barema")

--- a/models.py
+++ b/models.py
@@ -1565,16 +1565,18 @@ class RevisaoConfig(db.Model):
     )
 
 
-class Barema(db.Model):
+class EventoBarema(db.Model):
     """Define os critérios de avaliação para um evento."""
 
-    __tablename__ = "barema"
+    __tablename__ = "evento_barema"
 
     id = db.Column(db.Integer, primary_key=True)
     evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=False)
     requisitos = db.Column(db.JSON, nullable=False)
 
-    evento = db.relationship("Evento", backref=db.backref("barema", uselist=False))
+    evento = db.relationship(
+        "Evento", backref=db.backref("evento_barema", uselist=False)
+    )
 
 
 class ConfiguracaoCertificadoEvento(db.Model):
@@ -1897,10 +1899,10 @@ class RevisorProcess(db.Model):
         return True
 
 
-class Barema(db.Model):
+class ProcessoBarema(db.Model):
     """Conjunto de critérios de avaliação para um processo de revisores."""
 
-    __tablename__ = "barema"
+    __tablename__ = "processo_barema"
 
     id = db.Column(db.Integer, primary_key=True)
     process_id = db.Column(
@@ -1909,27 +1911,34 @@ class Barema(db.Model):
 
     process = db.relationship(
         "RevisorProcess",
-        backref=db.backref("barema", uselist=False, cascade="all, delete-orphan"),
+        backref=db.backref(
+            "processo_barema", uselist=False, cascade="all, delete-orphan"
+        ),
     )
     requisitos = db.relationship(
-        "BaremaRequisito", backref="barema", cascade="all, delete-orphan", lazy=True
+        "ProcessoBaremaRequisito",
+        backref="barema",
+        cascade="all, delete-orphan",
+        lazy=True,
     )
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<Barema id={self.id} process={self.process_id}>"
+        return f"<ProcessoBarema id={self.id} process={self.process_id}>"
 
 
-class BaremaRequisito(db.Model):
-    """Requisito avaliativo pertencente a um barema."""
+class ProcessoBaremaRequisito(db.Model):
+    """Requisito avaliativo pertencente a um barema de processo."""
 
-    __tablename__ = "barema_requisito"
+    __tablename__ = "processo_barema_requisito"
 
     id = db.Column(db.Integer, primary_key=True)
-    barema_id = db.Column(db.Integer, db.ForeignKey("barema.id"), nullable=False)
+    barema_id = db.Column(
+        db.Integer, db.ForeignKey("processo_barema.id"), nullable=False
+    )
     nome = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=True)
     pontuacao_min = db.Column(db.Numeric(5, 2), nullable=False, default=0)
     pontuacao_max = db.Column(db.Numeric(5, 2), nullable=False)
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<BaremaRequisito id={self.id} barema={self.barema_id}>"
+        return f"<ProcessoBaremaRequisito id={self.id} barema={self.barema_id}>"

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -43,7 +43,7 @@ from models import (
     Formulario,
 
 
-    Barema,
+    EventoBarema,
 
     RevisorCandidatura,
     RevisorCandidaturaEtapa,
@@ -484,7 +484,7 @@ def view_candidatura(cand_id: int):
 def avaliar(submission_id: int):
     """Permite ao revisor atribuir notas a uma submissão com base no barema."""
     submission = Submission.query.get_or_404(submission_id)
-    barema = Barema.query.filter_by(evento_id=submission.evento_id).first()
+    barema = EventoBarema.query.filter_by(evento_id=submission.evento_id).first()
     review = Review.query.filter_by(
         submission_id=submission.id, reviewer_id=current_user.id
     ).first()


### PR DESCRIPTION
## Summary
- Distinguish barema models by context: `EventoBarema` for events and `ProcessoBarema`/`ProcessoBaremaRequisito` for reviewer processes
- Update migration to create `evento_barema`, `processo_barema`, and related requirement tables
- Adjust reviewer routes to import and query the correct barema model

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a09c314bd08324ba881634b5bdb022