### PR TITLE
Add help chat widget to visitation scheduling page

### DIFF
--- a/static/js/agendamento_chat.js
+++ b/static/js/agendamento_chat.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const box = document.getElementById('chat-ajuda');
+    if (box) {
+        box.style.display = 'block';
+    }
+});

--- a/templates/agendamento/agendar_visita.html
+++ b/templates/agendamento/agendar_visita.html
@@ -33,4 +33,14 @@
         <button type="submit" class="btn btn-success">Confirmar Agendamento</button>
     </form>
 </div>
+
+<div id="chat-ajuda" class="border rounded p-3 bg-light" style="display:none; position:fixed; bottom:20px; right:20px; max-width:300px; z-index:1000;">
+    <strong>Precisa de ajuda?</strong>
+    <p class="mb-0">Após concluir o agendamento, acesse <strong>Meus Agendamentos</strong> para inserir nome e CPF dos alunos e baixar o comprovante.</p>
+</div>
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='js/agendamento_chat.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add chat/ajuda widget with guidance on agendamento
- include JS to show chat box on schedule page

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Table 'usuario' is already defined for this MetaData)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e9284848324a0678a900569391c