### PR TITLE
Restrict print and QR to confirmed agendamentos

### DIFF
--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -457,6 +457,10 @@ def imprimir_agendamento_professor(agendamento_id):
         )
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
 
+    if agendamento.status != 'confirmado':
+        flash('Agendamento ainda não confirmado.', 'warning')
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
+
     horario = agendamento.horario
     evento = horario.evento
     
@@ -511,6 +515,10 @@ def qrcode_agendamento_professor(agendamento_id):
             'Acesso negado! Este agendamento não pertence ao seu evento.',
             'danger',
         )
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
+
+    if agendamento.status != 'confirmado':
+        flash('Agendamento ainda não confirmado.', 'warning')
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
 
     # Página que exibe o QR Code para check-in

--- a/templates/professor/adicionar_alunos.html
+++ b/templates/professor/adicionar_alunos.html
@@ -136,15 +136,17 @@
             </div>
         {% endif %}
         
-        {% if total_adicionados > 0 %}
+        {% if agendamento.status == 'confirmado' and total_adicionados > 0 %}
         <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
         {% endif %}
-        
+
+        {% if agendamento.status == 'confirmado' %}
         <a href="{{ url_for('routes.qrcode_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-info">
             <i class="fas fa-qrcode"></i> Ver QR Code
         </a>
+        {% endif %}
         
         <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar

--- a/templates/professor/meus_agendamentos.html
+++ b/templates/professor/meus_agendamentos.html
@@ -104,10 +104,12 @@
                                                         </a>
                                                     {% endif %}
                                                     
-                                                    <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" 
-                                                       class="btn btn-sm btn-outline-primary" title="Imprimir">
-                                                        <i class="fas fa-print me-1"></i>Imprimir
-                                                    </a>
+                                                    {% if agendamento.status == 'confirmado' %}
+                                                        <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}"
+                                                           class="btn btn-sm btn-outline-primary" title="Imprimir">
+                                                            <i class="fas fa-print me-1"></i>Imprimir
+                                                        </a>
+                                                    {% endif %}
                                                 </div>
                                             </td>
                                         </tr>

--- a/templates/professor/qrcode_agendamento.html
+++ b/templates/professor/qrcode_agendamento.html
@@ -47,9 +47,11 @@
     </div>
     
     <div class="mt-4">
+        {% if agendamento.status == 'confirmado' %}
         <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
+        {% endif %}
         <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>

--- a/tests/test_agendamento_flow.py
+++ b/tests/test_agendamento_flow.py
@@ -249,8 +249,8 @@ def test_fluxo_agendamento(app):
     assert resp.status_code == 302
 
     resp = client.get(f'/professor/imprimir_agendamento/{agendamento_id}')
-    assert resp.status_code == 200
-    assert resp.data.startswith(b'PDF')
+    assert resp.status_code == 302
+    assert '/professor/meus_agendamentos' in resp.headers['Location']
 
     with app.app_context():
         agendamento = AgendamentoVisita.query.get(agendamento_id)

--- a/tests/test_professor_routes_access.py
+++ b/tests/test_professor_routes_access.py
@@ -134,10 +134,14 @@ def login(client, email):
 )
 def test_imprimir_agendamento_access(app, client, email):
     from models import AgendamentoVisita
+    from extensions import db
 
     login(client, email)
     with app.app_context():
-        agendamento_id = AgendamentoVisita.query.first().id
+        agendamento = AgendamentoVisita.query.first()
+        agendamento.status = 'confirmado'
+        db.session.commit()
+        agendamento_id = agendamento.id
     resp = client.get(f'/professor/imprimir_agendamento/{agendamento_id}')
     assert resp.status_code == 200
     assert resp.data.startswith(b'PDF')
@@ -149,10 +153,14 @@ def test_imprimir_agendamento_access(app, client, email):
 )
 def test_qrcode_agendamento_access(app, client, email):
     from models import AgendamentoVisita
+    from extensions import db
 
     login(client, email)
     with app.app_context():
-        agendamento_id = AgendamentoVisita.query.first().id
+        agendamento = AgendamentoVisita.query.first()
+        agendamento.status = 'confirmado'
+        db.session.commit()
+        agendamento_id = agendamento.id
     resp = client.get(f'/professor/qrcode_agendamento/{agendamento_id}')
     assert resp.status_code == 200
     assert b'QR Code do Agendamento' in resp.data


### PR DESCRIPTION
## Summary
- Block PDF and QR code access for unconfirmed agendamentos
- Hide print and QR buttons until agendamento is confirmed
- Update tests to reflect confirmation requirement

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Table 'usuario' is already defined...)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e9ad0988324b444113a420a3753