### PR TITLE
Add print and QR code actions for confirmed bookings

### DIFF
--- a/templates/cliente/meus_agendamentos.html
+++ b/templates/cliente/meus_agendamentos.html
@@ -108,6 +108,17 @@
                         <i class="fas fa-times me-1"></i>Cancelar
                       </a>
                       {% endif %}
+
+                      {% if agendamento.status == 'confirmado' %}
+                      <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}"
+                         class="btn btn-sm btn-outline-primary" title="Imprimir Comprovante">
+                        <i class="fas fa-print me-1"></i>Imprimir Comprovante
+                      </a>
+                      <a href="{{ url_for('routes.qrcode_agendamento_professor', agendamento_id=agendamento.id) }}"
+                         class="btn btn-sm btn-outline-secondary" title="Ver QR Code">
+                        <i class="fas fa-qrcode me-1"></i>Ver QR Code
+                      </a>
+                      {% endif %}
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- show print and QR code buttons for confirmed client appointments

## Testing
- `pytest` *(fails: Table 'usuario' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e9cbde483248fb99b67300687f8