### PR TITLE
Remove duplicated PDF report generator

### DIFF
--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -219,3 +219,21 @@ def test_template_contains_new_columns(client):
     assert 'Presentes' in html
     assert 'Aluno 1' in html
 
+
+def test_generate_pdf_uses_service(client, monkeypatch):
+    login(client)
+    called = {}
+
+    def fake_pdf(evento, agendamentos, caminho_pdf):
+        called['used'] = True
+        os.makedirs(os.path.dirname(caminho_pdf), exist_ok=True)
+        with open(caminho_pdf, 'wb') as f:
+            f.write(b'PDF')
+
+    monkeypatch.setattr(
+        'services.pdf_service.gerar_pdf_relatorio_agendamentos', fake_pdf
+    )
+    resp = client.get('/relatorio_geral_agendamentos?gerar_pdf=1')
+    assert resp.status_code == 200
+    assert called.get('used')
+


### PR DESCRIPTION
## Summary
- remove copy of `gerar_pdf_relatorio_agendamentos` from agendamento routes
- rely on `services.pdf_service.gerar_pdf_relatorio_agendamentos`
- add regression test covering PDF generation through service

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Table 'usuario' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e893e348324ac4bd34d3399d263