### PR TITLE
Record checkins for QR-code agendamentos

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3094,11 +3094,19 @@ def checkin_agendamento(qr_code_token):
     agendamento.checkin_realizado = True
     agendamento.data_checkin = datetime.utcnow()
     agendamento.status = 'realizado'
-    
+
+    checkin = Checkin(
+        usuario_id=agendamento.professor_id,
+        evento_id=agendamento.horario.evento_id,
+        cliente_id=agendamento.cliente_id,
+        palavra_chave='QR-AGENDAMENTO',
+    )
+    db.session.add(checkin)
+
     try:
-        # Salvar as alterações no banco de dados
+        # Salvar as alterações no banco de dados antes de responder
         db.session.commit()
-        
+
         # Formatar resposta
         resposta = {
             "mensagem": "Check-in realizado com sucesso",
@@ -3106,12 +3114,12 @@ def checkin_agendamento(qr_code_token):
                 "id": agendamento.id,
                 "status": agendamento.status,
                 "checkin_realizado": agendamento.checkin_realizado,
-                "data_checkin": agendamento.data_checkin.isoformat()
-            }
+                "data_checkin": agendamento.data_checkin.isoformat(),
+            },
         }
-        
+
         return jsonify(resposta), 200
-        
+
     except Exception as e:
         db.session.rollback()
         return jsonify({"erro": f"Erro ao realizar check-in: {str(e)}"}), 500


### PR DESCRIPTION
## Summary
- create `Checkin` entry when QR agendamento check-in occurs
- test agendamento QR check-in persistence

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Table 'usuario' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e87889083249931c2061558faaf