### PR TITLE
Add evento_id column to submission

### DIFF
--- a/migrations/versions/b460e470d7a9_add_evento_id_to_submission.py
+++ b/migrations/versions/b460e470d7a9_add_evento_id_to_submission.py
@@ -1,0 +1,30 @@
+# Add evento_id to submission.
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b460e470d7a9"
+down_revision = ("97ff1ac3c1dc", "b1aa30258a43")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "submission",
+        sa.Column("evento_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_submission_evento",
+        "submission",
+        "evento",
+        ["evento_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_submission_evento", "submission", type_="foreignkey")
+    op.drop_column("submission", "evento_id")


### PR DESCRIPTION
## Summary
- add Alembic migration for `submission.evento_id`

## Testing
- `flask db upgrade b460e470d7a9` *(fails: no such table: submission)*
- `pytest tests/test_config_cliente_review.py::test_dashboard_defaults -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4'; SyntaxError in tests/test_formulario_eventos.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab7d7f1c8324b6a3a820cc04258c