### PR TITLE
Validate reviewer score ranges

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -656,6 +656,28 @@ def avaliar(submission_id: int):
             if nota_raw:
                 scores[requisito] = int(nota_raw)
 
+        processo = (
+            RevisorProcess.query.join(RevisorProcess.eventos)
+            .filter(Evento.id == submission.evento_id)
+            .first()
+        )
+        requisitos_map: Dict[str, ProcessoBaremaRequisito] = {}
+        if processo and processo.processo_barema:
+            requisitos_map = {
+                r.nome: r for r in processo.processo_barema.requisitos
+            }
+
+        for nome, nota in scores.items():
+            req = requisitos_map.get(nome)
+            if req and not (req.pontuacao_min <= nota <= req.pontuacao_max):
+                flash(
+                    f"Nota para {nome} deve estar entre {req.pontuacao_min} e {req.pontuacao_max}.",
+                    "danger",
+                )
+                return redirect(
+                    url_for("revisor_routes.avaliar", submission_id=submission.id)
+                )
+
         if review is None:
             review = Review(
                 submission_id=submission.id, reviewer_id=current_user.id

--- a/tests/test_revisor_score_limits.py
+++ b/tests/test_revisor_score_limits.py
@@ -1,0 +1,128 @@
+import os
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ["SECRET_KEY"] = "test"
+os.environ["GOOGLE_CLIENT_ID"] = "dummy"
+os.environ["GOOGLE_CLIENT_SECRET"] = "dummy"
+
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = "sqlite://"
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models import (
+    Usuario,
+    Cliente,
+    Evento,
+    Submission,
+    Assignment,
+    RevisorProcess,
+    ProcessoBarema,
+    ProcessoBaremaRequisito,
+    EventoBarema,
+    Review,
+)
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome="Cli",
+            email="cli@test",
+            senha=generate_password_hash("123"),
+        )
+        db.session.add(cliente)
+        db.session.flush()
+        reviewer = Usuario(
+            nome="Rev",
+            cpf="1",
+            email="rev@test",
+            senha=generate_password_hash("123"),
+            formacao="X",
+            tipo="revisor",
+        )
+        process = RevisorProcess(cliente_id=cliente.id, num_etapas=1)
+        db.session.add_all([reviewer, process])
+        db.session.flush()
+        barema_proc = ProcessoBarema(process_id=process.id)
+        db.session.add(barema_proc)
+        db.session.flush()
+        requisito = ProcessoBaremaRequisito(
+            barema_id=barema_proc.id,
+            nome="Qualidade",
+            pontuacao_min=1,
+            pontuacao_max=5,
+        )
+        evento = Evento(
+            cliente_id=cliente.id,
+            nome="Evento",
+            inscricao_gratuita=True,
+        )
+        db.session.add_all([requisito, evento])
+        db.session.flush()
+        process.eventos.append(evento)
+        evento_barema = EventoBarema(evento_id=evento.id, requisitos={"Qualidade": 5})
+        submission = Submission(
+            title="T",
+            code_hash=generate_password_hash("code"),
+            evento_id=evento.id,
+        )
+        assignment = Assignment(submission=submission, reviewer=reviewer)
+        db.session.add_all([evento_barema, submission, assignment])
+        db.session.commit()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"email": "rev@test", "senha": "123"},
+        follow_redirects=True,
+    )
+
+
+def get_submission_id(app):
+    with app.app_context():
+        return Submission.query.first().id
+
+
+def test_score_below_min_rejected(client, app):
+    login(client)
+    sub_id = get_submission_id(app)
+    client.post(
+        f"/revisor/avaliar/{sub_id}",
+        data={"Qualidade": "0"},
+        follow_redirects=True,
+    )
+    with app.app_context():
+        assert Review.query.count() == 0
+
+
+def test_score_above_max_rejected(client, app):
+    login(client)
+    sub_id = get_submission_id(app)
+    client.post(
+        f"/revisor/avaliar/{sub_id}",
+        data={"Qualidade": "6"},
+        follow_redirects=True,
+    )
+    with app.app_context():
+        assert Review.query.count() == 0


### PR DESCRIPTION
## Summary
- ensure reviewer scores respect requirement min and max before saving
- add tests covering rejection of out-of-range scores

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py, test_dashboard_cliente_preview.py)*
- `pytest tests/test_revisor_score_limits.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0be98d21883249b2e45a7336ec21d