### PR TITLE
Validate requisito score range

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -202,6 +202,15 @@ def add_requisito(barema_id: int):
             pontuacao_min=request.form.get("pontuacao_min", type=float) or 0,
             pontuacao_max=request.form.get("pontuacao_max", type=float) or 0,
         )
+        if requisito.pontuacao_min > requisito.pontuacao_max:
+            error = "Pontuação mínima não pode ser maior que a máxima."
+            flash(error, "danger")
+            return render_template(
+                "revisor/requisito_form.html",
+                barema=barema,
+                requisito=requisito,
+                error=error,
+            )
         db.session.add(requisito)
         db.session.commit()
         flash("Requisito adicionado", "success")
@@ -233,6 +242,15 @@ def edit_requisito(req_id: int):
         requisito.pontuacao_max = (
             request.form.get("pontuacao_max", type=float) or 0
         )
+        if requisito.pontuacao_min > requisito.pontuacao_max:
+            error = "Pontuação mínima não pode ser maior que a máxima."
+            flash(error, "danger")
+            return render_template(
+                "revisor/requisito_form.html",
+                barema=requisito.barema,
+                requisito=requisito,
+                error=error,
+            )
         db.session.commit()
         flash("Requisito atualizado", "success")
         return redirect(

--- a/templates/revisor/requisito_form.html
+++ b/templates/revisor/requisito_form.html
@@ -3,6 +3,9 @@
 {% block content %}
 <div class="container py-4">
   <h1 class="h3 mb-4">{{ 'Editar' if requisito else 'Novo' }} Requisito</h1>
+  {% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
   <form method="post">
     <div class="mb-3">
       <label class="form-label">Nome</label>

--- a/tests/test_requisito_validation.py
+++ b/tests/test_requisito_validation.py
@@ -1,0 +1,142 @@
+import os
+import pytest
+from flask import Flask
+from jinja2 import ChoiceLoader, DictLoader
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
+
+from config import Config
+from extensions import db, login_manager, csrf
+from models import (
+    Cliente,
+    Formulario,
+    RevisorProcess,
+    ProcessoBarema,
+    ProcessoBaremaRequisito,
+)
+from routes.revisor_routes import revisor_routes
+
+Config.SQLALCHEMY_DATABASE_URI = "sqlite://"
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+
+@pytest.fixture
+def app():
+    templates_path = os.path.join(os.path.dirname(__file__), "..", "templates")
+    app = Flask(__name__, template_folder=templates_path)
+    app.jinja_loader = ChoiceLoader([
+        DictLoader({"base.html": "{% block content %}{% endblock %}"}),
+        app.jinja_loader,
+    ])
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="test",
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_ENGINE_OPTIONS=Config.build_engine_options("sqlite://"),
+    )
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):  # pragma: no cover
+        return Cliente.query.get(int(user_id))
+
+    db.init_app(app)
+    csrf.init_app(app)
+    app.register_blueprint(revisor_routes)
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome="C",
+            email="c@test",
+            senha=generate_password_hash("123"),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+        form = Formulario(nome="F", cliente_id=cliente.id)
+        db.session.add(form)
+        db.session.commit()
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+        )
+        db.session.add(proc)
+        db.session.commit()
+        barema = ProcessoBarema(process_id=proc.id)
+        db.session.add(barema)
+        db.session.commit()
+        requisito = ProcessoBaremaRequisito(
+            barema_id=barema.id,
+            nome="R",
+            pontuacao_min=0,
+            pontuacao_max=10,
+        )
+        db.session.add(requisito)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_add_requisito_invalid_range(client, app):
+    with client:
+        with app.app_context():
+            cliente = Cliente.query.first()
+            barema = ProcessoBarema.query.first()
+        with client.session_transaction() as sess:
+            sess['_user_id'] = str(cliente.id)
+            sess['_fresh'] = True
+        resp = client.post(
+            f"/revisor/barema/{barema.id}/requisito/new",
+            data={
+                "nome": "X",
+                "descricao": "Y",
+                "pontuacao_min": 5,
+                "pontuacao_max": 4,
+            },
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "Pontuação mínima" in html
+        with app.app_context():
+            count = ProcessoBaremaRequisito.query.filter_by(
+                barema_id=barema.id, nome="X"
+            ).count()
+            assert count == 0
+
+
+def test_edit_requisito_invalid_range(client, app):
+    with client:
+        with app.app_context():
+            requisito = ProcessoBaremaRequisito.query.first()
+            cliente = Cliente.query.first()
+            original_min = float(requisito.pontuacao_min)
+            original_max = float(requisito.pontuacao_max)
+        with client.session_transaction() as sess:
+            sess['_user_id'] = str(cliente.id)
+            sess['_fresh'] = True
+        resp = client.post(
+            f"/revisor/requisito/{requisito.id}/edit",
+            data={
+                "nome": requisito.nome,
+                "descricao": requisito.descricao,
+                "pontuacao_min": original_max + 1,
+                "pontuacao_max": original_max,
+            },
+        )
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "Pontuação mínima" in html
+        with app.app_context():
+            atualizado = ProcessoBaremaRequisito.query.get(requisito.id)
+            assert float(atualizado.pontuacao_min) == original_min
+            assert float(atualizado.pontuacao_max) == original_max


### PR DESCRIPTION
## Summary
- block requisito creation/update when pontuacao_min is greater than pontuacao_max
- show validation message on requisito form
- test invalid score ranges for add/edit requisites

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: SyntaxError in tests/test_formulario_eventos.py)*
- `pytest tests/test_requisito_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0be9c820c8324a096e6a22c5c1210