### PR TITLE
Refactor revisor templates to shared card layout

### DIFF
--- a/templates/partials/card.html
+++ b/templates/partials/card.html
@@ -1,0 +1,15 @@
+{% macro render_card(title, body, footer='', card_class='card shadow-sm') -%}
+<div class="{{ card_class }}">
+  <div class="card-header bg-primary text-white">
+    <h2 class="mb-0 fs-4">{{ title }}</h2>
+  </div>
+  <div class="card-body">
+    {{ body | safe }}
+  </div>
+  {% if footer %}
+  <div class="card-footer bg-white border-0">
+    {{ footer | safe }}
+  </div>
+  {% endif %}
+</div>
+{%- endmacro %}

--- a/templates/revisor/candidatura_form.html
+++ b/templates/revisor/candidatura_form.html
@@ -1,53 +1,57 @@
 {% extends "base.html" %}
+{% from 'partials/card.html' import render_card %}
+{% block title %}Processo Seletivo{% endblock %}
 {% block content %}
-<div class="container py-5">
-    <div class="card shadow-sm border-0 rounded-lg">
-        <div class="card-header bg-primary text-white">
-            <h2 class="mb-0 fs-4">{{ formulario.nome }}</h2>
-        </div>
-        <div class="card-body">
-            <div class="alert alert-info mb-4">
-                <i class="bi bi-info-circle me-2"></i>{{ formulario.descricao }}
-            </div>
-            <form method="POST" enctype="multipart/form-data">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                {% for campo in formulario.campos %}
-                <div class="mb-4">
-                    <label class="form-label fw-bold" for="campo-{{ campo.id }}">
-                        {{ campo.nome }}{% if campo.obrigatorio %}<span class="text-danger">*</span>{% endif %}
-                    </label>
-                    <div class="form-field-container">
-                        {% if campo.tipo == 'text' %}
-                        <input type="text" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
-                        {% elif campo.tipo == 'textarea' %}
-                        <textarea id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" rows="4" {% if campo.obrigatorio %}required{% endif %}></textarea>
-                        {% elif campo.tipo == 'number' %}
-                        <input type="number" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
-                        {% elif campo.tipo == 'file' %}
-                        <input type="file" id="campo-{{ campo.id }}" name="file_{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
-                        {% elif campo.tipo == 'date' %}
-                        <input type="date" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" {% if campo.obrigatorio %}required{% endif %}>
-                        {% elif campo.tipo == 'dropdown' %}
-                        <select id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-select" {% if campo.obrigatorio %}required{% endif %}>
-                            <option value="" disabled selected>Selecione uma opção</option>
-                            {% for opcao in campo.opcoes.split(',') %}
-                            <option value="{{ opcao.strip() }}">{{ opcao.strip() }}</option>
-                            {% endfor %}
-                        </select>
-                        {% endif %}
-                    </div>
-                </div>
-                {% endfor %}
-                <div class="d-grid gap-2 d-md-flex mt-5">
-                    <a href="{{ url_for('evento_routes.home') }}" class="btn btn-outline-secondary">
-                        <i class="bi bi-arrow-left me-1"></i>Voltar
-                    </a>
-                    <button type="submit" class="btn btn-primary ms-auto">
-                        <i class="bi bi-check-circle me-1"></i>Enviar Formulário
-                    </button>
-                </div>
-            </form>
-        </div>
+<div class="container py-4">
+  {% set body %}
+    <div class="alert alert-info mb-4">
+      <i class="bi bi-info-circle me-2"></i>{{ formulario.descricao }}
     </div>
+    <form method="POST" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      {% for campo in formulario.campos %}
+      <div class="mb-4">
+        <label class="form-label fw-bold" for="campo-{{ campo.id }}">
+          {{ campo.nome }}{% if campo.obrigatorio %}<span class="text-danger">*</span>{% endif %}
+        </label>
+        <div class="form-field-container">
+          {% if campo.tipo == 'text' %}
+          <input type="text" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control"
+                 {% if campo.obrigatorio %}required{% endif %}>
+          {% elif campo.tipo == 'textarea' %}
+          <textarea id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control" rows="4"
+                    {% if campo.obrigatorio %}required{% endif %}></textarea>
+          {% elif campo.tipo == 'number' %}
+          <input type="number" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control"
+                 {% if campo.obrigatorio %}required{% endif %}>
+          {% elif campo.tipo == 'file' %}
+          <input type="file" id="campo-{{ campo.id }}" name="file_{{ campo.id }}" class="form-control"
+                 {% if campo.obrigatorio %}required{% endif %}>
+          {% elif campo.tipo == 'date' %}
+          <input type="date" id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-control"
+                 {% if campo.obrigatorio %}required{% endif %}>
+          {% elif campo.tipo == 'dropdown' %}
+          <select id="campo-{{ campo.id }}" name="{{ campo.id }}" class="form-select"
+                  {% if campo.obrigatorio %}required{% endif %}>
+            <option value="" disabled selected>Selecione uma opção</option>
+            {% for opcao in campo.opcoes.split(',') %}
+            <option value="{{ opcao.strip() }}">{{ opcao.strip() }}</option>
+            {% endfor %}
+          </select>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+      <div class="d-grid gap-2 d-md-flex mt-5">
+        <a href="{{ url_for('evento_routes.home') }}" class="btn btn-outline-secondary">
+          <i class="bi bi-arrow-left me-1"></i>Voltar
+        </a>
+        <button type="submit" class="btn btn-primary ms-auto">
+          <i class="bi bi-check-circle me-1"></i>Enviar Formulário
+        </button>
+      </div>
+    </form>
+  {% endset %}
+  {{ render_card(formulario.nome, body, '', 'card shadow-sm border-0 rounded-lg') }}
 </div>
 {% endblock %}

--- a/templates/revisor/select_event.html
+++ b/templates/revisor/select_event.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'partials/card.html' import render_card %}
 {% block title %}Processo Seletivo{% endblock %}
 {% block content %}
 <div class="container py-4">
@@ -7,27 +8,28 @@
   <div class="row g-4">
     {% for item in eventos %}
     <div class="col-md-6">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header bg-primary text-white">
-          {{ item.evento.nome if item.evento else item.processo.formulario.nome }}
-        </div>
-        <div class="card-body">
-          {% if item.evento %}
-          <p class="mb-1"><strong>Cliente:</strong> {{ item.evento.cliente.nome }}</p>
-          <p class="mb-1"><strong>Período:</strong>
-            {% if item.evento.data_inicio %}{{ item.evento.data_inicio.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %}
-            a
-            {% if item.evento.data_fim %}{{ item.evento.data_fim.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %}
-          </p>
-          {% else %}
-          <p class="mb-1"><strong>Formulário:</strong> {{ item.processo.formulario.nome }}</p>
-          {% endif %}
-          <p class="mb-1"><strong>Status do processo:</strong> {{ item.status }}</p>
-        </div>
-        <div class="card-footer bg-white border-0">
-          <a href="{{ url_for('revisor_routes.submit_application', process_id=item.processo.id) }}" class="btn btn-success w-100">Participar do processo seletivo</a>
-        </div>
-      </div>
+      {% set body %}
+        {% if item.evento %}
+        <p class="mb-1"><strong>Cliente:</strong> {{ item.evento.cliente.nome }}</p>
+        <p class="mb-1"><strong>Período:</strong>
+          {% if item.evento.data_inicio %}{{ item.evento.data_inicio.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %} a
+          {% if item.evento.data_fim %}{{ item.evento.data_fim.strftime('%d/%m/%Y') }}{% else %}Não informado{% endif %}
+        </p>
+        {% else %}
+        <p class="mb-1"><strong>Formulário:</strong> {{ item.processo.formulario.nome }}</p>
+        {% endif %}
+        <p class="mb-1"><strong>Status do processo:</strong> {{ item.status }}</p>
+      {% endset %}
+      {% set footer %}
+        <a href="{{ url_for('revisor_routes.submit_application', process_id=item.processo.id) }}"
+           class="btn btn-success w-100">Participar do processo seletivo</a>
+      {% endset %}
+      {{ render_card(
+          item.evento.nome if item.evento else item.processo.formulario.nome,
+          body,
+          footer,
+          'card h-100 shadow-sm'
+      ) }}
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Summary
- add reusable card macro for consistent primary-styled cards
- refactor revisor templates to render cards via macro and unify container spacing

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: TypeError: cannot unpack non-iterable NoneType object)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d8cf1ccc8324901e20ee3684cb55