### PR TITLE
Handle open revisor processes without valid events

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -440,25 +440,17 @@ def select_event():
             if ev:
                 eventos.append(ev)
 
+        status = "Aberto" if proc.is_available() else "Encerrado"
         if not eventos:
-            registros.append(
-                {
-                    "evento": None,
-                    "processo": proc,
-                    "status": "Aberto" if proc.is_available() else "Encerrado",
-                }
-            )
+            registros.append({"evento": None, "processo": proc, "status": status})
             continue
 
-        for ev in eventos:
-            if ev.status == "ativo" and ev.publico:
-                registros.append(
-                    {
-                        "evento": ev,
-                        "processo": proc,
-                        "status": "Aberto" if proc.is_available() else "Encerrado",
-                    }
-                )
+        validos = [ev for ev in eventos if ev.status == "ativo" and ev.publico]
+        if validos:
+            for ev in validos:
+                registros.append({"evento": ev, "processo": proc, "status": status})
+        elif proc.is_available():
+            registros.append({"evento": None, "processo": proc, "status": status})
 
     if not registros:
         flash(


### PR DESCRIPTION
## Summary
- add fallback listing for open reviewer selection processes lacking public active events
- cover scenario with new test ensuring processes are shown even when events are invalid

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: tests/test_revisor_process.py::test_progress_pdf_download, tests/test_revisor_process.py::test_dashboard_lists_candidaturas_and_status_update, tests/test_revisor_process_extra.py::test_config_route_saves_availability, tests/test_revisor_process_extra.py::test_config_route_saves_eventos, tests/test_revisor_score_limits.py::test_score_below_min_rejected, tests/test_revisor_score_limits.py::test_score_above_max_rejected, tests/test_sortear_revisores.py::test_sortear_revisores_limits, tests/test_submission_via_form.py::test_get_submission_form, tests/test_submission_via_form.py::test_submission_creates_record, tests/test_superadmin_dashboard.py::test_superadmin_login_and_dashboard, tests/test_user_deletion_password_reset.py::test_delete_participant_removes_password_tokens, tests/test_usuario_bloqueio.py::test_toggle_usuario_block_login, tests/test_usuario_cliente_association.py::test_association_and_listing, tests/test_visualizar_agendamento.py::test_visualizar_agendamento_not_found, tests/test_reviewer_applications.py::test_dashboard_applications_visible_for_cliente, tests/test_reviewer_applications.py::test_update_application_requires_permission, tests/test_reviewer_applications.py::test_submit_application_and_visibility, tests/test_reviewer_applications.py::test_revisor_approval_without_email, tests/test_reviewer_applications.py::test_duplicate_application_redirects`)
- `pytest tests/test_revisor_select_event_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d8cbce008324a65c0f9feedeeace