### PR TITLE
Use date-based availability checks for reviewer processes

### DIFF
--- a/models.py
+++ b/models.py
@@ -1896,10 +1896,10 @@ class RevisorProcess(db.Model):
 
     def is_available(self) -> bool:
         """Return True if the process is currently available."""
-        now = datetime.utcnow()
-        if self.availability_start and now < self.availability_start:
+        today = date.today()
+        if self.availability_start and today < self.availability_start.date():
             return False
-        if self.availability_end and now > self.availability_end:
+        if self.availability_end and today > self.availability_end.date():
             return False
         return True
 

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -414,7 +414,7 @@ def progress_query():
 @revisor_routes.route("/processo_seletivo")
 def select_event():
     """Lista eventos com processo seletivo visível a participantes."""
-    now = datetime.utcnow()
+    today = date.today()
 
     processos = (
         RevisorProcess.query.options(selectinload(RevisorProcess.eventos))
@@ -422,11 +422,11 @@ def select_event():
             RevisorProcess.exibir_para_participantes.is_(True),
             or_(
                 RevisorProcess.availability_start.is_(None),
-                RevisorProcess.availability_start <= now,
+                func.date(RevisorProcess.availability_start) <= today,
             ),
             or_(
                 RevisorProcess.availability_end.is_(None),
-                RevisorProcess.availability_end >= now,
+                func.date(RevisorProcess.availability_end) >= today,
             ),
         )
         .all()

--- a/utils/revisor_helpers.py
+++ b/utils/revisor_helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, time
 from typing import Any, Dict, List
 
 from flask import Request
@@ -27,9 +27,12 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
     exibir_val = req.form.get("exibir_para_participantes")
     exibir_para_participantes = exibir_val in {"on", "1", "true"}
 
-    def _parse_dt(raw: str | None) -> datetime | None:
+    def _parse_dt(raw: str | None, *, end: bool = False) -> datetime | None:
         try:
-            return datetime.strptime(raw, "%Y-%m-%d") if raw else None
+            if not raw:
+                return None
+            dt = datetime.strptime(raw, "%Y-%m-%d")
+            return datetime.combine(dt.date(), time.max if end else time.min)
         except ValueError:
             return None
 
@@ -44,7 +47,7 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
         "num_etapas": num_etapas,
         "stage_names": stage_names,
         "availability_start": _parse_dt(start_raw),
-        "availability_end": _parse_dt(end_raw),
+        "availability_end": _parse_dt(end_raw, end=True),
         "exibir_para_participantes": exibir_para_participantes,
         "eventos_ids": eventos_ids,
         "criterios": criterios,


### PR DESCRIPTION
## Summary
- parse reviewer form end date as full-day using `time.max`
- compare availability using `date.today` in `RevisorProcess.is_available`
- filter visible reviewer processes by date in `select_event`

## Testing
- `pytest` *(fails: 64 failed, 115 passed, 188 warnings, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d8c301dc8324a5e33438ca76fdbd