### PR TITLE
Exibir conteúdo e validar barema na revisão pública

### DIFF
--- a/templates/peer_review/review_form.html
+++ b/templates/peer_review/review_form.html
@@ -2,17 +2,31 @@
 {% block content %}
 <div class="container mt-5">
   <h3>Revisar Trabalho</h3>
-  <p><strong>{{ review.submission.title }}</strong></p>
+  <h5 class="mb-4">{{ review.submission.title }}</h5>
+  {% if review.submission.file_path %}
+  <iframe src="{{ url_for('static', filename=review.submission.file_path) }}" width="100%" height="600"></iframe>
+  {% elif review.submission.content %}
+  <div class="border p-3 mb-4">{{ review.submission.content|safe }}</div>
+  {% endif %}
   <form method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="mb-3">
       <label>Código de Acesso</label>
       <input type="text" name="codigo" class="form-control" required>
     </div>
-    <div class="mb-3">
-      <label>Nota (1-5)</label>
-      <input type="number" name="nota" class="form-control">
-    </div>
+    {% if barema and barema.requisitos %}
+      {% for requisito, faixa in barema.requisitos.items() %}
+      <div class="mb-3">
+        <label class="form-label">{{ requisito }} ({{ faixa['min'] }}-{{ faixa['max'] }})</label>
+        <input type="number" class="form-control" name="{{ requisito }}" min="{{ faixa['min'] }}" max="{{ faixa['max'] }}" value="{{ review.scores[requisito] if review and review.scores }}">
+      </div>
+      {% endfor %}
+    {% else %}
+      <div class="mb-3">
+        <label>Nota (1-5)</label>
+        <input type="number" name="nota" class="form-control">
+      </div>
+    {% endif %}
     <div class="mb-3">
       <label>Comentários</label>
       <textarea name="comentarios" class="form-control"></textarea>

--- a/tests/test_peer_review_barema.py
+++ b/tests/test_peer_review_barema.py
@@ -1,0 +1,124 @@
+import sys
+import types
+
+import pytest
+from werkzeug.security import generate_password_hash
+from flask import Flask
+
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = "sqlite://"
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+# Stub mercadopago before importing routes
+mercadopago_stub = types.ModuleType("mercadopago")
+mercadopago_stub.SDK = lambda *a, **k: None
+sys.modules.setdefault("mercadopago", mercadopago_stub)
+
+from extensions import db
+from models import (
+    Cliente,
+    Evento,
+    Submission,
+    Review,
+    Assignment,
+    Usuario,
+    EventoBarema,
+)
+from routes.peer_review_routes import peer_review_routes
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.secret_key = "test"
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = Config.build_engine_options("sqlite://")
+    db.init_app(app)
+    app.register_blueprint(peer_review_routes)
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome="Cli", email="cli@test", senha=generate_password_hash("123"))
+        db.session.add(cliente)
+        db.session.flush()
+        evento = Evento(cliente_id=cliente.id, nome="Evento", inscricao_gratuita=True)
+        reviewer = Usuario(
+            nome="Rev",
+            cpf="1",
+            email="rev@test",
+            senha=generate_password_hash("123"),
+            formacao="X",
+            tipo="professor",
+        )
+        submission = Submission(
+            title="T",
+            content="Body",
+            code_hash=generate_password_hash("code"),
+            evento_id=evento.id,
+        )
+        db.session.add_all([evento, reviewer, submission])
+        db.session.flush()
+        assignment = Assignment(submission_id=submission.id, reviewer_id=reviewer.id)
+        review = Review(
+            submission_id=submission.id,
+            reviewer_id=reviewer.id,
+            locator="loc",
+            access_code="12345678",
+        )
+        barema = EventoBarema(
+            evento_id=evento.id, requisitos={"Qualidade": {"min": 1, "max": 5}}
+        )
+        db.session.add_all([assignment, review, barema])
+        db.session.commit()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _get_review(app):
+    with app.app_context():
+        return Review.query.first()
+
+
+def test_review_template_displays_barema_and_content(client, app):
+    review = _get_review(app)
+    resp = client.get(f"/review/{review.locator}")
+    assert b"Body" in resp.data
+    assert b"(1-5)" in resp.data
+    assert b'min="1"' in resp.data
+    assert b'max="5"' in resp.data
+
+
+def test_review_rejects_score_out_of_range(client, app):
+    review = _get_review(app)
+    resp = client.post(
+        f"/review/{review.locator}",
+        data={"codigo": review.access_code, "Qualidade": "6"},
+    )
+    assert b"deve estar entre 1 e 5" in resp.data
+    with app.app_context():
+        stored = Review.query.get(review.id)
+        assert stored.scores is None
+
+
+def test_review_accepts_valid_score(client, app):
+    review = _get_review(app)
+    resp = client.post(
+        f"/review/{review.locator}",
+        data={"codigo": review.access_code, "Qualidade": "3"},
+    )
+    assert resp.status_code in (302, 200)
+    with app.app_context():
+        stored = Review.query.get(review.id)
+        assert stored.scores == {"Qualidade": 3.0}
+        assert stored.note == 3.0
+


### PR DESCRIPTION
## Summary
- Exibe arquivo ou conteúdo da submissão na página de revisão
- Gera campos conforme EventoBarema e valida notas dentro dos limites
- Adiciona testes garantindo exibição e validação do barema no fluxo de revisão

## Testing
- `pytest` *(falha: vários testes existentes apresentam erros)*

------
https://chatgpt.com/codex/tasks/task_e_68a135480820832495bd9c3940005b18