### PR TITLE
Add alias for reviewer assignment endpoint

### DIFF
--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -115,6 +115,7 @@ def assign_reviews():
 # ---------------------------------------------------------------------------
 # Atribuição por filtros para revisores aprovados
 # ---------------------------------------------------------------------------
+@peer_review_routes.route("/revisores/sortear", methods=["POST"])
 @peer_review_routes.route("/assign_by_filters", methods=["POST"])
 @login_required
 def assign_by_filters():

--- a/tests/test_sortear_revisores.py
+++ b/tests/test_sortear_revisores.py
@@ -21,6 +21,7 @@ from models import (
     Submission,
     Usuario,
     Assignment,
+    Evento,
 )
 
 
@@ -45,9 +46,13 @@ def app():
                 num_revisores_max=1,
             )
         )
+        evento = Evento(cliente_id=cliente.id, nome='E1')
+        db.session.add(evento)
+        db.session.flush()
         proc = RevisorProcess(cliente_id=cliente.id)
         db.session.add(proc)
         db.session.flush()
+        proc.eventos.append(evento)
         db.session.add(
             RevisorCandidatura(
                 process_id=proc.id,
@@ -84,8 +89,8 @@ def app():
                 tipo='revisor',
             )
         )
-        db.session.add(Submission(title='S1', code_hash='h1'))
-        db.session.add(Submission(title='S2', code_hash='h2'))
+        db.session.add(Submission(title='S1', code_hash='h1', evento_id=evento.id))
+        db.session.add(Submission(title='S2', code_hash='h2', evento_id=evento.id))
         db.session.commit()
     yield app
 
@@ -102,7 +107,7 @@ def login(client, email, senha):
 def test_sortear_revisores_limits(client, app):
     login(client, 'cli@example.com', '123')
     resp = client.post(
-        '/revisores/sortear',
+        '/assign_by_filters',
         json={'filters': {'area': 'bio'}, 'limit': 1, 'max_per_submission': 1},
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Alias `/revisores/sortear` to existing `/assign_by_filters`
- Update reviewer assignment tests to target `/assign_by_filters`
- Ensure reviewer assignment tests include event context

## Testing
- `pytest tests/test_assign_by_filters.py tests/test_sortear_revisores.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a134fd98a48324bf85c7a8916b0286