### PR TITLE
Validate reviewer stage names and handle missing steps

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -115,7 +115,11 @@ def config_revisor():
 
 
     if request.method == "POST":
-        dados = parse_revisor_form(request)
+        try:
+            dados = parse_revisor_form(request)
+        except ValueError as exc:
+            flash(str(exc), "danger")
+            return redirect(url_for("revisor_routes.config_revisor"))
         if not processo:
             processo = RevisorProcess(cliente_id=current_user.id)  # type: ignore[attr-defined]
             db.session.add(processo)

--- a/tests/test_revisor_helpers.py
+++ b/tests/test_revisor_helpers.py
@@ -54,6 +54,7 @@ def test_parse_revisor_form(app):
             "availability_end": "2024-01-20",
 
             "exibir_para_participantes": "on",
+            "eventos_ids": [1, 2],
 
         },
     ):
@@ -66,6 +67,14 @@ def test_parse_revisor_form(app):
     assert dados["exibir_para_participantes"] is True
     assert dados["eventos_ids"] == [1, 2]
 
+
+def test_parse_revisor_form_missing_stage(app):
+    with app.test_request_context(
+        method="POST",
+        data={"num_etapas": 2, "stage_name": ["Etapa 1"]},
+    ):
+        with pytest.raises(ValueError):
+            parse_revisor_form(request)
 
 def test_update_and_recreate_stages(app):
     with app.app_context():


### PR DESCRIPTION
## Summary
- validate required stage names in reviewer config parsing
- flash an error when stages are missing in reviewer config view
- add tests for missing stage names and ensure event associations flush

## Testing
- `pytest tests/test_revisor_helpers.py -q`
- `env SECRET_KEY=test GOOGLE_CLIENT_ID=x GOOGLE_CLIENT_SECRET=y pytest tests/test_revisor_process_extra.py::test_config_route_saves_availability tests/test_revisor_process_extra.py::test_config_route_saves_eventos -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1350a90388324a1df508d061d25b8