### PR TITLE
Add reviewer filter inputs for automatic assignment

### DIFF
--- a/static/js/config_revisao.js
+++ b/static/js/config_revisao.js
@@ -111,13 +111,18 @@
   });
 
   attachOnce(document.getElementById('assignAutomatic'), 'click', () => {
+    const filters = {};
+    document.querySelectorAll('[data-filter]').forEach((el) => {
+      const valor = el.value.trim();
+      if (valor) filters[el.dataset.filter] = valor;
+    });
     fetch('/assign_by_filters', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFToken': csrfToken,
       },
-      body: JSON.stringify({ filters: {} }),
+      body: JSON.stringify({ filters }),
     })
       .then((r) => r.json())
       .then((data) => {

--- a/templates/peer_review/submission_control.html
+++ b/templates/peer_review/submission_control.html
@@ -56,8 +56,23 @@
         Selecione entre {{ config.num_revisores_min if config else 1 }} e {{ config.num_revisores_max if config else 2 }} revisores.
       </small>
     </div>
+    <div class="row g-3 mb-3">
+      <div class="col-md-4">
+        <label for="filterArea" class="form-label">Área</label>
+        <input type="text" id="filterArea" class="form-control" data-filter="area" placeholder="Ex.: Computação" />
+      </div>
+      <div class="col-md-4">
+        <label for="filterNivel" class="form-label">Nível</label>
+        <input type="text" id="filterNivel" class="form-control" data-filter="nivel" placeholder="Ex.: Doutorado" />
+      </div>
+    </div>
+    <small class="form-text text-muted mb-3">
+      Filtros disponíveis: área e nível. Deixe em branco para incluir todos os revisores.
+    </small>
     <button id="assignManual" class="btn btn-primary me-2">Atribuir Manualmente</button>
-    <button id="assignAutomatic" class="btn btn-secondary me-2">Sorteio Automático</button>
+    <button id="assignAutomatic" class="btn btn-secondary me-2" data-bs-toggle="tooltip" title="Sorteia revisores usando os filtros preenchidos">
+      Sorteio Automático
+    </button>
     <div class="input-group mt-2" style="max-width: 300px;">
       <input type="number" id="eventoId" class="form-control" placeholder="ID do Evento" />
       <button id="autoArea" class="btn btn-info">Auto por Área</button>


### PR DESCRIPTION
## Summary
- allow filtering reviewers by area and level when auto assigning
- send selected filter values to `/assign_by_filters`
- document available filters and tooltip on automatic assignment

## Testing
- `pytest` *(fails: tests failing, view log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68a135114e848324bd6b83c1f157cb38