### PR TITLE
Handle CPF collisions in reviewer approval

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -502,12 +502,28 @@ def approve(cand_id: int):
         if not reviewer:
             reviewer = Usuario(
                 nome=cand.nome or cand.email,
-                cpf=str(uuid.uuid4().int)[:11],
                 email=cand.email,
                 senha=generate_password_hash("temp123"),
                 formacao="",
                 tipo="revisor",
             )
+            for _ in range(5):
+                novo_cpf = str(uuid.uuid4().int)[:11]
+                if not Usuario.query.filter_by(cpf=novo_cpf).first():
+                    reviewer.cpf = novo_cpf
+                    break
+            else:  # pragma: no cover - defensive branch
+                current_app.logger.error(
+                    "Falha ao gerar CPF único para revisor %s", cand.email
+                )
+                err_msg = (
+                    "Erro ao gerar CPF único. "
+                    "Tente novamente ou contate o suporte."
+                )
+                if request.is_json:
+                    return jsonify({"success": False, "error": err_msg}), 500
+                flash(err_msg, "danger")
+                return redirect(url_for("dashboard_routes.dashboard_cliente"))
             db.session.add(reviewer)
             db.session.flush()
         else:


### PR DESCRIPTION
## Summary
- ensure reviewer approval generates unique CPF and logs repeated collisions
- notify operator on repeated CPF collisions
- add tests to simulate CPF collisions and ensure behaviour

## Testing
- `python -m pip install -r requirements-dev.txt`
- `python -m pip install beautifulsoup4`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pytest` *(fails: multiple tests failing)*
- `SECRET_KEY=test pytest tests/test_reviewer_applications.py -k "approve_revisor_cpf_collision"`


------
https://chatgpt.com/codex/tasks/task_e_68a13521b19483249d9d159f028c91df