### PR TITLE
Replace auto PDF redirect with download link

### DIFF
--- a/templates/revisor/progress.html
+++ b/templates/revisor/progress.html
@@ -15,12 +15,8 @@
       {% endfor %}
     </tbody>
   </table>
+  {% if pdf_url %}
+  <a class="btn btn-primary" href="{{ pdf_url }}" target="_blank">Baixar PDF</a>
+  {% endif %}
 </div>
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    {% if pdf_url %}
-    window.location.href = '{{ pdf_url }}';
-    {% endif %}
-  });
-</script>
 {% endblock %}

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -163,7 +163,10 @@ def test_application_and_approval_flow(client, app):
 
     resp = client.get(f"/revisor/progress/{code}")
     assert resp.status_code == 200
-    assert code in resp.get_data(as_text=True)
+    html = resp.get_data(as_text=True)
+    assert code in html
+    assert "Baixar PDF" in html
+    assert f"/revisor/progress/{code}/pdf" in html
 
     login(client, "cli@test", "123")
     resp = client.post(f"/revisor/approve/{cand_id}", json={})


### PR DESCRIPTION
## Summary
- show explicit "Baixar PDF" button on progress page instead of automatic redirect
- test progress page for download link

## Testing
- `pytest` *(fails: assert not True, BuildError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a1352734d08324ba836d1545fe8721