### PR TITLE
Send review access codes and log email failures

### DIFF
--- a/migrations/versions/6d0c1bfa2e5b_add_review_email_log.py
+++ b/migrations/versions/6d0c1bfa2e5b_add_review_email_log.py
@@ -1,0 +1,30 @@
+"""add table for review email failures"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "6d0c1bfa2e5b"
+down_revision = "25eb3573df18"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "review_email_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("review_id", sa.Integer(), sa.ForeignKey("review.id"), nullable=False),
+        sa.Column("recipient", sa.String(length=255), nullable=False),
+        sa.Column("error", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("review_email_log")

--- a/models.py
+++ b/models.py
@@ -1829,6 +1829,23 @@ class Review(db.Model):
 
 
 # -----------------------------------------------------------------------------
+# LOG DE FALHA DE E-MAIL DE REVIEW
+# -----------------------------------------------------------------------------
+class ReviewEmailLog(db.Model):
+    """Registra falhas no envio de e-mails de revisão."""
+
+    __tablename__ = "review_email_log"
+
+    id = db.Column(db.Integer, primary_key=True)
+    review_id = db.Column(db.Integer, db.ForeignKey("review.id"), nullable=False)
+    recipient = db.Column(db.String(255), nullable=False)
+    error = db.Column(db.String(255), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    review = db.relationship("Review", backref=db.backref("email_logs", lazy=True))
+
+
+# -----------------------------------------------------------------------------
 # ASSIGNMENT (vincula revisor ↔ submissão)
 # -----------------------------------------------------------------------------
 class Assignment(db.Model):

--- a/routes/dashboard_professor.py
+++ b/routes/dashboard_professor.py
@@ -1,5 +1,6 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask import Blueprint, render_template, redirect, url_for
 from flask_login import login_required, current_user
+from models import AgendamentoVisita, Review
 
 dashboard_professor_routes = Blueprint("dashboard_professor", __name__)
 
@@ -8,13 +9,17 @@ dashboard_professor_routes = Blueprint("dashboard_professor", __name__)
 def dashboard_professor():
     if current_user.tipo != 'professor':
         return redirect(url_for('dashboard_routes.dashboard'))
-    
+
     # Buscando os agendamentos do professor logado
-    agendamentos_professor = AgendamentoVisita.query.filter_by(professor_id=current_user.id).all()
+    agendamentos_professor = AgendamentoVisita.query.filter_by(
+        professor_id=current_user.id
+    ).all()
+    reviews = Review.query.filter_by(reviewer_id=current_user.id).all()
 
     return render_template(
-        'dashboard_professor.html', 
-        agendamentos=agendamentos_professor
+        'dashboard_professor.html',
+        agendamentos=agendamentos_professor,
+        reviews=reviews,
     )
 
 

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -17,6 +17,7 @@ from models import (
     RevisorCandidatura,
     RevisorProcess,
 )
+from services.review_notification_service import notify_reviewer
 
 import uuid
 from datetime import datetime, timedelta
@@ -86,6 +87,8 @@ def assign_reviews():
                 access_code=str(uuid.uuid4())[:8],
             )
             db.session.add(rev)
+            db.session.flush()
+            notify_reviewer(rev)
 
             evento = Evento.query.get(trabalho.evento_id)
             cliente_id = evento.cliente_id if evento else None
@@ -256,6 +259,8 @@ def auto_assign(evento_id):
                 access_code=str(uuid.uuid4())[:8],
             )
             db.session.add(rev)
+            db.session.flush()
+            notify_reviewer(rev)
 
             config_cli = ConfiguracaoCliente.query.filter_by(
                 cliente_id=t.evento.cliente_id
@@ -306,6 +311,8 @@ def create_review():
         access_code=str(uuid.uuid4())[:8],
     )
     db.session.add(rev)
+    db.session.flush()
+    notify_reviewer(rev)
     db.session.commit()
 
     if request.is_json:

--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -14,6 +14,7 @@ from werkzeug.security import generate_password_hash
 from models import Submission, Review, Assignment, ConfiguracaoCliente, AuditLog
 from extensions import db
 from services.mailjet_service import send_via_mailjet
+from services.review_notification_service import notify_reviewer
 from mailjet_rest.client import ApiError
 import logging
 
@@ -92,6 +93,8 @@ def add_review(locator):
         comments=comment,
     )
     db.session.add(review)
+    db.session.flush()
+    notify_reviewer(review)
 
     cliente_id = submission.author.cliente_id if submission.author else None
     config = None

--- a/services/review_notification_service.py
+++ b/services/review_notification_service.py
@@ -1,0 +1,59 @@
+"""Utilities for sending review notifications and logging failures."""
+
+import logging
+from flask import url_for
+from mailjet_rest.client import ApiError
+
+from extensions import db
+from models import ReviewEmailLog
+from services.mailjet_service import send_via_mailjet
+
+logger = logging.getLogger(__name__)
+
+
+def notify_reviewer(review):
+    """Send access details to the assigned reviewer via e-mail.
+
+    If sending fails, a ``ReviewEmailLog`` entry is created so failures can be
+    audited later.
+    """
+    if not review.reviewer or not review.reviewer.email:
+        return
+
+    link = url_for(
+        "peer_review_routes.review_form", locator=review.locator, _external=True
+    )
+    text = (
+        "Você foi designado para avaliar um trabalho.\n"
+        f"Acesse: {link}\nCódigo: {review.access_code}"
+    )
+
+    try:
+        send_via_mailjet(
+            to_email=review.reviewer.email,
+            subject="Novo parecer disponível",
+            text=text,
+        )
+    except ApiError as exc:  # pragma: no cover - network errors are rare
+        logger.exception(
+            "Erro ao enviar e-mail de revisão para %s", review.reviewer.email
+        )
+        db.session.add(
+            ReviewEmailLog(
+                review_id=review.id,
+                recipient=review.reviewer.email,
+                error=str(exc),
+            )
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.exception(
+            "Erro inesperado ao enviar e-mail de revisão para %s",
+            review.reviewer.email,
+        )
+        db.session.add(
+            ReviewEmailLog(
+                review_id=review.id,
+                recipient=review.reviewer.email,
+                error=str(exc),
+            )
+        )

--- a/templates/dashboard/dashboard_professor.html
+++ b/templates/dashboard/dashboard_professor.html
@@ -91,6 +91,31 @@
         </div>
       </div>
     </div>
+
+    <!-- Códigos de Revisão -->
+    <div class="col-md-6 col-lg-4">
+      <div class="card h-100 shadow border-0 rounded-3 overflow-hidden">
+        <div class="card-header bg-secondary text-white py-3">
+          <h5 class="card-title mb-0">
+            <i class="bi bi-key me-2"></i>Códigos de Revisão
+          </h5>
+        </div>
+        <div class="card-body">
+          {% if reviews %}
+            <ul class="list-group list-group-flush border-0">
+              {% for rev in reviews %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  {{ rev.submission.title if rev.submission else 'N/A' }}
+                  <span class="badge bg-primary">{{ rev.access_code }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="mb-0">Nenhum parecer atribuído.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
   </div>
 
 


### PR DESCRIPTION
## Summary
- notify reviewers by email when a review is assigned and store any send failures
- surface assigned review access codes on the professor dashboard

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ImportError while importing tests/test_dashboard_cliente_preview.py: No module named 'bs4'; 54 failed, 99 passed, 175 warnings, 5 errors, as per tests/test_revisor_avaliar_assignment.py, tests/test_revisor_email_notifications.py, tests/test_revisor_helpers.py, tests/test_revisor_process.py, tests/test_revisor_process_extra.py, tests/test_reviewer_applications.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a1354aa06c832488b2b020266f6abd