### PR TITLE
Remove outdated AvaliacaoTrabalho import

### DIFF
--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -14,9 +14,6 @@ from utils.mfa import mfa_required
 from extensions import db
 from models import (
     Submission,
-
-    AvaliacaoTrabalho,
-
     AuditLog,
     Evento,
     Usuario,


### PR DESCRIPTION
## Summary
- drop deprecated AvaliacaoTrabalho model import from trabalho routes

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: No module named 'bs4'; ImportError: cannot import name 'ReviewEmailLog')*


------
https://chatgpt.com/codex/tasks/task_e_68a140887b808324ad35a97522aae5c4