### PR TITLE
Remove duplicate password hash import

### DIFF
--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -27,9 +27,6 @@ from models import (
 import uuid
 import os
 
-from werkzeug.security import generate_password_hash
-
-
 trabalho_routes = Blueprint(
     "trabalho_routes",
     __name__,


### PR DESCRIPTION
## Summary
- tidy up imports in `trabalho_routes` to eliminate duplicate `generate_password_hash`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ImportError: cannot import name 'AvaliacaoTrabalho' from 'models')*

------
https://chatgpt.com/codex/tasks/task_e_68a1408974c48324a69b9cbe83c60efd