### PR TITLE
Remove unused AvaliacaoTrabalho import

### DIFF
--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -15,9 +15,6 @@ from utils.mfa import mfa_required
 from extensions import db
 from models import (
     Submission,
-
-    AvaliacaoTrabalho,
-
     AuditLog,
     Evento,
     Usuario,


### PR DESCRIPTION
## Summary
- clean up trabalho routes by removing unused AvaliacaoTrabalho import

## Testing
- `SECRET_KEY=dummy GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy python wsgi.py`
- `SECRET_KEY=dummy GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy pytest` *(fails: No module named 'bs4'; cannot import name 'ReviewEmailLog')*

------
https://chatgpt.com/codex/tasks/task_e_68a144f20abc83248c3870313a623516