### PR TITLE
Log warning when review lacks email destination

### DIFF
--- a/services/review_notification_service.py
+++ b/services/review_notification_service.py
@@ -18,6 +18,9 @@ def notify_reviewer(review):
     audited later.
     """
     if not review.reviewer or not review.reviewer.email:
+        logger.warning(
+            "Review %s has no email destination; skipping notification", review.id
+        )
         return
 
     link = url_for(


### PR DESCRIPTION
## Summary
- warn when a review has no e-mail destination

## Testing
- `pytest tests/test_revisor_email_notifications.py` *(fails: ImportError: cannot import name 'ReviewEmailLog')*


------
https://chatgpt.com/codex/tasks/task_e_68a14823fe908324ae3ba4df3878d6b3