### PR TITLE
Fix models import block in dashboard_cliente

### DIFF
--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -6,11 +6,11 @@ import logging
 logger = logging.getLogger(__name__)
 from sqlalchemy import func, and_, or_
 from datetime import datetime, timedelta
-
-    Evento, Oficina, Inscricao, Checkin,
-    ConfiguracaoCliente, AgendamentoVisita, HorarioVisitacao, Usuario,
-    EventoInscricaoTipo, Configuracao, ReviewerApplication,
-    RevisorCandidatura, RevisorProcess
+from models import (
+Evento, Oficina, Inscricao, Checkin,
+ConfiguracaoCliente, AgendamentoVisita, HorarioVisitacao, Usuario,
+EventoInscricaoTipo, Configuracao, ReviewerApplication,
+RevisorCandidatura, RevisorProcess
 )
 
 # Modelos opcionais usados no dashboard de agendamentos. Em alguns ambientes


### PR DESCRIPTION
## Summary
- add missing models import block in dashboard_cliente

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` (fails: 33 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68a1e2c3ed8c8324a1ae6d96099c612c