### PR TITLE
Fix missing models import in dashboard participante route

### DIFF
--- a/routes/dashboard_participante.py
+++ b/routes/dashboard_participante.py
@@ -9,9 +9,16 @@ from sqlalchemy.exc import ProgrammingError
 logger = logging.getLogger(__name__)
 
 from extensions import db
-
-    Evento, Oficina, OficinaDia, ConfiguracaoCliente, ConfiguracaoEvento, HorarioVisitacao,
-    Usuario, Formulario, RegraInscricaoEvento
+from models import (
+    Evento,
+    Oficina,
+    OficinaDia,
+    ConfiguracaoCliente,
+    ConfiguracaoEvento,
+    HorarioVisitacao,
+    Usuario,
+    Formulario,
+    RegraInscricaoEvento,
 )
 
 dashboard_participante_routes = Blueprint('dashboard_participante_routes', __name__)


### PR DESCRIPTION
## Summary
- import missing models in `dashboard_participante`

## Testing
- `pytest` *(fails: Interrupted: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eb6016e083248a26193f5888b080