### PR TITLE
Use logger.exception for detailed error logs

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -44,7 +44,7 @@ def home():
         return render_template('index.html',
                                eventos_destaque=_serializa_eventos(eventos))
     except Exception as e:
-        logger.error("home(): %s", e)
+        logger.exception("home(): %s", e)
         db.session.rollback()  # ensure session not left in failed state
         return render_template('index.html', eventos_destaque=[])
 
@@ -170,9 +170,9 @@ def listar_eventos():
             eventos_processed.append(evento_dict)
         
         return render_template('evento/eventos_disponiveis.html', eventos=eventos_processed)
-    
+
     except Exception as e:
-        logger.error("Erro em listar_eventos: %s", str(e))
+        logger.exception("Erro em listar_eventos: %s", e)
         return render_template('evento/eventos_disponiveis.html', eventos=[])
 
 @evento_routes.route('/configurar_evento', methods=['GET', 'POST'])
@@ -591,9 +591,7 @@ def configurar_evento():
             db.session.rollback()
             flash(f'Erro ao salvar evento: {str(e)}', 'danger')
             # Adicionar log para debugging
-            logger.error("Erro ao salvar evento: %s", str(e))
-            import traceback
-            traceback.print_exc()
+            logger.exception("Erro ao salvar evento: %s", e)
 
     return render_template(
         "evento/configurar_evento.html",

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -791,18 +791,18 @@ def inscrever(oficina_id):
                 oficina=oficina,
             )
 
-            enviar_email(
-                destinatario=current_user.email,
-                nome_participante=current_user.nome,
-                nome_oficina=oficina.titulo,
-                assunto=assunto,
-                corpo_texto=corpo_texto,
-                anexo_path=pdf_path,
-                corpo_html=corpo_html,
-            )
-        except Exception as e:
-            logger.error(f"❌ ERRO ao enviar e-mail: {e}", exc_info=True)
-            # Continuamos mesmo se houver erro no e-mail, pois a inscrição já foi concluída
+        enviar_email(
+            destinatario=current_user.email,
+            nome_participante=current_user.nome,
+            nome_oficina=oficina.titulo,
+            assunto=assunto,
+            corpo_texto=corpo_texto,
+            anexo_path=pdf_path,
+            corpo_html=corpo_html,
+        )
+    except Exception as e:
+        logger.exception("❌ ERRO ao enviar e-mail: %s", e)
+        # Continuamos mesmo se houver erro no e-mail, pois a inscrição já foi concluída
             
         return jsonify({
             'success': True,
@@ -812,7 +812,7 @@ def inscrever(oficina_id):
         
     except Exception as e:
         db.session.rollback()
-        logger.error(f"❌ ERRO ao realizar inscrição: {e}", exc_info=True)
+        logger.exception("❌ ERRO ao realizar inscrição: %s", e)
         return jsonify({
             'success': False,
             'message': f'Erro ao realizar inscrição: {str(e)}'
@@ -1009,7 +1009,7 @@ def inscrever_participantes_lote():
     except Exception as e:
         db.session.rollback()
         flash(f"Erro ao inscrever participantes em lote: {str(e)}", "danger")
-        logger.error("Erro ao inscrever participantes: %s", e)
+        logger.exception("Erro ao inscrever participantes: %s", e)
 
     return redirect(url_for('dashboard_routes.dashboard'))
 


### PR DESCRIPTION
## Summary
- switch exception handlers in event and registration routes to `logger.exception` for stack traces

## Testing
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eeb19700832493fe596a6e0199ab