### PR TITLE
Remove per-module logging configuration

### DIFF
--- a/_test_mp.py
+++ b/_test_mp.py
@@ -3,9 +3,8 @@ import sys
 import os
 from services.mp_service import get_sdk
 
-# Configuração básica de logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger("mp_test")
+# Logger do módulo
+logger = logging.getLogger(__name__)
 
 def main():
     logger.info("Testando conexão com o Mercado Pago")

--- a/_test_mp_integration.py
+++ b/_test_mp_integration.py
@@ -6,9 +6,7 @@ from dotenv import load_dotenv
 # Carregar variáveis de ambiente do .env
 load_dotenv()
 
-# Configurar logging
-logging.basicConfig(level=logging.INFO, 
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# Logger do módulo
 logger = logging.getLogger(__name__)
 
 # Tentar importar o módulo mercadopago

--- a/_test_mp_urls.py
+++ b/_test_mp_urls.py
@@ -3,9 +3,7 @@ import logging
 from flask import Flask, url_for, request
 import sys
 
-# Configurar logging
-logging.basicConfig(level=logging.INFO, 
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# Logger do módulo
 logger = logging.getLogger(__name__)
 
 # Criar uma aplicação Flask simples para testar a geração de URLs

--- a/debug_mp.py
+++ b/debug_mp.py
@@ -7,9 +7,7 @@ from dotenv import load_dotenv
 # Carregar variáveis de ambiente do .env
 load_dotenv()
 
-# Configurar logging
-logging.basicConfig(level=logging.DEBUG, 
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# Logger deste módulo
 logger = logging.getLogger(__name__)
 
 # Tentar importar o módulo mercadopago

--- a/mp_fix_patch.py
+++ b/mp_fix_patch.py
@@ -8,9 +8,7 @@ import logging
 from flask import request, current_app, url_for
 import os
 
-# Configurar logging
-logging.basicConfig(level=logging.INFO, 
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# Logger do módulo
 logger = logging.getLogger(__name__)
 
 # Função para gerar URLs absolutas corretamente

--- a/mp_patch.py
+++ b/mp_patch.py
@@ -8,9 +8,7 @@ import sys
 import logging
 from dotenv import load_dotenv
 
-# Configurar logging
-logging.basicConfig(level=logging.INFO, 
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+# Logger do módulo
 logger = logging.getLogger(__name__)
 
 # Carregar variáveis de ambiente

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3522,8 +3522,7 @@ from reportlab.lib.utils import ImageReader
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfbase import pdfmetrics
 
-# Configuração de logging
-logging.basicConfig(level=logging.DEBUG)
+# Logger do módulo
 logger = logging.getLogger(__name__)
 
 # Escopo necessário para envio de e-mails


### PR DESCRIPTION
## Summary
- remove `logging.basicConfig` calls in Mercado Pago scripts and PDF service
- use module-level loggers that rely on centralized logging setup

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError and missing SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eeae75f88324b6cc5e28492fc307