### PR TITLE
Remove redundant login_required import

### DIFF
--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -1,6 +1,25 @@
-from flask import render_template, request, redirect, url_for, flash, jsonify, session
+from flask import (
+    Blueprint,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_login import login_required, current_user
-from models import Oficina, OficinaDia, Evento, Checkin, Inscricao, MaterialOficina, RelatorioOficina, InscricaoTipo, Feedback
+from models import (
+    Oficina,
+    OficinaDia,
+    Evento,
+    Checkin,
+    Inscricao,
+    MaterialOficina,
+    RelatorioOficina,
+    InscricaoTipo,
+    Feedback,
+)
 from models.user import Ministrante, Cliente
 from extensions import db
 import logging
@@ -8,12 +27,7 @@ import logging
 logger = logging.getLogger(__name__)
 from datetime import datetime
 from utils import obter_estados  # ou de onde essa função vem
-from routes.auth_routes import login_required
 from sqlalchemy import text
-
-    Usuario, CampoPersonalizadoCadastro, RespostaCampo, RespostaFormulario
-)
-from flask import Blueprint
 
 oficina_routes = Blueprint('oficina_routes', __name__, template_folder="../templates/oficina")
 


### PR DESCRIPTION
## Summary
- clean up oficina routes by importing `login_required` only from `flask_login`
- organize imports and drop unused model references

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8bf008c8324ab47187f956156dc