### PR TITLE
Clean unused imports in oficina routes

### DIFF
--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -1,19 +1,33 @@
-from flask import render_template, request, redirect, url_for, flash, jsonify, session
+from flask import (
+    Blueprint,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_login import login_required, current_user
-from models import Oficina, OficinaDia, Evento, Checkin, Inscricao, MaterialOficina, RelatorioOficina, InscricaoTipo, Feedback
+from models import (
+    Oficina,
+    OficinaDia,
+    Evento,
+    Checkin,
+    Inscricao,
+    MaterialOficina,
+    RelatorioOficina,
+    InscricaoTipo,
+    Feedback,
+)
 from models.user import Ministrante, Cliente
 from extensions import db
 import logging
-
-logger = logging.getLogger(__name__)
 from datetime import datetime
 from utils import obter_estados  # ou de onde essa função vem
-from routes.auth_routes import login_required
 from sqlalchemy import text
 
-    Usuario, CampoPersonalizadoCadastro, RespostaCampo, RespostaFormulario
-)
-from flask import Blueprint
+logger = logging.getLogger(__name__)
 
 oficina_routes = Blueprint('oficina_routes', __name__, template_folder="../templates/oficina")
 


### PR DESCRIPTION
## Summary
- streamline oficina_routes imports by dropping unused model references
- organize flask and model imports for clarity

## Testing
- `python -m py_compile routes/oficina_routes.py`
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8c14d988324a5b840194afeaf80