### PR TITLE
Allow event clients to cancel their agendamentos

### DIFF
--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -152,7 +152,10 @@
                         </a>
                       {% endif %}
                       
-                      {% if current_user.is_admin or current_user.id == agendamento.professor_id %}
+                      {% if current_user.is_admin
+                            or current_user.id == agendamento.professor_id
+                            or (current_user.tipo == 'cliente'
+                                and current_user.id == agendamento.horario.evento.cliente_id) %}
                         <form action="{{ url_for('agendamento_routes.atualizar_status_agendamento', agendamento_id=agendamento.id) }}"
                               method="post" class="d-inline" onsubmit="return confirm('Tem certeza que deseja cancelar este agendamento?');">
                           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
## Summary
- show cancel button to event owners

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: DB_PASS environment variable is required)*
- manual Jinja render to verify button visibility for client owners

------
https://chatgpt.com/codex/tasks/task_e_68a631e0b8b48324bd3b0049570d5c6d