### PR TITLE
Allow viewing and scheduling upcoming events

### DIFF
--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -40,7 +40,6 @@ def eventos_disponiveis_professor():
     
     # Buscar eventos disponíveis para agendamento
     eventos = Evento.query.filter(
-        Evento.data_inicio <= datetime.utcnow(),
         Evento.data_fim >= datetime.utcnow(),
         Evento.status == 'ativo'
     ).all()
@@ -128,7 +127,7 @@ def horarios_disponiveis_professor(evento_id):
     ).filter(HorarioVisitacao.vagas_disponiveis > 0)
     
     # Filtrar apenas datas futuras (a partir de amanhã)
-    amanha = datetime.now().date() + timedelta(days=1)
+    amanha = datetime.utcnow().date() + timedelta(days=1)
     query = query.filter(HorarioVisitacao.data >= amanha)
     
     # Aplicar filtro por data específica
@@ -605,7 +604,7 @@ def horarios_disponiveis_participante(evento_id):
 
     query = HorarioVisitacao.query.filter_by(evento_id=evento_id).filter(
         HorarioVisitacao.vagas_disponiveis > 0,
-        HorarioVisitacao.data >= datetime.now().date() + timedelta(days=1)
+        HorarioVisitacao.data >= datetime.utcnow().date() + timedelta(days=1)
     )
 
     if data_filtro:

--- a/templates/evento/eventos_disponiveis.html
+++ b/templates/evento/eventos_disponiveis.html
@@ -45,7 +45,7 @@
         </div>
     {% else %}
         <div class="alert alert-info">
-            <i class="fas fa-info-circle"></i> Você ainda não possui agendamentos.
+            <i class="fas fa-info-circle"></i> Nenhum evento disponível no momento.
         </div>
     {% endif %}
     

--- a/templates/professor/eventos_disponiveis.html
+++ b/templates/professor/eventos_disponiveis.html
@@ -45,7 +45,7 @@
         </div>
     {% else %}
         <div class="alert alert-info">
-            <i class="fas fa-info-circle"></i> Você ainda não possui agendamentos.
+            <i class="fas fa-info-circle"></i> Nenhum evento disponível no momento.
         </div>
     {% endif %}
     


### PR DESCRIPTION
## Summary
- relax professor event listing to include upcoming events
- ensure professor and participant schedule listings filter by future dates
- clarify empty-event messages in templates

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: DB_PASS environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a631e398488324ace975f94d75401d