### PR TITLE
Map weekday numbers to Portuguese names

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -14,6 +14,7 @@ from mailjet_rest.client import ApiError
 import logging
 
 from utils.arquivo_utils import arquivo_permitido
+from utils.dia_semana import dia_semana
 
 logger = logging.getLogger(__name__)
 
@@ -2194,17 +2195,7 @@ def criar_periodo_agendamento():
                     # Como não sabemos a estrutura exata do seu modelo,
                     # vamos apenas exibir uma mensagem de sucesso simulada
                     
-                    # Converter lista de strings para dias da semana
-                    dias_nomes = {
-                        '0': 'Domingo',
-                        '1': 'Segunda',
-                        '2': 'Terça',
-                        '3': 'Quarta',
-                        '4': 'Quinta',
-                        '5': 'Sexta',
-                        '6': 'Sábado'
-                    }
-                    dias_selecionados = [dias_nomes.get(dia, '') for dia in dias_semana if dia in dias_nomes]
+                    dias_selecionados = [dia_semana(dia) for dia in dias_semana]
                     dias_texto = ", ".join(dias_selecionados)
                     
                     flash(f"Período de agendamento criado com sucesso! Horários configurados para {dias_texto} das {hora_inicio} às {hora_fim}.", "success")

--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -21,13 +21,8 @@
             </div>
             <div class="col-md-6">
               <p><strong>Horário de Funcionamento:</strong> {% if config.horario_inicio %}{{ config.horario_inicio.strftime('%H:%M') }}{% else %}08:00{% endif %} às {% if config.horario_fim %}{{ config.horario_fim.strftime('%H:%M') }}{% else %}17:00{% endif %}</p>
-              <p><strong>Dias da Semana:</strong> 
-                {% set dias_map = {'0': 'Domingo', '1': 'Segunda', '2': 'Terça', '3': 'Quarta', '4': 'Quinta', '5': 'Sexta', '6': 'Sábado'} %}
-                {% set dias_lista = [] %}
-                {% for dia in config.dias_semana.split(',') %}
-                  {% do dias_lista.append(dias_map[dia]) %}
-                {% endfor %}
-                {{ dias_lista|join(', ') }}
+              <p><strong>Dias da Semana:</strong>
+                {{ config.dias_semana.split(',') | map('dia_semana') | join(', ') }}
               </p>
             </div>
           </div>

--- a/utils/dia_semana.py
+++ b/utils/dia_semana.py
@@ -1,22 +1,45 @@
 from datetime import date, datetime
 
 DIAS_SEMANA = {
-    'Monday': 'Segunda-feira',
-    'Tuesday': 'Terça-feira',
-    'Wednesday': 'Quarta-feira',
-    'Thursday': 'Quinta-feira',
-    'Friday': 'Sexta-feira',
-    'Saturday': 'Sábado',
-    'Sunday': 'Domingo',
+    0: 'Domingo',
+    1: 'Segunda-feira',
+    2: 'Terça-feira',
+    3: 'Quarta-feira',
+    4: 'Quinta-feira',
+    5: 'Sexta-feira',
+    6: 'Sábado',
 }
 
-def dia_semana(valor: datetime | date | str) -> str:
+ENGLISH_TO_NUM = {
+    'Sunday': 0,
+    'Monday': 1,
+    'Tuesday': 2,
+    'Wednesday': 3,
+    'Thursday': 4,
+    'Friday': 5,
+    'Saturday': 6,
+}
+
+
+def dia_semana(valor: datetime | date | int | str) -> str:
     """Retorna o nome do dia da semana em português.
 
-    Aceita uma data ou uma string contendo o nome do dia em inglês.
+    Aceita uma data, ``datetime`` ou um valor numérico (``int`` ou ``str``)
+    representando o dia da semana onde ``0`` é domingo e ``6`` é sábado.
+    Também suporta nomes dos dias em inglês.
     """
+
     if isinstance(valor, str):
-        nome_em_ingles = valor
-    else:
-        nome_em_ingles = valor.strftime('%A')
-    return DIAS_SEMANA.get(nome_em_ingles, nome_em_ingles)
+        if valor.isdigit():
+            valor = int(valor)
+        else:
+            valor = ENGLISH_TO_NUM.get(valor, valor)
+
+    if isinstance(valor, int):
+        return DIAS_SEMANA.get(valor, str(valor))
+
+    if isinstance(valor, (datetime, date)):
+        indice = (valor.weekday() + 1) % 7
+        return DIAS_SEMANA.get(indice, str(indice))
+
+    return str(valor)


### PR DESCRIPTION
## Summary
- Map integers 0-6 (domingo–sábado) to Portuguese names and support int/numeric string inputs
- Use `dia_semana` helper for flashing weekday names in scheduling routes
- Render weekday names in `gerar_horarios_agendamento.html` via the `dia_semana` filter

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: DB_PASS environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a631e558e483248e072b098ba67849