### PR TITLE
Add visit scheduling fields

### DIFF
--- a/migrations/versions/b7f45c8e9d1a_add_campos_agendamento_visita.py
+++ b/migrations/versions/b7f45c8e9d1a_add_campos_agendamento_visita.py
@@ -1,0 +1,52 @@
+"""add campos agendamento visita
+
+Revision ID: b7f45c8e9d1a
+Revises: 6d0c1bfa2e5b, b460e470d7a9, f0c6022a4f5a
+Create Date: 2025-08-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b7f45c8e9d1a"
+down_revision = ("6d0c1bfa2e5b", "b460e470d7a9", "f0c6022a4f5a")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agendamento_visita") as batch_op:
+        batch_op.add_column(sa.Column("rede_ensino", sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column("municipio", sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column("bairro", sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column("responsavel_nome", sa.String(length=150), nullable=True))
+        batch_op.add_column(sa.Column("responsavel_cargo", sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column("responsavel_whatsapp", sa.String(length=20), nullable=True))
+        batch_op.add_column(sa.Column("responsavel_email", sa.String(length=120), nullable=True))
+        batch_op.add_column(sa.Column("acompanhantes_nomes", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("acompanhantes_qtd", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("precisa_transporte", sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column("observacoes", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("compromisso_1", sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column("compromisso_2", sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column("compromisso_3", sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column("compromisso_4", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agendamento_visita") as batch_op:
+        batch_op.drop_column("compromisso_4")
+        batch_op.drop_column("compromisso_3")
+        batch_op.drop_column("compromisso_2")
+        batch_op.drop_column("compromisso_1")
+        batch_op.drop_column("observacoes")
+        batch_op.drop_column("precisa_transporte")
+        batch_op.drop_column("acompanhantes_qtd")
+        batch_op.drop_column("acompanhantes_nomes")
+        batch_op.drop_column("responsavel_email")
+        batch_op.drop_column("responsavel_whatsapp")
+        batch_op.drop_column("responsavel_cargo")
+        batch_op.drop_column("responsavel_nome")
+        batch_op.drop_column("bairro")
+        batch_op.drop_column("municipio")
+        batch_op.drop_column("rede_ensino")

--- a/models/event.py
+++ b/models/event.py
@@ -951,6 +951,21 @@ class AgendamentoVisita(db.Model):
         db.String(50), nullable=False
     )  # Anos iniciais, finais, etc.
     quantidade_alunos = db.Column(db.Integer, nullable=False)
+    rede_ensino = db.Column(db.String(100), nullable=True)
+    municipio = db.Column(db.String(100), nullable=True)
+    bairro = db.Column(db.String(100), nullable=True)
+    responsavel_nome = db.Column(db.String(150), nullable=True)
+    responsavel_cargo = db.Column(db.String(100), nullable=True)
+    responsavel_whatsapp = db.Column(db.String(20), nullable=True)
+    responsavel_email = db.Column(db.String(120), nullable=True)
+    acompanhantes_nomes = db.Column(db.String(255), nullable=True)
+    acompanhantes_qtd = db.Column(db.Integer, nullable=True)
+    precisa_transporte = db.Column(db.Boolean, default=False)
+    observacoes = db.Column(db.Text, nullable=True)
+    compromisso_1 = db.Column(db.Boolean, default=False)
+    compromisso_2 = db.Column(db.Boolean, default=False)
+    compromisso_3 = db.Column(db.Boolean, default=False)
+    compromisso_4 = db.Column(db.Boolean, default=False)
 
     # Status do agendamento
     data_agendamento = db.Column(db.DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- extend `AgendamentoVisita` with school, contact, and commitment fields
- create Alembic migration adding columns to `agendamento_visita`

## Testing
- `flask db upgrade` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `flask db downgrade -- -1` *(fails: Relative revision -1 didn't produce 1 migrations)*
- `pytest` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a63277206c8324a14bd14c0162b766