### PR TITLE
Separate professor and participant scheduling routes

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1355,10 +1355,17 @@ def criar_agendamento():
                         try:
                             db.session.commit()
                             flash("Agendamento criado com sucesso!", "success")
-                            if current_user.tipo in ('professor', 'cliente'):
+                            if current_user.tipo == 'professor':
                                 return redirect(
                                     url_for(
-                                        'routes.adicionar_alunos_agendamento',
+                                        'routes.adicionar_alunos_professor',
+                                        agendamento_id=agendamento.id,
+                                    )
+                                )
+                            if current_user.tipo == 'cliente':
+                                return redirect(
+                                    url_for(
+                                        'routes.adicionar_alunos_professor',
                                         agendamento_id=agendamento.id,
                                     )
                                 )

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -161,11 +161,9 @@ def horarios_disponiveis_professor(evento_id):
 @routes.route('/professor/criar_agendamento/<int:horario_id>', methods=['GET', 'POST'])
 @login_required
 def criar_agendamento_professor(horario_id):
-    """Permite que professores ou participantes criem um agendamento."""
-    # Apenas professores ou participantes podem acessar
-    if current_user.tipo not in ('professor', 'participante'):
-        msg = 'Acesso negado! Esta área é exclusiva para professores e participantes.'
-        flash(msg, 'danger')
+    """Permite que o professor crie um agendamento."""
+    if current_user.tipo != 'professor':
+        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
     
     horario = HorarioVisitacao.query.get_or_404(horario_id)
@@ -240,7 +238,12 @@ def criar_agendamento_professor(horario_id):
                 flash('Agendamento realizado com sucesso!', 'success')
                 
                 # Redirecionar para a página de adicionar alunos
-                return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+                return redirect(
+                    url_for(
+                        'routes.adicionar_alunos_professor',
+                        agendamento_id=agendamento.id,
+                    )
+                )
             except Exception as e:
                 db.session.rollback()
                 flash(f'Erro ao realizar agendamento: {str(e)}', 'danger')
@@ -251,105 +254,149 @@ def criar_agendamento_professor(horario_id):
         evento=evento,
         salas=salas
     )
-
-
 @routes.route('/professor/adicionar_alunos/<int:agendamento_id>', methods=['GET', 'POST'])
-@routes.route(
-    '/participante/adicionar_alunos/<int:agendamento_id>', methods=['GET', 'POST']
-)
 @login_required
-def adicionar_alunos_agendamento(agendamento_id):
-    """Permite adicionar alunos a um agendamento."""
-    # Professores, clientes e participantes podem acessar
-    tipos_permitidos = {'professor', 'cliente', 'participante'}
-    if current_user.tipo not in tipos_permitidos:
-        msg = 'Acesso negado! Esta área é exclusiva para professores, clientes e participantes.'
-        flash(msg, 'danger')
+def adicionar_alunos_professor(agendamento_id):
+    """Permite que o professor adicione alunos a um agendamento."""
+    if current_user.tipo != 'professor':
+        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
-    # Verificar se o agendamento pertence ao usuário
-    if current_user.tipo == 'professor':
-        pertence = agendamento.professor_id == current_user.id
-        redirect_dest = url_for('agendamento_routes.meus_agendamentos')
-    elif current_user.tipo == 'participante':
-        pertence = agendamento.professor_id == current_user.id
-        redirect_dest = url_for('agendamento_routes.meus_agendamentos_participante')
-    else:  # cliente
-        pertence = agendamento.cliente_id == current_user.id
-        redirect_dest = url_for('agendamento_routes.meus_agendamentos_cliente')
-
-    if not pertence:
+    if agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
-        return redirect(redirect_dest)
-    
-    # Lista de alunos já adicionados
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
+
     alunos = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).all()
-    
+
     if request.method == 'POST':
         nome = request.form.get('nome')
         cpf = request.form.get('cpf')
-        
+
         if nome:
-            # Validar CPF se fornecido
             if cpf and len(cpf.replace('.', '').replace('-', '')) != 11:
                 flash('CPF inválido. Digite apenas os números ou deixe em branco.', 'danger')
             else:
                 aluno = AlunoVisitante(
                     agendamento_id=agendamento.id,
                     nome=nome,
-                    cpf=cpf
+                    cpf=cpf,
                 )
                 db.session.add(aluno)
-
                 try:
                     db.session.commit()
                     flash('Aluno adicionado com sucesso!', 'success')
-                    total = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).count()
+                    total = AlunoVisitante.query.filter_by(
+                        agendamento_id=agendamento.id
+                    ).count()
                     if total >= agendamento.quantidade_alunos:
-                        return redirect(url_for('routes.confirmacao_agendamento_professor', agendamento_id=agendamento.id))
-                    # Recarregar a página para mostrar o aluno adicionado
-                    return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+                        return redirect(
+                            url_for(
+                                'routes.confirmacao_agendamento_professor',
+                                agendamento_id=agendamento.id,
+                            )
+                        )
+                    return redirect(
+                        url_for(
+                            'routes.adicionar_alunos_professor',
+                            agendamento_id=agendamento.id,
+                        )
+                    )
                 except Exception as e:
                     db.session.rollback()
                     flash(f'Erro ao adicionar aluno: {str(e)}', 'danger')
         else:
             flash('Nome do aluno é obrigatório!', 'danger')
-    
+
     return render_template(
         'professor/adicionar_alunos.html',
         agendamento=agendamento,
         alunos=alunos,
         total_adicionados=len(alunos),
-        quantidade_esperada=agendamento.quantidade_alunos
+        quantidade_esperada=agendamento.quantidade_alunos,
+    )
+
+
+@routes.route('/participante/adicionar_alunos/<int:agendamento_id>', methods=['GET', 'POST'])
+@login_required
+def adicionar_alunos_participante(agendamento_id):
+    """Permite que o participante adicione alunos a um agendamento."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
+
+    if agendamento.professor_id != current_user.id:
+        flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    alunos = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).all()
+
+    if request.method == 'POST':
+        nome = request.form.get('nome')
+        cpf = request.form.get('cpf')
+
+        if nome:
+            if cpf and len(cpf.replace('.', '').replace('-', '')) != 11:
+                flash('CPF inválido. Digite apenas os números ou deixe em branco.', 'danger')
+            else:
+                aluno = AlunoVisitante(
+                    agendamento_id=agendamento.id,
+                    nome=nome,
+                    cpf=cpf,
+                )
+                db.session.add(aluno)
+                try:
+                    db.session.commit()
+                    flash('Aluno adicionado com sucesso!', 'success')
+                    total = AlunoVisitante.query.filter_by(
+                        agendamento_id=agendamento.id
+                    ).count()
+                    if total >= agendamento.quantidade_alunos:
+                        return redirect(
+                            url_for(
+                                'routes.confirmacao_agendamento_participante',
+                                agendamento_id=agendamento.id,
+                            )
+                        )
+                    return redirect(
+                        url_for(
+                            'routes.adicionar_alunos_participante',
+                            agendamento_id=agendamento.id,
+                        )
+                    )
+                except Exception as e:
+                    db.session.rollback()
+                    flash(f'Erro ao adicionar aluno: {str(e)}', 'danger')
+        else:
+            flash('Nome do aluno é obrigatório!', 'danger')
+
+    return render_template(
+        'professor/adicionar_alunos.html',
+        agendamento=agendamento,
+        alunos=alunos,
+        total_adicionados=len(alunos),
+        quantidade_esperada=agendamento.quantidade_alunos,
     )
 
 
 @routes.route('/professor/remover_aluno/<int:aluno_id>', methods=['POST'])
-@routes.route('/participante/remover_aluno/<int:aluno_id>', methods=['POST'])
 @login_required
-def remover_aluno_agendamento(aluno_id):
-    """Remove um aluno de um agendamento."""
-    # Professores e participantes podem acessar
-    if current_user.tipo not in ('professor', 'participante'):
-        msg = 'Acesso negado! Esta área é exclusiva para professores e participantes.'
-        flash(msg, 'danger')
+def remover_aluno_professor(aluno_id):
+    """Remove um aluno de um agendamento (professor)."""
+    if current_user.tipo != 'professor':
+        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
 
     aluno = AlunoVisitante.query.get_or_404(aluno_id)
     agendamento = aluno.agendamento
 
-    # Verificar se o agendamento pertence ao usuário
-    pertence = agendamento.professor_id == current_user.id
-    if current_user.tipo == 'professor':
-        redirect_dest = url_for('agendamento_routes.meus_agendamentos')
-    else:
-        redirect_dest = url_for('agendamento_routes.meus_agendamentos_participante')
-    if not pertence:
+    if agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este aluno não pertence a um agendamento seu.', 'danger')
-        return redirect(redirect_dest)
-    
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
+
     try:
         db.session.delete(aluno)
         db.session.commit()
@@ -357,8 +404,40 @@ def remover_aluno_agendamento(aluno_id):
     except Exception as e:
         db.session.rollback()
         flash(f'Erro ao remover aluno: {str(e)}', 'danger')
-    
-    return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+
+    return redirect(
+        url_for('routes.adicionar_alunos_professor', agendamento_id=agendamento.id)
+    )
+
+
+@routes.route('/participante/remover_aluno/<int:aluno_id>', methods=['POST'])
+@login_required
+def remover_aluno_participante(aluno_id):
+    """Remove um aluno de um agendamento (participante)."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    aluno = AlunoVisitante.query.get_or_404(aluno_id)
+    agendamento = aluno.agendamento
+
+    if agendamento.professor_id != current_user.id:
+        flash('Acesso negado! Este aluno não pertence a um agendamento seu.', 'danger')
+        return redirect(
+            url_for('agendamento_routes.meus_agendamentos_participante')
+        )
+
+    try:
+        db.session.delete(aluno)
+        db.session.commit()
+        flash('Aluno removido com sucesso!', 'success')
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Erro ao remover aluno: {str(e)}', 'danger')
+
+    return redirect(
+        url_for('routes.adicionar_alunos_participante', agendamento_id=agendamento.id)
+    )
 
 
 @routes.route('/professor/importar_alunos/<int:agendamento_id>', methods=['GET', 'POST'])
@@ -433,7 +512,12 @@ def importar_alunos_agendamento(agendamento_id):
                 else:
                     flash('Nenhum aluno encontrado no arquivo!', 'warning')
 
-                return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+                return redirect(
+                    url_for(
+                        'routes.adicionar_alunos_professor',
+                        agendamento_id=agendamento.id,
+                    )
+                )
             except Exception as e:
                 db.session.rollback()
                 flash(f'Erro ao processar arquivo: {str(e)}', 'danger')
@@ -470,7 +554,12 @@ def confirmacao_agendamento_professor(agendamento_id):
     alunos = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).all()
     if not alunos:
         flash('Nenhum aluno cadastrado neste agendamento.', 'warning')
-        return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+        return redirect(
+            url_for(
+                'routes.adicionar_alunos_professor',
+                agendamento_id=agendamento.id,
+            )
+        )
 
     return render_template(
         'professor/confirmacao_agendamento.html',
@@ -478,34 +567,49 @@ def confirmacao_agendamento_professor(agendamento_id):
         alunos=alunos
     )
 
-@routes.route('/professor/imprimir_agendamento/<int:agendamento_id>')
+
+@routes.route('/participante/confirmacao_agendamento/<int:agendamento_id>')
 @login_required
-def imprimir_agendamento_professor(agendamento_id):
-    """Gera o comprovante de um agendamento."""
-    # Permitir acesso a professores, participantes, clientes e usuários
-    tipos_permitidos = {'professor', 'participante', 'cliente', 'usuario'}
-    if current_user.tipo not in tipos_permitidos:
-        flash(
-            'Acesso negado! Esta área é exclusiva para professores, '
-            'participantes, clientes e usuários.',
-            'danger',
-        )
+def confirmacao_agendamento_participante(agendamento_id):
+    """Exibe a página de confirmação do agendamento para participantes."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
-    # Validar propriedade conforme o tipo do usuário
-    if current_user.tipo == 'professor' and agendamento.professor_id != current_user.id:
+    if agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
-        return redirect(url_for('agendamento_routes.meus_agendamentos'))
-    if (
-        current_user.tipo == 'cliente'
-        and agendamento.horario.evento.cliente_id != current_user.id
-    ):
-        flash(
-            'Acesso negado! Este agendamento não pertence ao seu evento.',
-            'danger',
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    alunos = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).all()
+    if not alunos:
+        flash('Nenhum aluno cadastrado neste agendamento.', 'warning')
+        return redirect(
+            url_for(
+                'routes.adicionar_alunos_participante',
+                agendamento_id=agendamento.id,
+            )
         )
+
+    return render_template(
+        'professor/confirmacao_agendamento.html',
+        agendamento=agendamento,
+        alunos=alunos,
+    )
+
+@routes.route('/professor/imprimir_agendamento/<int:agendamento_id>')
+@login_required
+def imprimir_agendamento_professor(agendamento_id):
+    """Gera o comprovante de um agendamento."""
+    if current_user.tipo != 'professor':
+        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
+
+    if agendamento.professor_id != current_user.id:
+        flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
 
     if agendamento.status != 'confirmado':
@@ -524,7 +628,12 @@ def imprimir_agendamento_professor(agendamento_id):
 
     if not alunos:
         flash('Adicione alunos antes de imprimir o comprovante.', 'warning')
-        return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+        return redirect(
+            url_for(
+                'routes.adicionar_alunos_professor',
+                agendamento_id=agendamento.id,
+            )
+        )
 
     # Gerar PDF para impressão
     pdf_filename = f"agendamento_{agendamento_id}.pdf"
@@ -533,7 +642,61 @@ def imprimir_agendamento_professor(agendamento_id):
     
     # Chamar função para gerar PDF
     gerar_pdf_comprovante_agendamento(agendamento, horario, evento, salas, alunos, pdf_path)
-    
+
+    return send_file(pdf_path, as_attachment=True)
+
+
+@routes.route('/participante/imprimir_agendamento/<int:agendamento_id>')
+@login_required
+def imprimir_agendamento_participante(agendamento_id):
+    """Gera o comprovante de um agendamento para participantes."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
+
+    if agendamento.professor_id != current_user.id:
+        flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    if agendamento.status != 'confirmado':
+        flash('Agendamento ainda não confirmado.', 'warning')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    horario = agendamento.horario
+    evento = horario.evento
+
+    salas_ids = (
+        agendamento.salas_selecionadas.split(',')
+        if agendamento.salas_selecionadas
+        else []
+    )
+    salas = (
+        SalaVisitacao.query.filter(SalaVisitacao.id.in_(salas_ids)).all()
+        if salas_ids
+        else []
+    )
+
+    alunos = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).all()
+
+    if not alunos:
+        flash('Adicione alunos antes de imprimir o comprovante.', 'warning')
+        return redirect(
+            url_for(
+                'routes.adicionar_alunos_participante',
+                agendamento_id=agendamento.id,
+            )
+        )
+
+    pdf_filename = f"agendamento_{agendamento_id}.pdf"
+    pdf_path = os.path.join("static", "agendamentos", pdf_filename)
+    os.makedirs(os.path.dirname(pdf_path), exist_ok=True)
+
+    gerar_pdf_comprovante_agendamento(
+        agendamento, horario, evento, salas, alunos, pdf_path
+    )
+
     return send_file(pdf_path, as_attachment=True)
 
 
@@ -541,41 +704,49 @@ def imprimir_agendamento_professor(agendamento_id):
 @login_required
 def qrcode_agendamento_professor(agendamento_id):
     """Exibe o QR Code de um agendamento."""
-    # Permitir acesso a professores, participantes, clientes e usuários
-    tipos_permitidos = {'professor', 'participante', 'cliente', 'usuario'}
-    if current_user.tipo not in tipos_permitidos:
-        flash(
-            'Acesso negado! Esta área é exclusiva para professores, '
-            'participantes, clientes e usuários.',
-            'danger',
-        )
+    if current_user.tipo != 'professor':
+        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
         return redirect(url_for('dashboard_routes.dashboard'))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
-    # Validar propriedade conforme o tipo do usuário
-    if current_user.tipo == 'professor' and agendamento.professor_id != current_user.id:
+    if agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
-        return redirect(url_for('agendamento_routes.meus_agendamentos'))
-    if (
-        current_user.tipo == 'cliente'
-        and agendamento.horario.evento.cliente_id != current_user.id
-    ):
-        flash(
-            'Acesso negado! Este agendamento não pertence ao seu evento.',
-            'danger',
-        )
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
 
     if agendamento.status != 'confirmado':
         flash('Agendamento ainda não confirmado.', 'warning')
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
 
-    # Página que exibe o QR Code para check-in
     return render_template(
         'professor/qrcode_agendamento.html',
         agendamento=agendamento,
-        token=agendamento.qr_code_token
+        token=agendamento.qr_code_token,
+    )
+
+
+@routes.route('/participante/qrcode_agendamento/<int:agendamento_id>')
+@login_required
+def qrcode_agendamento_participante(agendamento_id):
+    """Exibe o QR Code de um agendamento para participantes."""
+    if current_user.tipo != 'participante':
+        flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
+        return redirect(url_for('dashboard_routes.dashboard'))
+
+    agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
+
+    if agendamento.professor_id != current_user.id:
+        flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    if agendamento.status != 'confirmado':
+        flash('Agendamento ainda não confirmado.', 'warning')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_participante'))
+
+    return render_template(
+        'professor/qrcode_agendamento.html',
+        agendamento=agendamento,
+        token=agendamento.qr_code_token,
     )
 
 

--- a/templates/cliente/meus_agendamentos.html
+++ b/templates/cliente/meus_agendamentos.html
@@ -99,7 +99,7 @@
                       </a>
 
                       {% if agendamento.status in ['pendente', 'confirmado'] %}
-                      <a href="{{ url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id) }}"
+                      <a href="{{ url_for('routes.adicionar_alunos_professor', agendamento_id=agendamento.id) }}"
                          class="btn btn-sm btn-outline-success" title="Adicionar alunos">
                         <i class="fas fa-user-plus me-1"></i>Adicionar
                       </a>

--- a/templates/participante/meus_agendamentos.html
+++ b/templates/participante/meus_agendamentos.html
@@ -72,7 +72,7 @@
                                             <td>
                                                 <div class="d-flex flex-wrap justify-content-center gap-1">
                                                     {% if agendamento.status in ['pendente', 'confirmado'] %}
-                                                        <a href="{{ url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id) }}" class="btn btn-sm btn-outline-success" title="Adicionar alunos">
+                                                        <a href="{{ url_for('routes.adicionar_alunos_participante', agendamento_id=agendamento.id) }}" class="btn btn-sm btn-outline-success" title="Adicionar alunos">
                                                             <i class="fas fa-user-plus me-1"></i>Adicionar
                                                         </a>
                                                     {% endif %}

--- a/templates/professor/adicionar_alunos.html
+++ b/templates/professor/adicionar_alunos.html
@@ -6,6 +6,19 @@
 {% block title %}Adicionar Alunos{% endblock %}
 
 {% block content %}
+{% if current_user.tipo == 'professor' %}
+    {% set add_route = 'routes.adicionar_alunos_professor' %}
+    {% set remove_route = 'routes.remover_aluno_professor' %}
+    {% set print_route = 'routes.imprimir_agendamento_professor' %}
+    {% set qrcode_route = 'routes.qrcode_agendamento_professor' %}
+    {% set agendamentos_route = 'agendamento_routes.meus_agendamentos' %}
+{% else %}
+    {% set add_route = 'routes.adicionar_alunos_participante' %}
+    {% set remove_route = 'routes.remover_aluno_participante' %}
+    {% set print_route = 'routes.imprimir_agendamento_participante' %}
+    {% set qrcode_route = 'routes.qrcode_agendamento_participante' %}
+    {% set agendamentos_route = 'agendamento_routes.meus_agendamentos_participante' %}
+{% endif %}
 <div class="container mt-4">
     <h2>Adicionar Alunos ao Agendamento</h2>
     
@@ -45,7 +58,7 @@
                     <i class="fas fa-user-plus"></i> Adicionar Aluno
                 </div>
                 <div class="card-body">
-                    <form method="POST" action="{{ url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id) }}">
+                    <form method="POST" action="{{ url_for(add_route, agendamento_id=agendamento.id) }}">
                         <div class="mb-3">
                             <label for="nome" class="form-label">Nome do Aluno *</label>
                             <input type="text" class="form-control" id="nome" name="nome" required>
@@ -78,11 +91,13 @@
                     <pre>Nome do Aluno,CPF</pre>
                     <p>O CPF é opcional e pode ser deixado em branco.</p>
                     
+                    {% if current_user.tipo == 'professor' %}
                     <div class="d-grid">
                         <a href="{{ url_for('routes.importar_alunos_agendamento', agendamento_id=agendamento.id) }}" class="btn btn-info">
                             <i class="fas fa-file-import"></i> Importar Alunos
                         </a>
                     </div>
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -110,7 +125,7 @@
                                     <td>{{ aluno.nome }}</td>
                                     <td>{{ aluno.cpf or '-' }}</td>
                                     <td class="text-end">
-                                        <form method="POST" action="{{ url_for('routes.remover_aluno_agendamento', aluno_id=aluno.id) }}" class="d-inline">
+                                        <form method="POST" action="{{ url_for(remove_route, aluno_id=aluno.id) }}" class="d-inline">
                                             <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Tem certeza que deseja remover este aluno?')">
                                                 <i class="fas fa-trash"></i>
                                             </button>
@@ -137,18 +152,18 @@
         {% endif %}
         
         {% if agendamento.status == 'confirmado' and total_adicionados > 0 %}
-        <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
+        <a href="{{ url_for(print_route, agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
         {% endif %}
 
         {% if agendamento.status == 'confirmado' %}
-        <a href="{{ url_for('routes.qrcode_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-info">
+        <a href="{{ url_for(qrcode_route, agendamento_id=agendamento.id) }}" class="btn btn-info">
             <i class="fas fa-qrcode"></i> Ver QR Code
         </a>
         {% endif %}
         
-        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
+        <a href="{{ url_for(agendamentos_route) }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>

--- a/templates/professor/confirmacao_agendamento.html
+++ b/templates/professor/confirmacao_agendamento.html
@@ -4,6 +4,11 @@
 {% block title %}Confirmar Agendamento{% endblock %}
 
 {% block content %}
+{% if current_user.tipo == 'professor' %}
+    {% set voltar_route = 'routes.adicionar_alunos_professor' %}
+{% else %}
+    {% set voltar_route = 'routes.adicionar_alunos_participante' %}
+{% endif %}
 <div class="container mt-4">
     <h2>Confirmar Agendamento</h2>
 
@@ -64,7 +69,7 @@
                 <i class="fas fa-check"></i> Confirmar
             </button>
             <a href="{{ url_for(
-                'routes.adicionar_alunos_agendamento',
+                voltar_route,
                 agendamento_id=agendamento.id
             ) }}" class="btn btn-secondary">
                 <i class="fas fa-arrow-left"></i> Voltar

--- a/templates/professor/importar_alunos.html
+++ b/templates/professor/importar_alunos.html
@@ -57,7 +57,7 @@ Pedro Santos,98765432100</pre>
                     <button type="submit" class="btn btn-success">
                         <i class="fas fa-upload"></i> Importar Alunos
                     </button>
-                    <a href="{{ url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id) }}" class="btn btn-secondary">
+                    <a href="{{ url_for('routes.adicionar_alunos_professor', agendamento_id=agendamento.id) }}" class="btn btn-secondary">
                         <i class="fas fa-chevron-left"></i> Voltar
                     </a>
                 </div>

--- a/templates/professor/meus_agendamentos.html
+++ b/templates/professor/meus_agendamentos.html
@@ -93,7 +93,7 @@
                                                     </a>
                                                     
                                                     {% if agendamento.status in ['pendente', 'confirmado'] %}
-                                                        <a href="{{ url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id) }}"
+                                                        <a href="{{ url_for('routes.adicionar_alunos_professor', agendamento_id=agendamento.id) }}"
                                                            class="btn btn-sm btn-outline-success" title="Adicionar alunos">
                                                             <i class="fas fa-user-plus me-1"></i>Adicionar
                                                         </a>

--- a/templates/professor/qrcode_agendamento.html
+++ b/templates/professor/qrcode_agendamento.html
@@ -6,6 +6,13 @@
 {% block title %}QR Code do Agendamento{% endblock %}
 
 {% block content %}
+{% if current_user.tipo == 'professor' %}
+    {% set print_route = 'routes.imprimir_agendamento_professor' %}
+    {% set agendamentos_route = 'agendamento_routes.meus_agendamentos' %}
+{% else %}
+    {% set print_route = 'routes.imprimir_agendamento_participante' %}
+    {% set agendamentos_route = 'agendamento_routes.meus_agendamentos_participante' %}
+{% endif %}
 <div class="container mt-4">
     <h2>QR Code do Agendamento</h2>
     
@@ -48,11 +55,11 @@
     
     <div class="mt-4">
         {% if agendamento.status == 'confirmado' %}
-        <a href="{{ url_for('routes.imprimir_agendamento_professor', agendamento_id=agendamento.id) }}" class="btn btn-primary">
+        <a href="{{ url_for(print_route, agendamento_id=agendamento.id) }}" class="btn btn-primary">
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
         {% endif %}
-        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
+        <a href="{{ url_for(agendamentos_route) }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>


### PR DESCRIPTION
## Summary
- restrict professor endpoints to professors only
- add participant-specific endpoints for managing visitation
- update templates to call role-specific routes

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: DB_PASS environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a631d4d774832497e067aaae2bd17f