### PR TITLE
Filter agendamento report by visit date

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -358,9 +358,6 @@ def relatorio_geral_agendamentos():
     else:
         data_fim = datetime.utcnow().date()
 
-    inicio_dt = datetime.combine(data_inicio, datetime.min.time())
-    fim_dt = datetime.combine(data_fim, datetime.max.time())
-
     # Buscar eventos do cliente com agendamentos no período selecionado
     eventos = (
         Evento.query.outerjoin(
@@ -371,13 +368,13 @@ def relatorio_geral_agendamentos():
         )
         .filter(
             Evento.cliente_id == current_user.id,
-            AgendamentoVisita.data_agendamento >= inicio_dt,
-            AgendamentoVisita.data_agendamento <= fim_dt,
+            HorarioVisitacao.data >= data_inicio,
+            HorarioVisitacao.data <= data_fim,
         )
         .distinct()
         .all()
     )
-    
+
     # Estatísticas agregadas em uma única consulta
     aggregados = (
         db.session.query(
@@ -415,8 +412,8 @@ def relatorio_geral_agendamentos():
         )
         .filter(
             Evento.cliente_id == current_user.id,
-            AgendamentoVisita.data_agendamento >= inicio_dt,
-            AgendamentoVisita.data_agendamento <= fim_dt,
+            HorarioVisitacao.data >= data_inicio,
+            HorarioVisitacao.data <= data_fim,
         )
         .group_by(Evento.id)
         .all()
@@ -450,8 +447,8 @@ def relatorio_geral_agendamentos():
         .join(Evento)
         .filter(
             Evento.cliente_id == current_user.id,
-            AgendamentoVisita.data_agendamento >= inicio_dt,
-            AgendamentoVisita.data_agendamento <= fim_dt,
+            HorarioVisitacao.data >= data_inicio,
+            HorarioVisitacao.data <= data_fim,
         )
         .order_by(HorarioVisitacao.data, HorarioVisitacao.horario_inicio)
         .all()

--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -118,16 +118,6 @@ def app():
         )
         db.session.add(horario)
         db.session.commit()
-        horario_fora = HorarioVisitacao(
-            evento_id=evento.id,
-            data=date.today() + timedelta(days=60),
-            horario_inicio=time(9, 0),
-            horario_fim=time(10, 0),
-            capacidade_total=100,
-            vagas_disponiveis=100,
-        )
-        db.session.add(horario_fora)
-        db.session.commit()
         ags = [
             AgendamentoVisita(
                 horario_id=horario.id,
@@ -170,17 +160,17 @@ def app():
         ]
         db.session.add_all(ags)
         db.session.commit()
-        ag_foras = AgendamentoVisita(
-            horario_id=horario_fora.id,
+        ag_antigo = AgendamentoVisita(
+            horario_id=horario.id,
             escola_nome='E5',
             turma='T1',
             nivel_ensino='1',
             quantidade_alunos=10,
             salas_selecionadas='1',
             status='pendente',
-            data_agendamento=datetime.utcnow(),
+            data_agendamento=datetime.utcnow() - timedelta(days=60),
         )
-        db.session.add(ag_foras)
+        db.session.add(ag_antigo)
         db.session.commit()
 
         alunos = [
@@ -241,7 +231,7 @@ def test_counts_all_statuses(client, app):
     assert stats['total'] == 5
 
 
-def test_agendamento_outside_horario_range_included(client, app):
+def test_agendamento_created_outside_range_included(client, app):
     login(client)
     with captured_templates(app) as templates:
         resp = client.get('/relatorio_geral_agendamentos')


### PR DESCRIPTION
## Summary
- Filter general scheduling report by `HorarioVisitacao.data` instead of `AgendamentoVisita.data_agendamento`
- Ensure aggregation and listing queries use visit date range
- Adjust tests to cover agendamentos created outside the selected period but scheduled within it

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in multiple test files)*
- `pytest tests/test_relatorio_geral_agendamentos.py::test_agendamento_created_outside_range_included`

------
https://chatgpt.com/codex/tasks/task_e_68a6857545d4832497b75b74df355c7b