### PR TITLE
Rename final approval checkbox

### DIFF
--- a/templates/participante/criar_agendamento.html
+++ b/templates/participante/criar_agendamento.html
@@ -187,8 +187,8 @@
                         <p class="mt-2">Ao marcar as opções acima, sua instituição confirma estar de acordo com os compromissos estabelecidos.</p>
                     </div>
                     <div class="form-check mb-4">
-                        <input class="form-check-input" type="checkbox" id="declaro_ciente" name="declaro_ciente" required>
-                        <label class="form-check-label" for="declaro_ciente">Declaro que li e estou de acordo com as informações fornecidas.</label>
+                        <input class="form-check-input" type="checkbox" id="aceite_final" name="aceite_final" required>
+                        <label class="form-check-label" for="aceite_final">Declaro que li e estou de acordo com as informações fornecidas.</label>
                     </div>
                     <div class="alert alert-info mb-4">
                         <i class="fas fa-info-circle"></i> Após confirmar o agendamento, você poderá adicionar a lista de alunos participantes.

--- a/templates/professor/criar_agendamento.html
+++ b/templates/professor/criar_agendamento.html
@@ -190,8 +190,8 @@
                 </div>
 
                 <div class="form-check mb-4">
-                    <input class="form-check-input" type="checkbox" id="declaro_ciente" name="declaro_ciente" required>
-                    <label class="form-check-label" for="declaro_ciente">Declaro que li e estou de acordo com as informações fornecidas.</label>
+                    <input class="form-check-input" type="checkbox" id="aceite_final" name="aceite_final" required>
+                    <label class="form-check-label" for="aceite_final">Declaro que li e estou de acordo com as informações fornecidas.</label>
                 </div>
 
                 <div class="alert alert-info mb-4">


### PR DESCRIPTION
## Summary
- rename declaro_ciente checkbox to aceite_final in agendamento forms

## Testing
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a687a6e34c83249e83c690bd2741c5