### PR TITLE
Ensure QR check-in redirect preserves token

### DIFF
--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -51,7 +51,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (response.ok) {
                 const data = await response.json();
                 if (data.redirect) {
-                    window.location.href = '/confirmar_checkin_agendamento';
+                    let redirectUrl = data.redirect;
+                    if (token && !redirectUrl.includes(token)) {
+                        const separator = redirectUrl.includes('?') ? '&' : '?';
+                        redirectUrl += `${separator}token=${encodeURIComponent(token)}`;
+                    }
+                    window.location.href = redirectUrl;
                 }
             }
         } catch (error) {


### PR DESCRIPTION
## Summary
- Pass server-provided redirect URL when handling QR scan
- Append QR token to redirect URL if missing

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a68d2b548c8324bbcd65b352cb2dce