### PR TITLE
Stop QR scanner after booking scan

### DIFF
--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -26,9 +26,11 @@ import { initScanner, stopScanner } from "{{ url_for('static', filename='js/qr_s
 document.addEventListener('DOMContentLoaded', async () => {
     const statusElement = document.getElementById('scan-status');
     const scanResult = document.getElementById('scan-result');
-
+    let isProcessing = false;
 
     async function handleScan(decodedText) {
+        if (isProcessing) return;
+        isProcessing = true;
         scanResult.innerHTML = `<div class="alert alert-success">QR Lido: ${decodedText}</div>`;
 
         let token;
@@ -50,8 +52,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             if (response.ok) {
                 const data = await response.json();
+                await stopScanner();
                 if (data.redirect) {
-                    window.location.href = '/confirmar_checkin_agendamento';
+                    window.location.href = data.redirect;
                 }
             }
         } catch (error) {


### PR DESCRIPTION
## Summary
- avoid duplicate QR processing in check-in flow
- stop scanner and redirect using server-provided URL

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a68cfb47908324b2f96250b410061c