### PR TITLE
Send CSRF token with QR check-in

### DIFF
--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -26,6 +26,8 @@ import { initScanner, stopScanner } from "{{ url_for('static', filename='js/qr_s
 document.addEventListener('DOMContentLoaded', async () => {
     const statusElement = document.getElementById('scan-status');
     const scanResult = document.getElementById('scan-result');
+    const csrfToken = document
+        .querySelector('meta[name="csrf-token"]')?.content || '';
 
 
     async function handleScan(decodedText) {
@@ -43,7 +45,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             const response = await fetch('/processar_qrcode_agendamento', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
                 },
                 body: JSON.stringify({ token })
             });


### PR DESCRIPTION
## Summary
- read CSRF token from meta tag before sending QR check-in request
- include X-CSRFToken header so QR check-in POSTs are accepted

## Testing
- `python - <<'PY'\n...\nPY` (POST 404 with token instead of 400)
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a68d21f4b48324aa3ea388560728b4