### PR TITLE
Use distinct counts for agendamento report

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -381,19 +381,54 @@ def relatorio_geral_agendamentos():
         db.session.query(
             Evento.id.label('evento_id'),
             func.count(
-                case((AgendamentoVisita.status == 'confirmado', 1))
+                func.distinct(
+                    case(
+                        (
+                            AgendamentoVisita.status == 'confirmado',
+                            AgendamentoVisita.id,
+                        )
+                    )
+                )
             ).label('confirmados'),
             func.count(
-                case((AgendamentoVisita.status == 'realizado', 1))
+                func.distinct(
+                    case(
+                        (
+                            AgendamentoVisita.status == 'realizado',
+                            AgendamentoVisita.id,
+                        )
+                    )
+                )
             ).label('realizados'),
             func.count(
-                case((AgendamentoVisita.status == 'cancelado', 1))
+                func.distinct(
+                    case(
+                        (
+                            AgendamentoVisita.status == 'cancelado',
+                            AgendamentoVisita.id,
+                        )
+                    )
+                )
             ).label('cancelados'),
             func.count(
-                case((AgendamentoVisita.status == 'pendente', 1))
+                func.distinct(
+                    case(
+                        (
+                            AgendamentoVisita.status == 'pendente',
+                            AgendamentoVisita.id,
+                        )
+                    )
+                )
             ).label('pendentes'),
             func.count(
-                case((AgendamentoVisita.checkin_realizado == True, 1))
+                func.distinct(
+                    case(
+                        (
+                            AgendamentoVisita.checkin_realizado == True,
+                            AgendamentoVisita.id,
+                        )
+                    )
+                )
             ).label('checkins'),
             func.sum(
                 case(


### PR DESCRIPTION
## Summary
- ensure relatorio_geral_agendamentos counts distinct agendamentos for each status and check-in

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6934dc30083248f76c159739a1954