### PR TITLE
Use outer join to list all agendamentos

### DIFF
--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -238,6 +238,7 @@ def test_agendamento_created_outside_range_included(client, app):
     assert resp.status_code == 200
     template, context = templates[0]
     ags = context['agendamentos']
+    assert len(ags) == 5
     assert any(a.escola_nome == 'E5' for a in ags)
 
 
@@ -248,6 +249,14 @@ def test_template_contains_new_columns(client):
     assert 'Check-in' in html
     assert 'Presentes' in html
     assert 'Aluno 1' in html
+
+
+def test_template_lists_all_agendamentos(client):
+    login(client)
+    resp = client.get('/relatorio_geral_agendamentos')
+    html = resp.get_data(as_text=True)
+    for escola in ['E1', 'E2', 'E3', 'E4', 'E5']:
+        assert escola in html
 
 
 def test_generate_pdf_uses_service(client, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure agendamento report counts statuses distinctly and includes all appointments for period
- add regression tests verifying all scheduled schools appear in report

## Testing
- `pip install -r requirements-dev.txt`
- `pytest tests/test_relatorio_geral_agendamentos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a695ab4520832497c2f20a6ece7598