### PR TITLE
Add confirmed professors report section

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -467,6 +467,30 @@ def relatorio_geral_agendamentos():
         .all()
     )
 
+    professores_confirmados = (
+        db.session.query(
+            Usuario.nome.label('nome'),
+            Usuario.email.label('email'),
+            AgendamentoVisita.responsavel_whatsapp.label(
+                'responsavel_whatsapp'
+            ),
+        )
+        .join(AgendamentoVisita, AgendamentoVisita.professor_id == Usuario.id)
+        .join(
+            HorarioVisitacao,
+            AgendamentoVisita.horario_id == HorarioVisitacao.id,
+        )
+        .join(Evento, HorarioVisitacao.evento_id == Evento.id)
+        .filter(
+            Evento.cliente_id == current_user.id,
+            AgendamentoVisita.status == 'confirmado',
+            HorarioVisitacao.data >= data_inicio,
+            HorarioVisitacao.data <= data_fim,
+        )
+        .distinct()
+        .all()
+    )
+
     # Gerar PDF com detalhes
     if request.args.get('gerar_pdf'):
         pdf_filename = (
@@ -491,6 +515,7 @@ def relatorio_geral_agendamentos():
         eventos=eventos,
         estatisticas=estatisticas,
         agendamentos=agendamentos,
+        professores_confirmados=professores_confirmados,
         filtros={
             'data_inicio': data_inicio,
             'data_fim': data_fim

--- a/templates/agendamento/relatorio_geral_agendamentos.html
+++ b/templates/agendamento/relatorio_geral_agendamentos.html
@@ -196,55 +196,125 @@
 
     <div class="card mb-4">
         <div class="card-header bg-secondary text-white">
-            <i class="fas fa-table"></i> Lista de Agendamentos
+            <i class="fas fa-table"></i> Listas
         </div>
-        <div class="card-body table-responsive">
-            {% if agendamentos %}
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Data</th>
-                        <th>Horário</th>
-                        <th>Escola</th>
-                        <th>Professor</th>
-                        <th>Alunos</th>
-                        <th>Presentes</th>
-                        <th>Check-in</th>
-                        <th>Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for agendamento in agendamentos %}
-                    <tr>
-                        <td>{{ agendamento.id }}</td>
-                        <td>{{ agendamento.horario.data.strftime('%d/%m/%Y') }}</td>
-                        <td>{{ agendamento.horario.horario_inicio.strftime('%H:%M') }}</td>
-                        <td>{{ agendamento.escola_nome }}</td>
-                        <td>{{ agendamento.professor.nome if agendamento.professor else '-' }}</td>
-                        <td>{{ agendamento.quantidade_alunos }}</td>
-                        <td>{{ 'Prof' if agendamento.checkin_realizado else '-' }} + {{ agendamento.alunos|selectattr('presente')|list|length }}</td>
-                        <td>{{ agendamento.data_checkin.strftime('%d/%m/%Y %H:%M') if agendamento.data_checkin else '-' }}</td>
-                        <td>{{ agendamento.status }}</td>
-                    </tr>
-                    {% set presentes = agendamento.alunos|selectattr('presente')|list %}
-                    {% if presentes %}
-                    <tr>
-                        <td colspan="9">
-                            <ul class="mb-0">
-                                {% for aluno in presentes %}
-                                <li>{{ aluno.nome }}</li>
+        <div class="card-body">
+            <ul class="nav nav-tabs" id="relatorioTabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="agendamentos-tab"
+                            data-bs-toggle="tab" data-bs-target="#agendamentos"
+                            type="button" role="tab">
+                        Agendamentos
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="professores-tab"
+                            data-bs-toggle="tab" data-bs-target="#professores"
+                            type="button" role="tab">
+                        Professores Confirmados
+                    </button>
+                </li>
+            </ul>
+            <div class="tab-content pt-3">
+                <div class="tab-pane fade show active" id="agendamentos"
+                     role="tabpanel" aria-labelledby="agendamentos-tab">
+                    <div class="table-responsive">
+                        {% if agendamentos %}
+                        <table class="table table-striped">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Data</th>
+                                    <th>Horário</th>
+                                    <th>Escola</th>
+                                    <th>Professor</th>
+                                    <th>Alunos</th>
+                                    <th>Presentes</th>
+                                    <th>Check-in</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for agendamento in agendamentos %}
+                                <tr>
+                                    <td>{{ agendamento.id }}</td>
+                                    <td>
+                                        {{ agendamento.horario.data.strftime('%d/%m/%Y') }}
+                                    </td>
+                                    <td>
+                                        {{ agendamento.horario.horario_inicio.strftime('%H:%M') }}
+                                    </td>
+                                    <td>{{ agendamento.escola_nome }}</td>
+                                    <td>
+                                        {{ agendamento.professor.nome if agendamento.professor else '-' }}
+                                    </td>
+                                    <td>{{ agendamento.quantidade_alunos }}</td>
+                                    <td>
+                                        {{ 'Prof' if agendamento.checkin_realizado else '-' }} +
+                                        {{ agendamento.alunos|selectattr('presente')|list|length }}
+                                    </td>
+                                    <td>
+                                        {{ agendamento.data_checkin.strftime('%d/%m/%Y %H:%M') if agendamento.data_checkin else '-' }}
+                                    </td>
+                                    <td>{{ agendamento.status }}</td>
+                                </tr>
+                                {% set presentes = agendamento.alunos|selectattr('presente')|list %}
+                                {% if presentes %}
+                                <tr>
+                                    <td colspan="9">
+                                        <ul class="mb-0">
+                                            {% for aluno in presentes %}
+                                            <li>{{ aluno.nome }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </td>
+                                </tr>
+                                {% endif %}
                                 {% endfor %}
-                            </ul>
-                        </td>
-                    </tr>
-                    {% endif %}
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% else %}
-            <div class="alert alert-info mb-0">Nenhum agendamento no período.</div>
-            {% endif %}
+                            </tbody>
+                        </table>
+                        {% else %}
+                        <div class="alert alert-info mb-0">
+                            Nenhum agendamento no período.
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="professores"
+                     role="tabpanel" aria-labelledby="professores-tab">
+                    <div class="table-responsive">
+                        {% if professores_confirmados %}
+                        <table class="table table-striped">
+                            <thead>
+                                <tr>
+                                    <th>Nome</th>
+                                    <th>Email</th>
+                                    <th>WhatsApp</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for prof in professores_confirmados %}
+                                <tr>
+                                    <td>{{ prof.nome }}</td>
+                                    <td>{{ prof.email }}</td>
+                                    <td>
+                                        <a href="https://api.whatsapp.com/send?phone={{ prof.responsavel_whatsapp }}"
+                                           target="_blank">
+                                            {{ prof.responsavel_whatsapp }}
+                                        </a>
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        {% else %}
+                        <div class="alert alert-info mb-0">
+                            Nenhum professor com agendamento confirmado.
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -82,7 +82,13 @@ os.environ.setdefault('DB_PASS', 'test')
 from config import Config
 from app import create_app
 from extensions import db
-from models import Evento, HorarioVisitacao, AgendamentoVisita, AlunoVisitante
+from models import (
+    Evento,
+    HorarioVisitacao,
+    AgendamentoVisita,
+    AlunoVisitante,
+    Usuario,
+)
 from models.user import Cliente
 
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
@@ -118,6 +124,16 @@ def app():
         )
         db.session.add(horario)
         db.session.commit()
+        professor = Usuario(
+            nome='Prof',
+            cpf='00000000000',
+            email='prof@test',
+            senha=generate_password_hash('123'),
+            formacao='x',
+            tipo='professor',
+        )
+        db.session.add(professor)
+        db.session.commit()
         ags = [
             AgendamentoVisita(
                 horario_id=horario.id,
@@ -136,6 +152,8 @@ def app():
                 quantidade_alunos=10,
                 salas_selecionadas='1',
                 status='confirmado',
+                professor_id=professor.id,
+                responsavel_whatsapp='55999999999',
             ),
             AgendamentoVisita(
                 horario_id=horario.id,
@@ -178,12 +196,7 @@ def app():
                 agendamento_id=ags[2].id,
                 nome='Aluno 1',
                 presente=True,
-            ),
-            AlunoVisitante(
-                agendamento_id=ags[2].id,
-                nome='Aluno 2',
-                presente=False,
-            ),
+            )
         ]
         db.session.add_all(alunos)
         db.session.commit()
@@ -248,6 +261,15 @@ def test_template_contains_new_columns(client):
     assert 'Check-in' in html
     assert 'Presentes' in html
     assert 'Aluno 1' in html
+
+
+def test_professores_confirmados_tab(client):
+    login(client)
+    resp = client.get('/relatorio_geral_agendamentos')
+    html = resp.get_data(as_text=True)
+    assert 'Professores Confirmados' in html
+    assert 'prof@test' in html
+    assert 'https://api.whatsapp.com/send?phone=55999999999' in html
 
 
 def test_generate_pdf_uses_service(client, monkeypatch):


### PR DESCRIPTION
## Summary
- list confirmed professors with contact details in agendamento report
- display professor contacts in new report tab
- cover report tab in relatorio tests

## Testing
- `pytest tests/test_relatorio_geral_agendamentos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a695ad96748324a87e75318bb360a8