### PR TITLE
Fix loop index reference in reviewer config template

### DIFF
--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -52,7 +52,7 @@
       <div class="border rounded p-3 mb-3">
         <input type="text" class="form-control mb-2" name="criterio_nome" value="{{ c.nome }}">
         {% for r in c.requisitos %}
-        <input type="text" class="form-control mb-1" name="criterio_{{ loop.parent.loop.index0 }}_requisito" value="{{ r.descricao }}">
+        <input type="text" class="form-control mb-1" name="criterio_{{ loop.parent.index0 }}_requisito" value="{{ r.descricao }}">
         {% endfor %}
         <input type="text" class="form-control mb-1" name="criterio_{{ loop.index0 }}_requisito" placeholder="Novo requisito">
       </div>


### PR DESCRIPTION
## Summary
- Ensure inner requisito loop references the correct outer index in reviewer config template

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a731d919748324a25c35ecffb1cbbb