### PR TITLE
Add date filter option to agendamento report

### DIFF
--- a/templates/agendamento/relatorio_geral_agendamentos.html
+++ b/templates/agendamento/relatorio_geral_agendamentos.html
@@ -14,17 +14,25 @@
         <div class="card-body">
             <form method="GET" action="{{ url_for('agendamento_routes.relatorio_geral_agendamentos') }}">
                 <div class="row">
-                    <div class="col-md-4 mb-3">
+                    <div class="col-md-3 mb-3">
                         <label for="data_inicio" class="form-label">Data Inicial:</label>
                         <input type="date" id="data_inicio" name="data_inicio" class="form-control" value="{{ filtros.data_inicio.strftime('%Y-%m-%d') if filtros.data_inicio else '' }}">
                     </div>
-                    
-                    <div class="col-md-4 mb-3">
+
+                    <div class="col-md-3 mb-3">
                         <label for="data_fim" class="form-label">Data Final:</label>
                         <input type="date" id="data_fim" name="data_fim" class="form-control" value="{{ filtros.data_fim.strftime('%Y-%m-%d') if filtros.data_fim else '' }}">
                     </div>
-                    
-                    <div class="col-md-4 mb-3 d-flex align-items-end">
+
+                    <div class="col-md-3 mb-3">
+                        <label for="tipo_data" class="form-label">Tipo de Data:</label>
+                        <select id="tipo_data" name="tipo_data" class="form-select">
+                            <option value="horario" {% if filtros.tipo_data == 'horario' %}selected{% endif %}>Data da Visita</option>
+                            <option value="agendamento" {% if filtros.tipo_data == 'agendamento' %}selected{% endif %}>Data do Agendamento</option>
+                        </select>
+                    </div>
+
+                    <div class="col-md-3 mb-3 d-flex align-items-end">
                         <div class="d-grid gap-2 d-md-flex w-100">
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-search"></i> Filtrar
@@ -385,7 +393,7 @@
         <a href="{{ url_for('agendamento_routes.eventos_agendamento') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
-        <button type="button" class="btn btn-danger" onclick="window.location.href='{{ url_for('agendamento_routes.relatorio_geral_agendamentos', data_inicio=filtros.data_inicio.strftime('%Y-%m-%d') if filtros.data_inicio else '', data_fim=filtros.data_fim.strftime('%Y-%m-%d') if filtros.data_fim else '', gerar_pdf=1) }}'">
+        <button type="button" class="btn btn-danger" onclick="window.location.href='{{ url_for('agendamento_routes.relatorio_geral_agendamentos', data_inicio=filtros.data_inicio.strftime('%Y-%m-%d') if filtros.data_inicio else '', data_fim=filtros.data_fim.strftime('%Y-%m-%d') if filtros.data_fim else '', tipo_data=filtros.tipo_data, gerar_pdf=1) }}'">
             <i class="fas fa-file-pdf"></i> Gerar PDF
         </button>
     </div>

--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -244,15 +244,26 @@ def test_counts_all_statuses(client, app):
     assert stats['total'] == 5
 
 
-def test_agendamento_created_outside_range_included(client, app):
+def test_filter_by_horario_date_includes_old(client, app):
     login(client)
     with captured_templates(app) as templates:
-        resp = client.get('/relatorio_geral_agendamentos')
+        resp = client.get('/relatorio_geral_agendamentos?tipo_data=horario')
     assert resp.status_code == 200
     template, context = templates[0]
     ags = context['agendamentos']
     assert len(ags) == 5
     assert any(a.escola_nome == 'E5' for a in ags)
+
+
+def test_filter_by_agendamento_date_excludes_old(client, app):
+    login(client)
+    with captured_templates(app) as templates:
+        resp = client.get('/relatorio_geral_agendamentos?tipo_data=agendamento')
+    assert resp.status_code == 200
+    template, context = templates[0]
+    ags = context['agendamentos']
+    assert len(ags) == 4
+    assert all(a.escola_nome != 'E5' for a in ags)
 
 
 def test_template_contains_new_columns(client):


### PR DESCRIPTION
## Summary
- Allow `/relatorio_geral_agendamentos` to filter by visit date or scheduling creation date via `tipo_data`
- Update template to expose `tipo_data` selection and persist when exporting PDF
- Test both filtering modes for expected agendamentos

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError, ModuleNotFoundError: No module named 'bs4')*
- `pytest tests/test_relatorio_geral_agendamentos.py tests/test_relatorio_geral_agendamentos_invalid_dates.py`

------
https://chatgpt.com/codex/tasks/task_e_68a731ff11c883249e1253c1ff7880fb