### PR TITLE
Handle QR check-in processing state and errors

### DIFF
--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -30,6 +30,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const csrfToken = document
         .querySelector('meta[name="csrf-token"]')?.content || '';
 
+    let isProcessing = false;
+
 
 
     async function handleScan(decodedText) {
@@ -45,6 +47,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             token = decodedText;
         }
 
+        let redirected = false;
         try {
             const response = await fetch('/processar_qrcode_agendamento', {
                 method: 'POST',
@@ -55,17 +58,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                 body: JSON.stringify({ token })
             });
 
+            const data = await response.json();
             if (response.ok) {
-                const data = await response.json();
                 await stopScanner();
                 if (data.redirect) {
-
+                    redirected = true;
                     window.location.href = data.redirect;
-
                 }
+            } else {
+                scanResult.innerHTML = `<div class="alert alert-danger">${data.message}</div>`;
             }
         } catch (error) {
             console.error('Erro ao processar QR Code:', error);
+        } finally {
+            if (!redirected) {
+                isProcessing = false;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- initialize QR scan processing guard
- reset processing flag when no redirect
- show server error messages on QR scan failure

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in multiple test modules and missing bs4 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a7398899748324861fdf0e3feeccd3