### PR TITLE
Filter approved reviewers in submission control

### DIFF
--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -57,7 +57,15 @@ def submission_control():
         flash("Acesso negado!", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
     submissions = Submission.query.all()
-    reviewers = Usuario.query.filter_by(tipo="professor").all()
+    reviewers = (
+        Usuario.query
+        .join(RevisorCandidatura, Usuario.email == RevisorCandidatura.email)
+        .filter(
+            Usuario.tipo == "revisor",
+            RevisorCandidatura.status == "aprovado",
+        )
+        .all()
+    )
     config = ConfiguracaoCliente.query.filter_by(
         cliente_id=getattr(current_user, "id", None)
     ).first()

--- a/templates/peer_review/submission_control.html
+++ b/templates/peer_review/submission_control.html
@@ -50,6 +50,8 @@
               data-max="{{ config.num_revisores_max if config else 2 }}">
         {% for r in reviewers %}
         <option value="{{ r.id }}">{{ r.nome }}</option>
+        {% else %}
+        <option disabled>Nenhum revisor aprovado</option>
         {% endfor %}
       </select>
       <small class="form-text text-muted">

--- a/tests/test_submission_control_reviewers.py
+++ b/tests/test_submission_control_reviewers.py
@@ -1,0 +1,113 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
+os.environ.setdefault('DB_PASS', 'x')
+
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models import Usuario, Cliente, RevisorProcess, RevisorCandidatura, Submission
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        admin = Usuario(
+            nome='Admin',
+            cpf='1',
+            email='admin@test',
+            senha=generate_password_hash('123'),
+            formacao='',
+            tipo='admin',
+        )
+        cliente = Cliente(
+            nome='Cli',
+            email='cli@test',
+            senha=generate_password_hash('123'),
+        )
+        db.session.add_all([admin, cliente])
+        db.session.flush()
+        proc = RevisorProcess(cliente_id=cliente.id)
+        db.session.add(proc)
+        db.session.flush()
+        db.session.add_all(
+            [
+                Usuario(
+                    nome='Aprovado',
+                    cpf='2',
+                    email='aprovado@test',
+                    senha=generate_password_hash('123'),
+                    formacao='',
+                    tipo='revisor',
+                ),
+                Usuario(
+                    nome='Pendente',
+                    cpf='3',
+                    email='pendente@test',
+                    senha=generate_password_hash('123'),
+                    formacao='',
+                    tipo='revisor',
+                ),
+            ]
+        )
+        db.session.add_all(
+            [
+                RevisorCandidatura(
+                    process_id=proc.id,
+                    status='aprovado',
+                    email='aprovado@test',
+                ),
+                RevisorCandidatura(
+                    process_id=proc.id,
+                    status='pendente',
+                    email='pendente@test',
+                ),
+            ]
+        )
+        db.session.add(Submission(title='S1', code_hash='h'))
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post('/login', data={'email': 'admin@test', 'senha': '123'}, follow_redirects=True)
+
+
+def test_submission_control_lists_only_approved_reviewers(client, app):
+    login(client)
+    resp = client.get('/submissoes/controle')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Aprovado' in html
+    assert 'Pendente' not in html
+    assert 'Nenhum revisor aprovado' not in html
+
+
+def test_submission_control_shows_placeholder_when_no_approved(client, app):
+    with app.app_context():
+        cand = RevisorCandidatura.query.filter_by(email='aprovado@test').first()
+        cand.status = 'pendente'
+        db.session.commit()
+    login(client)
+    resp = client.get('/submissoes/controle')
+    html = resp.get_data(as_text=True)
+    assert 'Nenhum revisor aprovado' in html


### PR DESCRIPTION
## Summary
- fetch only approved reviewers for submission control
- show placeholder when no approved reviewers available
- test reviewer listing behavior in submission control

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError and ModuleNotFoundError: bs4)*
- `pytest tests/test_submission_control_reviewers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73ae691988324888f87bb85af14ba