### PR TITLE
Render event stats as responsive cards in schedule report

### DIFF
--- a/templates/agendamento/relatorio_geral_agendamentos.html
+++ b/templates/agendamento/relatorio_geral_agendamentos.html
@@ -142,49 +142,80 @@
                 </div>
                 <div class="card-body">
                     {% if estatisticas %}
-                        <div class="table-responsive">
-                            <table class="table table-striped table-hover">
-                                <thead>
-                                    <tr>
-                                        <th>Evento</th>
-                                        <th class="text-center">Confirmados</th>
-                                        <th class="text-center">Realizados</th>
-                                        <th class="text-center">Cancelados</th>
-                                        <th class="text-center">Pendentes</th>
-                                        <th class="text-center">Check-ins</th>
-                                        <th class="text-center">Visitantes</th>
-                                        <th class="text-center">Total</th>
-                                        <th class="text-center">Taxa Conclusão</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for stats in estatisticas.values() %}
-                                        <tr>
-                                            <td>{{ stats.nome }}</td>
-                                            <td class="text-center">{{ stats.confirmados }}</td>
-                                            <td class="text-center">{{ stats.realizados }}</td>
-                                            <td class="text-center">{{ stats.cancelados }}</td>
-                                            <td class="text-center">{{ stats.pendentes }}</td>
-                                            <td class="text-center">{{ stats.checkins }}</td>
-                                            <td class="text-center">{{ stats.visitantes_confirmados }}</td>
-                                            <td class="text-center">{{ stats.total }}</td>
-                                            <td class="text-center">
-                                                {% if stats.confirmados + stats.realizados > 0 %}
-                                                    {% set taxa = (stats.realizados / (stats.confirmados + stats.realizados)) * 100 %}
-                                                    <div class="progress" style="height: 20px;">
-                                                        <div class="progress-bar {% if taxa < 50 %}bg-danger{% elif taxa < 80 %}bg-warning{% else %}bg-success{% endif %}" 
-                                                             role="progressbar" style="width: {{ taxa }}%;">
-                                                            {{ taxa|round }}%
-                                                        </div>
-                                                    </div>
-                                                {% else %}
-                                                    <span class="badge bg-secondary">N/A</span>
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
+                        <div class="row row-cols-1 row-cols-md-2 g-4">
+                            {% for stats in estatisticas.values() %}
+                            <div class="col">
+                                <div class="card h-100">
+                                    <div class="card-header">
+                                        <a class="text-decoration-none d-block" data-bs-toggle="collapse"
+                                           href="#evento{{ loop.index }}" role="button"
+                                           aria-expanded="false" aria-controls="evento{{ loop.index }}">
+                                            {{ stats.nome }}
+                                        </a>
+                                    </div>
+                                    <div class="collapse" id="evento{{ loop.index }}">
+                                        <div class="card-body">
+                                            <ul class="list-group list-group-flush mb-3">
+                                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <span>Confirmados</span>
+                                                    <span class="badge bg-primary rounded-pill">{{ stats.confirmados }}</span>
+                                                </li>
+                                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <span>Realizados</span>
+                                                    <span class="badge bg-success rounded-pill">{{ stats.realizados }}</span>
+                                                </li>
+                                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <span>Cancelados</span>
+                                                    <span class="badge bg-danger rounded-pill">{{ stats.cancelados }}</span>
+                                                </li>
+                                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <span>Pendentes</span>
+                                                    <span class="badge bg-warning text-dark rounded-pill">{{ stats.pendentes }}</span>
+                                                </li>
+                                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <span>Check-ins</span>
+                                                    <span class="badge bg-secondary rounded-pill">{{ stats.checkins }}</span>
+                                                </li>
+                                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <span>Visitantes</span>
+                                                    <span class="badge bg-info text-dark rounded-pill">{{ stats.visitantes_confirmados }}</span>
+                                                </li>
+                                            </ul>
+                                            {% if stats.total > 0 %}
+                                            {% set porcentagem_confirmados = (stats.confirmados / stats.total) * 100 %}
+                                            {% set porcentagem_realizados = (stats.realizados / stats.total) * 100 %}
+                                            {% set porcentagem_cancelados = (stats.cancelados / stats.total) * 100 %}
+                                            {% set porcentagem_pendentes = (stats.pendentes / stats.total) * 100 %}
+                                            <div class="progress" style="height: 20px;">
+                                                <div class="progress-bar bg-primary" role="progressbar"
+                                                     style="width: {{ porcentagem_confirmados }}%;"
+                                                     title="Confirmados: {{ stats.confirmados }}">
+                                                </div>
+                                                <div class="progress-bar bg-success" role="progressbar"
+                                                     style="width: {{ porcentagem_realizados }}%;"
+                                                     title="Realizados: {{ stats.realizados }}">
+                                                </div>
+                                                <div class="progress-bar bg-danger" role="progressbar"
+                                                     style="width: {{ porcentagem_cancelados }}%;"
+                                                     title="Cancelados: {{ stats.cancelados }}">
+                                                </div>
+                                                <div class="progress-bar bg-warning text-dark" role="progressbar"
+                                                     style="width: {{ porcentagem_pendentes }}%;"
+                                                     title="Pendentes: {{ stats.pendentes }}">
+                                                </div>
+                                            </div>
+                                            <div class="d-flex justify-content-between mt-1 small flex-wrap">
+                                                <span class="text-primary">Confirmados</span>
+                                                <span class="text-success">Realizados</span>
+                                                <span class="text-danger">Cancelados</span>
+                                                <span class="text-warning">Pendentes</span>
+                                            </div>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {% endfor %}
                         </div>
                     {% else %}
                         <div class="alert alert-info">


### PR DESCRIPTION
## Summary
- display per-event statistics as responsive Bootstrap cards with collapsible details
- add status distribution progress bars for each event

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a756a817608324bd0c64869e10abfc