### PR TITLE
Order events and reuse stats table

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -449,7 +449,7 @@ def relatorio_geral_agendamentos():
     )
     if evento_id:
         eventos_query = eventos_query.filter(Evento.id == evento_id)
-    eventos_periodo = eventos_query.distinct().all()
+    eventos_periodo = eventos_query.distinct().order_by(Evento.nome).all()
 
     # Estatísticas agregadas em uma única consulta
     aggregados_query = (

--- a/templates/agendamento/relatorio_geral_agendamentos.html
+++ b/templates/agendamento/relatorio_geral_agendamentos.html
@@ -142,50 +142,8 @@
                 </div>
                 <div class="card-body">
                     {% if estatisticas %}
-                        <div class="table-responsive">
-                            <table class="table table-striped table-hover">
-                                <thead>
-                                    <tr>
-                                        <th>Evento</th>
-                                        <th class="text-center">Confirmados</th>
-                                        <th class="text-center">Realizados</th>
-                                        <th class="text-center">Cancelados</th>
-                                        <th class="text-center">Pendentes</th>
-                                        <th class="text-center">Check-ins</th>
-                                        <th class="text-center">Visitantes</th>
-                                        <th class="text-center">Total</th>
-                                        <th class="text-center">Taxa Conclusão</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for stats in estatisticas.values() %}
-                                        <tr>
-                                            <td>{{ stats.nome }}</td>
-                                            <td class="text-center">{{ stats.confirmados }}</td>
-                                            <td class="text-center">{{ stats.realizados }}</td>
-                                            <td class="text-center">{{ stats.cancelados }}</td>
-                                            <td class="text-center">{{ stats.pendentes }}</td>
-                                            <td class="text-center">{{ stats.checkins }}</td>
-                                            <td class="text-center">{{ stats.visitantes_confirmados }}</td>
-                                            <td class="text-center">{{ stats.total }}</td>
-                                            <td class="text-center">
-                                                {% if stats.confirmados + stats.realizados > 0 %}
-                                                    {% set taxa = (stats.realizados / (stats.confirmados + stats.realizados)) * 100 %}
-                                                    <div class="progress" style="height: 20px;">
-                                                        <div class="progress-bar {% if taxa < 50 %}bg-danger{% elif taxa < 80 %}bg-warning{% else %}bg-success{% endif %}" 
-                                                             role="progressbar" style="width: {{ taxa }}%;">
-                                                            {{ taxa|round }}%
-                                                        </div>
-                                                    </div>
-                                                {% else %}
-                                                    <span class="badge bg-secondary">N/A</span>
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
+                        {% set estatisticas_ordenadas = estatisticas.values()|sort(attribute='nome') %}
+                        {% include 'partials/relatorio_evento_table.html' %}
                     {% else %}
                         <div class="alert alert-info">
                             <i class="fas fa-info-circle"></i> Não há dados para o período selecionado.

--- a/templates/partials/relatorio_evento_table.html
+++ b/templates/partials/relatorio_evento_table.html
@@ -1,0 +1,53 @@
+<div class="table-responsive">
+    <table
+        class="table table-striped table-hover table-bordered table-sm align-middle"
+    >
+        <thead class="table-light">
+            <tr>
+                <th>Evento</th>
+                <th class="text-center">Confirmados</th>
+                <th class="text-center">Realizados</th>
+                <th class="text-center">Cancelados</th>
+                <th class="text-center">Pendentes</th>
+                <th class="text-center">Check-ins</th>
+                <th class="text-center">Visitantes</th>
+                <th class="text-center">Total</th>
+                <th class="text-center">Taxa Conclusão</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for stats in estatisticas_ordenadas %}
+                <tr>
+                    <td>{{ stats.nome }}</td>
+                    <td class="text-center">{{ stats.confirmados }}</td>
+                    <td class="text-center">{{ stats.realizados }}</td>
+                    <td class="text-center">{{ stats.cancelados }}</td>
+                    <td class="text-center">{{ stats.pendentes }}</td>
+                    <td class="text-center">{{ stats.checkins }}</td>
+                    <td class="text-center">{{ stats.visitantes_confirmados }}</td>
+                    <td class="text-center">{{ stats.total }}</td>
+                    <td class="text-center">
+                        {% if stats.confirmados + stats.realizados > 0 %}
+                            {% set taxa = (
+                                stats.realizados
+                                / (stats.confirmados + stats.realizados)
+                            ) * 100 %}
+                            <div class="progress" style="height: 20px;">
+                                <div
+                                    class="progress-bar
+                                    {% if taxa < 50 %}bg-danger{% elif taxa < 80 %}
+                                    bg-warning{% else %}bg-success{% endif %}"
+                                    role="progressbar" style="width: {{ taxa }}%;">
+                                    {{ taxa|round }}%
+                                </div>
+                            </div>
+                        {% else %}
+                            <span class="badge bg-secondary">N/A</span>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+


### PR DESCRIPTION
## Summary
- ensure event list is ordered before building statistics
- render event stats table through a reusable partial and sort by name
- apply responsive Bootstrap styling to event stats table

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError and missing bs4 during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a756afb90c83249940e221e3ac0295