### PR TITLE
Handle missing token in QR check-in URL

### DIFF
--- a/templates/checkin/checkin_qr_agendamento.html
+++ b/templates/checkin/checkin_qr_agendamento.html
@@ -43,6 +43,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
             const url = new URL(decodedText);
             token = url.searchParams.get('token');
+            if (!token) {
+                const segments = url.pathname.split('/').filter(Boolean);
+                token = segments.pop() || '';
+            }
         } catch {
             token = decodedText;
         }


### PR DESCRIPTION
## Summary
- Extract token from QR code URL path when missing query parameter

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError: unexpected indent in tests and ModuleNotFoundError: bs4)*

------
https://chatgpt.com/codex/tasks/task_e_68a757edf5148324b8d7f73372014c5b