### PR TITLE
Redirect check-in to role dashboards

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3513,8 +3513,16 @@ def confirmar_checkin_agendamento(token):
                 flash('Check-in realizado com sucesso!', 'success')
             else:
                 flash('Este agendamento já teve check-in realizado anteriormente.', 'warning')
-            
-            return redirect(url_for('dashboard_routes.dashboard_cliente'))
+
+            if current_user.tipo == 'professor':
+                return redirect(
+                    url_for('dashboard_professor.dashboard_professor')
+                )
+            if current_user.tipo == 'cliente':
+                return redirect(
+                    url_for('dashboard_routes.dashboard_cliente')
+                )
+            return redirect(url_for('dashboard_routes.dashboard'))
         
         except Exception as e:
             db.session.rollback()


### PR DESCRIPTION
## Summary
- Redirect check-in completion to appropriate dashboard based on logged user type
- Test redirection for professor, client, and other user roles

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in multiple test files)*
- `pytest tests/test_checkin_routes.py::test_confirmar_checkin_redirect_professor`
- `pytest tests/test_checkin_routes.py::test_confirmar_checkin_redirect_cliente`
- `pytest tests/test_checkin_routes.py::test_confirmar_checkin_redirect_outro_usuario`


------
https://chatgpt.com/codex/tasks/task_e_68a757efe6a88324a8c9eb21a2a9be09