### PR TITLE
Refactor agendamento field names

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1447,9 +1447,12 @@ def criar_agendamento():
             data = request.form.get('data')
             horario_id = request.form.get('horario_id')
             escola_nome = request.form.get('escola_nome')
-            nome_responsavel = request.form.get('nome_responsavel')
-            email_responsavel = request.form.get('email_responsavel')
-            telefone_escola = request.form.get('telefone_escola')
+            responsavel_nome = request.form.get('responsavel_nome')
+            responsavel_cargo = request.form.get('responsavel_cargo')
+            responsavel_email = request.form.get('responsavel_email')
+            responsavel_whatsapp = request.form.get('responsavel_whatsapp')
+            acompanhantes_qtd = request.form.get('acompanhantes_qtd', type=int)
+            acompanhantes_nomes = request.form.get('acompanhantes_nomes')
             turma = request.form.get('turma')
             quantidade_alunos = request.form.get('quantidade_alunos')
             faixa_etaria = request.form.get('faixa_etaria')
@@ -1519,21 +1522,18 @@ def criar_agendamento():
                             turma=turma,
                             nivel_ensino=faixa_etaria,
                             quantidade_alunos=quantidade,
+                            responsavel_nome=responsavel_nome,
+                            responsavel_cargo=responsavel_cargo,
+                            responsavel_email=responsavel_email,
+                            responsavel_whatsapp=responsavel_whatsapp,
+                            acompanhantes_nomes=acompanhantes_nomes,
+                            acompanhantes_qtd=acompanhantes_qtd,
+                            observacoes=observacoes,
+                            compromisso_1=True,
+                            compromisso_2=True,
+                            compromisso_3=True,
+                            compromisso_4=True,
                         )
-                        extra_campos = {
-                            'nome_responsavel': nome_responsavel,
-                            'email_responsavel': email_responsavel,
-                            'telefone_escola': telefone_escola,
-                            'observacoes': observacoes,
-                            'compromisso1': True,
-                            'compromisso2': True,
-                            'compromisso3': True,
-                            'compromisso4': True,
-                            'aceite_final': True,
-                        }
-                        for campo, valor in extra_campos.items():
-                            if valor and hasattr(AgendamentoVisita, campo):
-                                setattr(agendamento, campo, valor)
 
                         horario.vagas_disponiveis -= quantidade
                         db.session.add(agendamento)

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -202,13 +202,20 @@ def criar_agendamento_professor(horario_id):
         # Validar campos obrigatórios
         escola_nome = request.form.get('escola_nome')
         escola_codigo_inep = request.form.get('escola_codigo_inep')
+        rede_ensino = request.form.get('rede_ensino')
+        municipio = request.form.get('municipio')
+        bairro = request.form.get('bairro')
         turma = request.form.get('turma')
         nivel_ensino = request.form.get('nivel_ensino')
         quantidade_alunos = request.form.get('quantidade_alunos', type=int)
         salas_selecionadas = request.form.getlist('salas_selecionadas')
-        nome_responsavel = request.form.get('nome_responsavel')
-        email_responsavel = request.form.get('email_responsavel')
-        telefone_escola = request.form.get('telefone_escola')
+        responsavel_nome = request.form.get('responsavel_nome')
+        responsavel_cargo = request.form.get('responsavel_cargo')
+        responsavel_whatsapp = request.form.get('responsavel_whatsapp')
+        responsavel_email = request.form.get('responsavel_email')
+        acompanhantes_qtd = request.form.get('acompanhantes_qtd', type=int)
+        acompanhantes_nomes = request.form.get('acompanhantes_nomes')
+        precisa_transporte = request.form.get('precisa_transporte')
         observacoes = request.form.get('observacoes')
 
         compromissos = [
@@ -241,28 +248,28 @@ def criar_agendamento_professor(horario_id):
                 cliente_id=current_user.cliente_id,
                 escola_nome=escola_nome,
                 escola_codigo_inep=escola_codigo_inep,
+                rede_ensino=rede_ensino,
+                municipio=municipio,
+                bairro=bairro,
                 turma=turma,
                 nivel_ensino=nivel_ensino,
                 quantidade_alunos=quantidade_alunos,
                 salas_selecionadas=','.join(salas_selecionadas)
                 if salas_selecionadas
                 else None,
+                responsavel_nome=responsavel_nome,
+                responsavel_cargo=responsavel_cargo,
+                responsavel_whatsapp=responsavel_whatsapp,
+                responsavel_email=responsavel_email,
+                acompanhantes_nomes=acompanhantes_nomes,
+                acompanhantes_qtd=acompanhantes_qtd,
+                precisa_transporte=precisa_transporte == 'sim',
+                observacoes=observacoes,
+                compromisso_1=True,
+                compromisso_2=True,
+                compromisso_3=True,
+                compromisso_4=True,
             )
-
-            extra_campos = {
-                'nome_responsavel': nome_responsavel,
-                'email_responsavel': email_responsavel,
-                'telefone_escola': telefone_escola,
-                'observacoes': observacoes,
-                'compromisso1': True,
-                'compromisso2': True,
-                'compromisso3': True,
-                'compromisso4': True,
-                'aceite_final': True,
-            }
-            for campo, valor in extra_campos.items():
-                if valor and hasattr(AgendamentoVisita, campo):
-                    setattr(agendamento, campo, valor)
 
             # Atualizar vagas disponíveis
             horario.vagas_disponiveis -= quantidade_alunos
@@ -871,13 +878,20 @@ def criar_agendamento_participante(horario_id):
         # Obter dados do formulário
         escola_nome = request.form.get('escola_nome')
         escola_codigo_inep = request.form.get('escola_codigo_inep')
+        rede_ensino = request.form.get('rede_ensino')
+        municipio = request.form.get('municipio')
+        bairro = request.form.get('bairro')
         turma = request.form.get('turma')
         nivel_ensino = request.form.get('nivel_ensino')
         quantidade_alunos = request.form.get('quantidade_alunos', type=int)
         salas_selecionadas = request.form.getlist('salas_selecionadas')
-        nome_responsavel = request.form.get('nome_responsavel')
-        email_responsavel = request.form.get('email_responsavel')
-        telefone_escola = request.form.get('telefone_escola')
+        responsavel_nome = request.form.get('responsavel_nome')
+        responsavel_cargo = request.form.get('responsavel_cargo')
+        responsavel_whatsapp = request.form.get('responsavel_whatsapp')
+        responsavel_email = request.form.get('responsavel_email')
+        acompanhantes_qtd = request.form.get('acompanhantes_qtd', type=int)
+        acompanhantes_nomes = request.form.get('acompanhantes_nomes')
+        precisa_transporte = request.form.get('precisa_transporte')
         observacoes = request.form.get('observacoes')
 
         compromissos = [
@@ -910,28 +924,28 @@ def criar_agendamento_participante(horario_id):
                 cliente_id=current_user.cliente_id,
                 escola_nome=escola_nome,
                 escola_codigo_inep=escola_codigo_inep,
+                rede_ensino=rede_ensino,
+                municipio=municipio,
+                bairro=bairro,
                 turma=turma,
                 nivel_ensino=nivel_ensino,
                 quantidade_alunos=quantidade_alunos,
                 salas_selecionadas=','.join(salas_selecionadas)
                 if salas_selecionadas
                 else None,
+                responsavel_nome=responsavel_nome,
+                responsavel_cargo=responsavel_cargo,
+                responsavel_whatsapp=responsavel_whatsapp,
+                responsavel_email=responsavel_email,
+                acompanhantes_nomes=acompanhantes_nomes,
+                acompanhantes_qtd=acompanhantes_qtd,
+                precisa_transporte=precisa_transporte == 'sim',
+                observacoes=observacoes,
+                compromisso_1=True,
+                compromisso_2=True,
+                compromisso_3=True,
+                compromisso_4=True,
             )
-
-            extra_campos = {
-                'nome_responsavel': nome_responsavel,
-                'email_responsavel': email_responsavel,
-                'telefone_escola': telefone_escola,
-                'observacoes': observacoes,
-                'compromisso1': True,
-                'compromisso2': True,
-                'compromisso3': True,
-                'compromisso4': True,
-                'aceite_final': True,
-            }
-            for campo, valor in extra_campos.items():
-                if valor and hasattr(AgendamentoVisita, campo):
-                    setattr(agendamento, campo, valor)
 
             horario.vagas_disponiveis -= quantidade_alunos
             db.session.add(agendamento)

--- a/templates/agendamento/criar_agendamento.html
+++ b/templates/agendamento/criar_agendamento.html
@@ -76,20 +76,37 @@
             
             <!-- Nome do Responsável -->
             <div class="mb-3">
-              <label for="nome_responsavel" class="form-label">Nome do Responsável</label>
-              <input type="text" class="form-control" id="nome_responsavel" name="nome_responsavel">
+              <label for="responsavel_nome" class="form-label">Nome do Responsável</label>
+              <input type="text" class="form-control" id="responsavel_nome" name="responsavel_nome">
             </div>
-            
+
+            <!-- Cargo do Responsável -->
+            <div class="mb-3">
+              <label for="responsavel_cargo" class="form-label">Cargo/Função</label>
+              <input type="text" class="form-control" id="responsavel_cargo" name="responsavel_cargo">
+            </div>
+
             <!-- Email do Responsável -->
             <div class="mb-3">
-              <label for="email_responsavel" class="form-label">Email do Responsável</label>
-              <input type="email" class="form-control" id="email_responsavel" name="email_responsavel">
+              <label for="responsavel_email" class="form-label">Email do Responsável</label>
+              <input type="email" class="form-control" id="responsavel_email" name="responsavel_email">
             </div>
-            
-            <!-- Telefone da Escola -->
+
+            <!-- WhatsApp para Contato -->
             <div class="mb-3">
-              <label for="telefone_escola" class="form-label">Telefone para Contato</label>
-              <input type="tel" class="form-control" id="telefone_escola" name="telefone_escola">
+              <label for="responsavel_whatsapp" class="form-label">WhatsApp para Contato</label>
+              <input type="tel" class="form-control" id="responsavel_whatsapp" name="responsavel_whatsapp">
+            </div>
+
+            <!-- Acompanhantes -->
+            <div class="mb-3">
+              <label for="acompanhantes_qtd" class="form-label">Quantidade de Acompanhantes</label>
+              <input type="number" class="form-control" id="acompanhantes_qtd" name="acompanhantes_qtd" min="0">
+            </div>
+            <div class="mb-3">
+              <label for="acompanhantes_nomes" class="form-label">Lista de Acompanhantes</label>
+              <textarea class="form-control" id="acompanhantes_nomes" name="acompanhantes_nomes" rows="1"></textarea>
+              <small class="text-muted">Separe os nomes por vírgula</small>
             </div>
           </div>
         </div>

--- a/templates/participante/criar_agendamento.html
+++ b/templates/participante/criar_agendamento.html
@@ -119,12 +119,12 @@
                     </div>
                     <div class="row">
                         <div class="col-md-6 mb-3">
-                            <label for="quantidade_acompanhantes" class="form-label">Quantidade de Acompanhantes</label>
-                            <input type="number" class="form-control" id="quantidade_acompanhantes" name="quantidade_acompanhantes" min="0">
+                            <label for="acompanhantes_qtd" class="form-label">Quantidade de Acompanhantes</label>
+                            <input type="number" class="form-control" id="acompanhantes_qtd" name="acompanhantes_qtd" min="0">
                         </div>
                         <div class="col-md-6 mb-3">
-                            <label for="acompanhantes" class="form-label">Lista de Acompanhantes</label>
-                            <textarea class="form-control" id="acompanhantes" name="acompanhantes" rows="1"></textarea>
+                            <label for="acompanhantes_nomes" class="form-label">Lista de Acompanhantes</label>
+                            <textarea class="form-control" id="acompanhantes_nomes" name="acompanhantes_nomes" rows="1"></textarea>
                             <small class="text-muted">Separe os nomes por vírgula</small>
                         </div>
                     </div>
@@ -133,8 +133,8 @@
                 <div class="form-step d-none">
                     <div class="row">
                         <div class="col-md-6 mb-3">
-                            <label for="necessita_transporte" class="form-label">Necessita de Transporte?</label>
-                            <select class="form-select" id="necessita_transporte" name="necessita_transporte">
+                            <label for="precisa_transporte" class="form-label">Necessita de Transporte?</label>
+                            <select class="form-select" id="precisa_transporte" name="precisa_transporte">
                                 <option value="">Selecione...</option>
                                 <option value="sim">Sim</option>
                                 <option value="nao">Não</option>

--- a/templates/professor/criar_agendamento.html
+++ b/templates/professor/criar_agendamento.html
@@ -121,20 +121,20 @@
 
                 <div class="row">
                     <div class="col-md-6 mb-3">
-                        <label for="quantidade_acompanhantes" class="form-label">Quantidade de Acompanhantes</label>
-                        <input type="number" class="form-control" id="quantidade_acompanhantes" name="quantidade_acompanhantes" min="0">
+                        <label for="acompanhantes_qtd" class="form-label">Quantidade de Acompanhantes</label>
+                        <input type="number" class="form-control" id="acompanhantes_qtd" name="acompanhantes_qtd" min="0">
                     </div>
                     <div class="col-md-6 mb-3">
-                        <label for="acompanhantes" class="form-label">Lista de Acompanhantes</label>
-                        <textarea class="form-control" id="acompanhantes" name="acompanhantes" rows="1"></textarea>
+                        <label for="acompanhantes_nomes" class="form-label">Lista de Acompanhantes</label>
+                        <textarea class="form-control" id="acompanhantes_nomes" name="acompanhantes_nomes" rows="1"></textarea>
                         <small class="text-muted">Separe os nomes por vírgula</small>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-6 mb-3">
-                        <label for="necessita_transporte" class="form-label">Necessita de Transporte?</label>
-                        <select class="form-select" id="necessita_transporte" name="necessita_transporte">
+                        <label for="precisa_transporte" class="form-label">Necessita de Transporte?</label>
+                        <select class="form-select" id="precisa_transporte" name="precisa_transporte">
                             <option value="">Selecione...</option>
                             <option value="sim">Sim</option>
                             <option value="nao">Não</option>


### PR DESCRIPTION
## Summary
- capture detailed responsible and accompaniment data directly when professors schedule visits
- mirror new field names in participant and generic agendamento flows
- update templates to match renamed fields

## Testing
- `pytest`
- `pytest tests/test_relatorio_geral_agendamentos.py`

------
https://chatgpt.com/codex/tasks/task_e_68a76176f7b8832484e5dab88c898085