### PR TITLE
Generate absolute URL for check-in QR code

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -4383,6 +4383,7 @@ def qrcode_agendamento(agendamento_id):
     qr_data = url_for(
         'agendamento_routes.checkin_qr_agendamento',
         token=agendamento.qr_code_token,
+        _external=True,
     )
 
     qr = qrcode.QRCode(version=1, box_size=10, border=5)


### PR DESCRIPTION
## Summary
- ensure QR code for agendamentos uses absolute URLs so scanning opens check-in page directly

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a89515438c832497e96d792d8d3806