### PR TITLE
Use HorarioVisitacao data in monitor routes

### DIFF
--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -582,14 +582,16 @@ def editar_monitor(monitor_id):
             HorarioVisitacao, AgendamentoVisita.horario_id == HorarioVisitacao.id
         ).filter(
             MonitorAgendamento.monitor_id == monitor_id
-        ).order_by(AgendamentoVisita.data_visita.desc()).all()
+        ).order_by(HorarioVisitacao.data.desc()).all()
         
         # Estatísticas do monitor
         total_agendamentos = len(agendamentos)
-        agendamentos_hoje = sum(1 for ma, av, hv in agendamentos 
-                               if av.data_visita == datetime.now().date())
-        agendamentos_futuros = sum(1 for ma, av, hv in agendamentos 
-                                  if av.data_visita > datetime.now().date())
+        agendamentos_hoje = sum(
+            1 for ma, av, hv in agendamentos if hv.data == datetime.now().date()
+        )
+        agendamentos_futuros = sum(
+            1 for ma, av, hv in agendamentos if hv.data > datetime.now().date()
+        )
         
         return render_template('editar_monitor.html', 
                              monitor=monitor,
@@ -657,8 +659,8 @@ def distribuicao_manual():
             MonitorAgendamento, AgendamentoVisita.id == MonitorAgendamento.agendamento_id
         ).filter(
             MonitorAgendamento.id.is_(None),
-            AgendamentoVisita.data_visita >= datetime.now().date()
-        ).order_by(AgendamentoVisita.data_visita, HorarioVisitacao.horario_inicio).all()
+            HorarioVisitacao.data >= datetime.now().date()
+        ).order_by(HorarioVisitacao.data, HorarioVisitacao.horario_inicio).all()
         
         # Buscar monitores ativos
         monitores_ativos = Monitor.query.filter_by(ativo=True).order_by(Monitor.nome_completo).all()
@@ -676,8 +678,8 @@ def distribuicao_manual():
         ).join(
             Monitor, MonitorAgendamento.monitor_id == Monitor.id
         ).filter(
-            AgendamentoVisita.data_visita >= datetime.now().date()
-        ).order_by(AgendamentoVisita.data_visita, HorarioVisitacao.horario_inicio).all()
+            HorarioVisitacao.data >= datetime.now().date()
+        ).order_by(HorarioVisitacao.data, HorarioVisitacao.horario_inicio).all()
         
         return render_template('distribuicao_manual.html',
                              agendamentos_sem_monitor=agendamentos_sem_monitor,


### PR DESCRIPTION
## Summary
- Switch monitor editing and manual distribution routes to use `HorarioVisitacao.data`
- Update stats and filtering to rely on schedule dates

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests during collection)*
- Attempted to load `/distribuicao-manual` with Flask test client *(missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9e4607088324ab2168820f23fa5f