### PR TITLE
Ensure Bootstrap scripts run on monitor pages

### DIFF
--- a/templates/monitor/distribuicao_manual.html
+++ b/templates/monitor/distribuicao_manual.html
@@ -240,7 +240,7 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_extra %}
 <script>
 function abrirModalAtribuicao(agendamentoId, dataVisita, horario) {
     document.getElementById('agendamento_id').value = agendamentoId;

--- a/templates/monitor/gerenciar_monitores.html
+++ b/templates/monitor/gerenciar_monitores.html
@@ -298,7 +298,7 @@
 
 {% endblock %}
 
-{% block scripts %}
+{% block scripts_extra %}
 <script>
 // Inicializar tooltips do Bootstrap
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- use `scripts_extra` block in `gerenciar_monitores.html`
- use `scripts_extra` block in `distribuicao_manual.html`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py, tests/test_audit_log_resposta_deletion.py, ModuleNotFoundError: No module named 'bs4', and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9e5977c483248d08c32b1ec8973b