### PR TITLE
Align assignment count key in automatic distribution

### DIFF
--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -1120,7 +1120,7 @@ def distribuir_automaticamente():
                 'message': 'Nenhum monitor ativo encontrado',
             })
         
-        atribuicoes_realizadas = 0
+        atribuicoes = 0
         
         for agendamento in agendamentos_sem_monitor:
             # Determinar o turno do agendamento
@@ -1172,7 +1172,7 @@ def distribuir_automaticamente():
                 )
 
                 db.session.add(atribuicao)
-                atribuicoes_realizadas += 1
+                atribuicoes += 1
                 current_app.logger.info(
                     "Monitor %s atribuído ao agendamento %s",
                     monitor_escolhido.id,
@@ -1184,7 +1184,7 @@ def distribuir_automaticamente():
                     agendamento.id,
                 )
 
-        if atribuicoes_realizadas == 0:
+        if atribuicoes == 0:
             current_app.logger.warning(
                 "Nenhuma atribuição de monitor foi realizada"
             )
@@ -1197,13 +1197,13 @@ def distribuir_automaticamente():
         db.session.commit()
         current_app.logger.info(
             "Distribuição automática concluída com %s atribuições",
-            atribuicoes_realizadas,
+            atribuicoes,
         )
 
         return jsonify({
             'success': True,
             'message': 'Distribuição automática concluída',
-            'atribuicoes': atribuicoes_realizadas,
+            'atribuicoes': atribuicoes,
         })
          
     except Exception as e:

--- a/templates/monitor/distribuicao_automatica.html
+++ b/templates/monitor/distribuicao_automatica.html
@@ -130,7 +130,7 @@ function executarDistribuicaoAutomatica() {
             conteudoDiv.innerHTML = `
                 <div class="alert alert-success">
                     <h6>Distribuição realizada com sucesso!</h6>
-                    <p><strong>Atribuições realizadas:</strong> ${data.atribuicoes_realizadas}</p>
+                    <p><strong>Atribuições realizadas:</strong> ${data.atribuicoes}</p>
                     <p><strong>Mensagem:</strong> ${data.message}</p>
                 </div>
             `;


### PR DESCRIPTION
## Summary
- standardize key name for automatic monitor assignment count
- update automatic distribution template to use new key

## Testing
- `node <<'NODE'
const data={atribuicoes:5,message:'ok',success:true};
const output=`<div class="alert alert-success"><h6>Distribuição realizada com sucesso!</h6><p><strong>Atribuições realizadas:</strong> ${data.atribuicoes}</p><p><strong>Mensagem:</strong> ${data.message}</p></div>`;
console.log(output);
NODE`
- `pytest` *(fails: IndentationError: unexpected indent in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa43db2b88324a3db308debd3d34c