### PR TITLE
Add rollback for read route errors

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1437,6 +1437,7 @@ def criar_agendamento():
         else:
             eventos = Evento.query.all()
     except Exception as e:
+        db.session.rollback()
         flash(f"Erro ao buscar eventos: {str(e)}", "danger")
     
     # Processar o formulário quando enviado via POST
@@ -1661,6 +1662,7 @@ def configurar_horarios_agendamento():
                     } for h in horarios_existentes
                 ]
     except Exception as e:
+        db.session.rollback()
         flash(f"Erro ao buscar eventos: {str(e)}", "danger")
     
     # Processar o formulário quando enviado via POST
@@ -1955,6 +1957,7 @@ def importar_agendamentos():
     try:
         eventos = Evento.query.filter_by(cliente_id=current_user.id).all()
     except Exception as e:
+        db.session.rollback()
         flash(f"Erro ao buscar eventos: {str(e)}", "danger")
     
     # Processar o formulário quando enviado via POST
@@ -2353,6 +2356,7 @@ def criar_periodo_agendamento():
     try:
         eventos = Evento.query.filter_by(cliente_id=current_user.id).all()
     except Exception as e:
+        db.session.rollback()
         flash(f"Erro ao buscar eventos: {str(e)}", "danger")
     
     # Processar o formulário quando enviado via POST

--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -612,6 +612,7 @@ def editar_monitor(monitor_id):
                              agendamentos_futuros=agendamentos_futuros)
         
     except Exception as e:
+        db.session.rollback()
         flash(f'Erro ao carregar dados do monitor: {str(e)}', 'error')
         return redirect(url_for('monitor_routes.gerenciar_monitores'))
 
@@ -698,6 +699,7 @@ def distribuicao_manual():
                              agendamentos_atribuidos=agendamentos_atribuidos)
         
     except Exception as e:
+        db.session.rollback()
         flash(f'Erro ao carregar dados: {str(e)}', 'error')
         return redirect(url_for('monitor_routes.gerenciar_monitores'))
 
@@ -1264,6 +1266,7 @@ def gerar_qrcode(agendamento_id):
         })
         
     except Exception as e:
+        db.session.rollback()
         return jsonify({'success': False, 'message': str(e)})
 
 @monitor_routes.route('/processar-qrcode', methods=['POST'])
@@ -1390,4 +1393,5 @@ def gerar_qrcode_aluno(aluno_id, agendamento_id):
         })
         
     except Exception as e:
+        db.session.rollback()
         return jsonify({'success': False, 'message': str(e)})


### PR DESCRIPTION
## Summary
- Roll back session on monitor edit failure and manual distribution data load errors
- Ensure QR code generation routes and event lookup handlers reset failed sessions
- Add rollbacks to event query error handlers in agendamento routes

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; multiple IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa43aad788324bc678619291712d9