### PR TITLE
Add module-level logger to oficina routes

### DIFF
--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -23,6 +23,8 @@ from models import (
 from models.user import Ministrante, Cliente
 from extensions import db
 import logging
+logger = logging.getLogger(__name__)
+
 from datetime import datetime
 from utils import obter_estados  # ou de onde essa função vem
 from sqlalchemy import text


### PR DESCRIPTION
## Summary
- add module-level `logger` using `logging.getLogger(__name__)` in `oficina_routes`
- ensure logging calls utilize this logger instance

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py and others during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ab10e04832486caa715115acc63