### PR TITLE
Validate ministrante ownership in extra IDs

### DIFF
--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -181,8 +181,13 @@ def criar_oficina():
             ids_extras = request.form.getlist('ministrantes_ids[]')  # array
             for mid in ids_extras:
                 m = Ministrante.query.get(int(mid))
-                if m:
-                    nova_oficina.ministrantes_associados.append(m)
+                if not m:
+                    continue
+                if current_user.tipo == 'cliente' and m.cliente_id != current_user.id:
+                    raise ValueError(
+                        'Ministrante não pertence ao cliente atual.'
+                    )
+                nova_oficina.ministrantes_associados.append(m)
 
             db.session.commit()
             flash('Atividade criada com sucesso!', 'success')


### PR DESCRIPTION
## Summary
- ensure clientes can only attach own ministrantes when creating an oficina

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in test files and ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ab397988324b28cf1261cdec824