### PR TITLE
Validate numeric form fields before conversion

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -2115,10 +2115,22 @@ def criar_evento_agendamento():
                             
                             for nome, preco in zip(nomes_tipos, precos):
                                 if nome and preco:
+                                    try:
+                                        preco_float = float(preco.strip())
+                                    except ValueError:
+                                        db.session.rollback()
+                                        form_erro = (
+                                            "Erro: o campo 'preço' deve conter apenas números."
+                                        )
+                                        flash(form_erro, 'danger')
+                                        return render_template(
+                                            'criar_evento_agendamento.html',
+                                            form_erro=form_erro,
+                                        )
                                     novo_tipo = EventoInscricaoTipo(
                                         evento_id=novo_evento.id,
                                         nome=nome,
-                                        preco=float(preco)
+                                        preco=preco_float,
                                     )
                                     db.session.add(novo_tipo)
                     

--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -204,6 +204,14 @@ def configurar_evento():
             config_certificado = ConfiguracaoCertificadoEvento.query.filter_by(evento_id=evento.id).first()
             oficinas = Oficina.query.filter_by(evento_id=evento.id).order_by(Oficina.titulo).all()
 
+    template_args = {
+        'eventos': eventos,
+        'evento': evento,
+        'habilita_pagamento': True,
+        'config_certificado': config_certificado,
+        'oficinas': oficinas,
+    }
+
     if request.method == 'POST':
         nome = request.form.get('nome')
         descricao = request.form.get('descricao')
@@ -319,7 +327,21 @@ def configurar_evento():
                     if nome_tipo:  # Só adicionar se o nome for preenchido
                         # Se o preço estiver vazio, trata como 0
                         preco_tipo_str = preco_tipo.strip() if preco_tipo else ''
-                        preco_efetivo = 0.0 if inscricao_gratuita or preco_tipo_str == '' else float(preco_tipo_str)
+                        try:
+                            preco_efetivo = (
+                                0.0
+                                if inscricao_gratuita or preco_tipo_str == ''
+                                else float(preco_tipo_str)
+                            )
+                        except ValueError:
+                            flash(
+                                "Erro: o campo 'preço' deve conter apenas números.",
+                                'danger',
+                            )
+                            return render_template(
+                                'evento/configurar_evento.html',
+                                **template_args,
+                            )
                         flag = idx < len(submission_flags) and submission_flags[idx] in ['on', '1', 'true']
                         
                         # Verificar se já existe um tipo com este nome
@@ -442,15 +464,28 @@ def configurar_evento():
 
                                 if preco_valor is not None:
                                     preco_valor = preco_valor.strip()
-                                    # Se o valor estiver vazio ou for gratuito, usar 0
-                                    preco_final = 0.0 if inscricao_gratuita or preco_valor == '' else float(preco_valor)
-                                    
+                                    try:
+                                        preco_final = (
+                                            0.0
+                                            if inscricao_gratuita or preco_valor == ''
+                                            else float(preco_valor)
+                                        )
+                                    except ValueError:
+                                        flash(
+                                            "Erro: o campo 'preço' deve conter apenas números.",
+                                            'danger',
+                                        )
+                                        return render_template(
+                                            'evento/configurar_evento.html',
+                                            **template_args,
+                                        )
+
                                     # Verificar se já existe um registro de preço para este lote e tipo
                                     lote_tipo = LoteTipoInscricao.query.filter_by(
-                                        lote_id=lote.id, 
+                                        lote_id=lote.id,
                                         tipo_inscricao_id=tipo.id
                                     ).first()
-                                    
+
                                     if lote_tipo:
                                         # Atualizar preço existente
                                         lote_tipo.preco = preco_final
@@ -488,7 +523,21 @@ def configurar_evento():
                     if nome_tipo:  # Só adicionar se o nome for preenchido
                         # Se o preço estiver vazio, trata como 0
                         preco_tipo_str = preco_tipo.strip() if preco_tipo else ''
-                        preco_efetivo = 0.0 if inscricao_gratuita or preco_tipo_str == '' else float(preco_tipo_str)
+                        try:
+                            preco_efetivo = (
+                                0.0
+                                if inscricao_gratuita or preco_tipo_str == ''
+                                else float(preco_tipo_str)
+                            )
+                        except ValueError:
+                            flash(
+                                "Erro: o campo 'preço' deve conter apenas números.",
+                                'danger',
+                            )
+                            return render_template(
+                                'evento/configurar_evento.html',
+                                **template_args,
+                            )
                         flag = idx < len(submission_flags) and submission_flags[idx] in ['on', '1', 'true']
 
                         tipo = EventoInscricaoTipo(
@@ -561,9 +610,22 @@ def configurar_evento():
 
                                 if preco_valor is not None:
                                     preco_valor = preco_valor.strip()
-                                    # Se o valor estiver vazio ou for gratuito, usar 0
-                                    preco_final = 0.0 if inscricao_gratuita or preco_valor == '' else float(preco_valor)
-                                    
+                                    try:
+                                        preco_final = (
+                                            0.0
+                                            if inscricao_gratuita or preco_valor == ''
+                                            else float(preco_valor)
+                                        )
+                                    except ValueError:
+                                        flash(
+                                            "Erro: o campo 'preço' deve conter apenas números.",
+                                            'danger',
+                                        )
+                                        return render_template(
+                                            'evento/configurar_evento.html',
+                                            **template_args,
+                                        )
+
                                     novo_lote_tipo = LoteTipoInscricao(
                                         lote_id=lote.id,
                                         tipo_inscricao_id=tipo.id,

--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -90,18 +90,29 @@ def criar_oficina():
         evento_id = request.form.get('evento_id')
 
         # Validação básica dos campos obrigatórios
+        context = {
+            'estados': estados,
+            'ministrantes': ministrantes_disponiveis,
+            'clientes': clientes_disponiveis,
+            'eventos': eventos_disponiveis,
+            'datas': request.form.getlist('data[]'),
+            'horarios_inicio': request.form.getlist('horario_inicio[]'),
+            'horarios_fim': request.form.getlist('horario_fim[]'),
+        }
         if not all([titulo, descricao, vagas, carga_horaria, estado, cidade, evento_id]):
             flash("Erro: Todos os campos obrigatórios devem ser preenchidos!", "danger")
-            return render_template(
-                'criar_oficina.html',
-                estados=estados,
-                ministrantes=ministrantes_disponiveis,
-                clientes=clientes_disponiveis,
-                eventos=eventos_disponiveis,
-                datas=request.form.getlist('data[]'),
-                horarios_inicio=request.form.getlist('horario_inicio[]'),
-                horarios_fim=request.form.getlist('horario_fim[]')
+            return render_template('criar_oficina.html', **context)
+
+        if not vagas.isdigit():
+            flash("Erro: o campo 'vagas' deve conter apenas números.", "danger")
+            return render_template('criar_oficina.html', **context)
+
+        if not carga_horaria.isdigit():
+            flash(
+                "Erro: o campo 'carga horária' deve conter apenas números.",
+                "danger",
             )
+            return render_template('criar_oficina.html', **context)
 
         # Definir o cliente da oficina
         cliente_id = (
@@ -151,12 +162,28 @@ def criar_oficina():
                 nomes_tipos = request.form.getlist('nome_tipo[]')
                 precos = request.form.getlist('preco_tipo[]')
                 if not nomes_tipos or not precos:
-                    raise ValueError("Tipos de inscrição e preços são obrigatórios para oficinas pagas.")
-                for nome, preco in zip(nomes_tipos, precos):
+                    raise ValueError(
+                        "Tipos de inscrição e preços são obrigatórios para oficinas pagas."
+                    )
+                precos_convertidos = []
+                for preco in precos:
+                    preco_str = preco.strip()
+                    if preco_str == '':
+                        flash("Erro: preço inválido.", "danger")
+                        return render_template('criar_oficina.html', **context)
+                    try:
+                        precos_convertidos.append(float(preco_str))
+                    except ValueError:
+                        flash(
+                            "Erro: o campo 'preço' deve conter apenas números.",
+                            "danger",
+                        )
+                        return render_template('criar_oficina.html', **context)
+                for nome, preco in zip(nomes_tipos, precos_convertidos):
                     novo_tipo = InscricaoTipo(
                         oficina_id=nova_oficina.id,
                         nome=nome,
-                        preco=float(preco)
+                        preco=preco,
                     )
                     db.session.add(novo_tipo)
 
@@ -234,11 +261,25 @@ def editar_oficina(oficina_id):
     clientes_disponiveis = Cliente.query.all() if current_user.tipo == 'admin' else []
 
     if request.method == 'POST':
+        context = {
+            'oficina': oficina,
+            'estados': estados,
+            'ministrantes': ministrantes,
+            'clientes': clientes_disponiveis,
+            'eventos': eventos_disponiveis,
+            'datas': request.form.getlist('data[]'),
+            'horarios_inicio': request.form.getlist('horario_inicio[]'),
+            'horarios_fim': request.form.getlist('horario_fim[]'),
+        }
         oficina.titulo = request.form.get('titulo')
         oficina.descricao = request.form.get('descricao')
         ministrante_id = request.form.get('ministrante_id') or None
         oficina.ministrante_id = ministrante_id
-        oficina.carga_horaria = request.form.get('carga_horaria')
+        carga_horaria = request.form.get('carga_horaria')
+        if not carga_horaria.isdigit():
+            flash("O campo 'carga horária' deve conter apenas números.", 'danger')
+            return render_template('editar_oficina.html', **context)
+        oficina.carga_horaria = carga_horaria
         oficina.estado = request.form.get('estado')
         oficina.cidade = request.form.get('cidade')
         oficina.opcoes_checkin = request.form.get('opcoes_checkin')
@@ -263,7 +304,11 @@ def editar_oficina(oficina_id):
         elif tipo_inscricao == 'com_inscricao_sem_limite':
             oficina.vagas = 9999  # Um valor alto para representar "sem limite"
         else:  # com_inscricao_com_limite
-            oficina.vagas = int(request.form.get('vagas'))
+            vagas_val = request.form.get('vagas', '')
+            if not vagas_val.isdigit():
+                flash("O campo 'vagas' deve conter apenas números.", 'danger')
+                return render_template('editar_oficina.html', **context)
+            oficina.vagas = int(vagas_val)
 
         # Permitir que apenas admins alterem o cliente
         if current_user.tipo == 'admin':
@@ -308,17 +353,33 @@ def editar_oficina(oficina_id):
             if not oficina.inscricao_gratuita:
                 # Remove os tipos de inscrição antigos
                 InscricaoTipo.query.filter_by(oficina_id=oficina.id).delete()
-                
+
                 # Adiciona os novos tipos de inscrição
                 nomes_tipos = request.form.getlist('nome_tipo[]')
                 precos = request.form.getlist('preco_tipo[]')
                 if not nomes_tipos or not precos:
-                    raise ValueError("Tipos de inscrição e preços são obrigatórios para oficinas pagas.")
-                for nome, preco in zip(nomes_tipos, precos):
+                    raise ValueError(
+                        "Tipos de inscrição e preços são obrigatórios para oficinas pagas."
+                    )
+                precos_convertidos = []
+                for preco in precos:
+                    preco_str = preco.strip()
+                    if preco_str == '':
+                        flash("Erro: preço inválido.", 'danger')
+                        return render_template('editar_oficina.html', **context)
+                    try:
+                        precos_convertidos.append(float(preco_str))
+                    except ValueError:
+                        flash(
+                            "Erro: o campo 'preço' deve conter apenas números.",
+                            'danger',
+                        )
+                        return render_template('editar_oficina.html', **context)
+                for nome, preco in zip(nomes_tipos, precos_convertidos):
                     novo_tipo = InscricaoTipo(
                         oficina_id=oficina.id,
                         nome=nome,
-                        preco=float(preco)
+                        preco=preco,
                     )
                     db.session.add(novo_tipo)
 


### PR DESCRIPTION
## Summary
- ensure `vagas` and `carga_horaria` are numeric before creating or editing oficinas
- validate `preco_tipo[]` fields across oficina, evento and agendamento flows

## Testing
- `pytest` *(fails: IndentationError in tests during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ab4d09483249e8d16b045e1276c