### PR TITLE
Add role-based redirect after schedule update

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3502,7 +3502,17 @@ def atualizar_status_agendamento(agendamento_id):
             if alunos_existentes < agendamento.quantidade_alunos:
                 flash('Agendamento confirmado! Agora cadastre os alunos participantes.', 'info')
                 return redirect(url_for('routes.adicionar_alunos_professor', agendamento_id=agendamento.id))
-        
+
+        if current_user.tipo == 'professor':
+            return redirect(url_for('agendamento_routes.meus_agendamentos'))
+        if current_user.tipo == 'participante':
+            return redirect(
+                url_for('agendamento_routes.meus_agendamentos_participante')
+            )
+        if current_user.tipo == 'cliente':
+            return redirect(
+                url_for('agendamento_routes.meus_agendamentos_cliente')
+            )
         return redirect(url_for('agendamento_routes.listar_agendamentos'))
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- implement role-specific redirects when updating booking status
- test redirect behavior for professor, participant, and client profiles

## Testing
- `pytest` (fails: IndentationError in tests/test_submission_via_form.py)
- `pytest tests/test_agendamento_confirmacao.py::test_redirecionamento_professor tests/test_agendamento_confirmacao.py::test_redirecionamento_participante tests/test_agendamento_confirmacao.py::test_redirecionamento_cliente -vv`


------
https://chatgpt.com/codex/tasks/task_e_68acb07045b48324b4d861d59a049443