### PR TITLE
Filter participant workshops by selected event

### DIFF
--- a/routes/dashboard_participante.py
+++ b/routes/dashboard_participante.py
@@ -294,6 +294,17 @@ def dashboard_participante():
     
     logger.debug(f"DEBUG [49] -> Total de oficinas encontradas: {len(oficinas)}")
 
+    # Filtra oficinas pelo evento selecionado (inclui atividades gerais)
+    if selected_event_id is not None:
+        oficinas = [
+            o for o in oficinas if o.evento_id == selected_event_id or o.evento_id is None
+        ]
+        logger.debug(
+            "DEBUG [49A] -> Oficinas após filtro por evento %s: %s",
+            selected_event_id,
+            len(oficinas),
+        )
+
     if current_user.tipo_inscricao and getattr(current_user.tipo_inscricao, 'submission_only', False):
         oficinas = []
 

--- a/templates/dashboard/dashboard_participante.html
+++ b/templates/dashboard/dashboard_participante.html
@@ -444,25 +444,27 @@
     <!-- Agrupa oficinas por evento -->
     {% set eventos = {} %}
     {% for oficina in oficinas %}
-      {% if oficina.tipo_inscricao == 'com_inscricao_sem_limite' or oficina.tipo_inscricao == 'com_inscricao_com_limite' %}
-        {% if oficina.evento_id not in eventos %}
-          {% set _ = eventos.update({
-            oficina.evento_id: {
-              'nome': oficina.evento_nome,
-              'data_inicio': oficina.evento_data_inicio,
-              'data_fim': oficina.evento_data_fim,
-              'oficinas': []
-            }
-          }) %}
-        {% else %}
-          {% if not eventos[oficina.evento_id].get('data_inicio') and oficina.evento_data_inicio %}
-            {% set _ = eventos[oficina.evento_id].update({'data_inicio': oficina.evento_data_inicio}) %}
+      {% if not evento or oficina.evento_id == evento.id or oficina.evento_id is none %}
+        {% if oficina.tipo_inscricao == 'com_inscricao_sem_limite' or oficina.tipo_inscricao == 'com_inscricao_com_limite' %}
+          {% if oficina.evento_id not in eventos %}
+            {% set _ = eventos.update({
+              oficina.evento_id: {
+                'nome': oficina.evento_nome,
+                'data_inicio': oficina.evento_data_inicio,
+                'data_fim': oficina.evento_data_fim,
+                'oficinas': []
+              }
+            }) %}
+          {% else %}
+            {% if not eventos[oficina.evento_id].get('data_inicio') and oficina.evento_data_inicio %}
+              {% set _ = eventos[oficina.evento_id].update({'data_inicio': oficina.evento_data_inicio}) %}
+            {% endif %}
+            {% if not eventos[oficina.evento_id].get('data_fim') and oficina.evento_data_fim %}
+              {% set _ = eventos[oficina.evento_id].update({'data_fim': oficina.evento_data_fim}) %}
+            {% endif %}
           {% endif %}
-          {% if not eventos[oficina.evento_id].get('data_fim') and oficina.evento_data_fim %}
-            {% set _ = eventos[oficina.evento_id].update({'data_fim': oficina.evento_data_fim}) %}
-          {% endif %}
+          {% if eventos[oficina.evento_id]['oficinas'].append(oficina) %}{% endif %}
         {% endif %}
-        {% if eventos[oficina.evento_id]['oficinas'].append(oficina) %}{% endif %}
       {% endif %}
     {% endfor %}
     


### PR DESCRIPTION
## Summary
- filter dashboard workshops to selected event and general activities
- adjust template grouping to respect selected event
- add regression test covering event-specific workshop listing

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_submission_via_form.py)*
- `SECRET_KEY=secret DB_PASS=postgres pytest tests/test_dashboard_participante_event_selection.py`

------
https://chatgpt.com/codex/tasks/task_e_68acb150fcb48324a89c0b761903b8ad