### PR TITLE
Allow custom scheduling date range

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1421,7 +1421,15 @@ def gerar_horarios_agendamento(evento_id):
         # Obter datas do form
         data_inicial = datetime.strptime(request.form.get('data_inicial'), '%Y-%m-%d').date()
         data_final = datetime.strptime(request.form.get('data_final'), '%Y-%m-%d').date()
-        
+
+        if data_final < data_inicial:
+            flash('A data final deve ser igual ou posterior à data inicial.', 'danger')
+            return render_template(
+                'gerar_horarios_agendamento.html',
+                evento=evento,
+                config=config,
+            )
+
         # Converter dias da semana para ints
         dias_permitidos = [int(dia) for dia in config.dias_semana.split(',')]
         

--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -80,46 +80,36 @@
 {% block scripts %}
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    // Definir valores padrão para as datas
     const hoje = new Date();
     const dataInicial = document.getElementById('data_inicial');
     const dataFinal = document.getElementById('data_final');
-    
-    // Data inicial: próximo dia útil
-    let dataInicialValue = new Date(hoje);
-    dataInicialValue.setDate(dataInicialValue.getDate() + 1);
-    // Garantir que não seja fim de semana (0 = domingo, 6 = sábado)
-    while(dataInicialValue.getDay() === 0 || dataInicialValue.getDay() === 6) {
-      dataInicialValue.setDate(dataInicialValue.getDate() + 1);
+
+    const inicioEvento = "{{ evento.data_inicio.strftime('%Y-%m-%d') if evento.data_inicio else '' }}";
+    const fimEvento = "{{ evento.data_fim.strftime('%Y-%m-%d') if evento.data_fim else '' }}";
+
+    if (inicioEvento) {
+      dataInicial.min = inicioEvento;
+      dataInicial.value = inicioEvento;
+      dataFinal.min = inicioEvento;
+    } else {
+      const hojeStr = hoje.toISOString().split('T')[0];
+      dataInicial.value = hojeStr;
+      dataFinal.min = hojeStr;
     }
-    
-    // Data final: 30 dias após a data inicial
-    let dataFinalValue = new Date(dataInicialValue);
-    dataFinalValue.setDate(dataFinalValue.getDate() + 30);
-    
-    // Formatar datas para o input (YYYY-MM-DD)
-    dataInicial.value = dataInicialValue.toISOString().split('T')[0];
-    dataFinal.value = dataFinalValue.toISOString().split('T')[0];
-    
-    // Validação: data final deve ser posterior à data inicial
+
+    if (fimEvento) {
+      dataFinal.max = fimEvento;
+      dataFinal.value = fimEvento;
+    } else {
+      dataFinal.value = dataFinal.min;
+    }
+
     dataInicial.addEventListener('change', function() {
-      const minDataFinal = new Date(this.value);
-      minDataFinal.setDate(minDataFinal.getDate() + 1);
-      dataFinal.min = minDataFinal.toISOString().split('T')[0];
-      
-      if (new Date(dataFinal.value) <= new Date(this.value)) {
-        dataFinal.value = minDataFinal.toISOString().split('T')[0];
+      dataFinal.min = this.value;
+      if (dataFinal.value < this.value) {
+        dataFinal.value = this.value;
       }
     });
-    
-    // Definir data mínima como hoje
-    dataInicial.min = hoje.toISOString().split('T')[0];
-    dataFinal.min = dataInicialValue.toISOString().split('T')[0];
-    
-    // Limite máximo de 3 meses (90 dias) para facilitar o gerenciamento
-    const maxDate = new Date(hoje);
-    maxDate.setDate(maxDate.getDate() + 90);
-    dataFinal.max = maxDate.toISOString().split('T')[0];
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove hard-coded 90-day schedule limit and use event start/end bounds when available
- validate only that end date is not before start date on schedule generation backend

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_sortear_revisores.py)*

------
https://chatgpt.com/codex/tasks/task_e_68adebf0e6908324b06ffb28be0c0c6f