### PR TITLE
Return JSON 401 for unauthorized AJAX requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,11 @@
-from flask import Flask, url_for as flask_url_for, send_from_directory
+from flask import (
+    Flask,
+    url_for as flask_url_for,
+    send_from_directory,
+    request,
+    jsonify,
+    redirect,
+)
 from flask_cors import CORS
 from flask_socketio import join_room
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -54,6 +61,16 @@ def create_app():
 
     login_manager.login_view = "auth_routes.login"
     login_manager.session_protection = "strong"
+
+    @login_manager.unauthorized_handler
+    def handle_unauthorized():
+        """Return JSON for unauthorized AJAX requests."""
+        if (
+            request.accept_mimetypes["application/json"]
+            >= request.accept_mimetypes["text/html"]
+        ):
+            return jsonify({"success": False, "message": "Unauthorized"}), 401
+        return redirect(flask_url_for(login_manager.login_view))
 
     # Cache busting para arquivos estáticos
     def versioned_url_for(endpoint: str, **values):

--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -1,3 +1,8 @@
+"""Routes for material management.
+
+Unauthorized AJAX requests receive a JSON 401 from the global handler.
+"""
+
 from flask import Blueprint, render_template, request, jsonify, flash, redirect, url_for, current_app
 from flask_login import login_required, current_user
 from datetime import datetime


### PR DESCRIPTION
## Summary
- Add global unauthorized handler that sends JSON 401 for AJAX requests
- Document material routes to note JSON unauthorized handler

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f49ef19c8324a0f8ddced4dec08a