### PR TITLE
Add monitor material API tests

### DIFF
--- a/tests/test_monitor_material_api.py
+++ b/tests/test_monitor_material_api.py
@@ -1,0 +1,145 @@
+import pytest
+import os
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('DB_PASS', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db, login_manager
+from models.user import Cliente, Monitor
+from models.material import Polo, Material, MonitorPolo
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    login_manager.session_protection = None
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options(
+        app.config['SQLALCHEMY_DATABASE_URI']
+    )
+    with app.app_context():
+        db.create_all()
+
+        cliente = Cliente(nome='Cliente', email='c@test', senha='x')
+        db.session.add(cliente)
+        db.session.commit()
+
+        polo_a = Polo(nome='Polo A', cliente_id=cliente.id, ativo=True)
+        polo_b = Polo(nome='Polo B', cliente_id=cliente.id, ativo=True)
+        db.session.add_all([polo_a, polo_b])
+        db.session.commit()
+
+        mat_a = Material(
+            nome='Material A',
+            polo_id=polo_a.id,
+            cliente_id=cliente.id,
+            quantidade_inicial=1,
+            quantidade_atual=1,
+            quantidade_minima=0,
+        )
+        mat_b = Material(
+            nome='Material B',
+            polo_id=polo_b.id,
+            cliente_id=cliente.id,
+            quantidade_inicial=1,
+            quantidade_atual=1,
+            quantidade_minima=0,
+        )
+        db.session.add_all([mat_a, mat_b])
+        db.session.commit()
+
+        monitor1 = Monitor(
+            nome_completo='Monitor Um',
+            curso='C',
+            carga_horaria_disponibilidade=10,
+            dias_disponibilidade='segunda',
+            turnos_disponibilidade='manha',
+            email='m1@test',
+            telefone_whatsapp='1',
+            codigo_acesso='ABC123',
+            cliente_id=cliente.id,
+        )
+        monitor2 = Monitor(
+            nome_completo='Monitor Dois',
+            curso='C',
+            carga_horaria_disponibilidade=10,
+            dias_disponibilidade='segunda',
+            turnos_disponibilidade='manha',
+            email='m2@test',
+            telefone_whatsapp='2',
+            codigo_acesso='DEF456',
+            cliente_id=cliente.id,
+        )
+        db.session.add_all([monitor1, monitor2])
+        db.session.commit()
+
+        atribuicao = MonitorPolo(
+            monitor_id=monitor1.id,
+            polo_id=polo_a.id,
+            ativo=True,
+        )
+        db.session.add(atribuicao)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_monitor_session(client, monitor_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(monitor_id)
+        sess['_fresh'] = True
+        sess['_id'] = 'test-session'
+        sess['user_type'] = 'monitor'
+
+def test_monitor_with_assignments(client, app):
+    with app.app_context():
+        monitor = Monitor.query.filter_by(email='m1@test').first()
+
+    with client:
+        login_monitor_session(client, monitor.id)
+        resp = client.get('/api/polos')
+        data = resp.get_json()
+        assert resp.status_code == 200
+        assert data['success'] is True
+        assert len(data['polos']) == 1
+        assert data['polos'][0]['nome'] == 'Polo A'
+
+        resp = client.get('/api/materiais')
+        data = resp.get_json()
+        assert resp.status_code == 200
+        assert data['success'] is True
+        assert len(data['materiais']) == 1
+        assert data['materiais'][0]['nome'] == 'Material A'
+
+
+def test_monitor_without_assignments(client, app):
+    with app.app_context():
+        monitor = Monitor.query.filter_by(email='m2@test').first()
+
+    with client:
+        login_monitor_session(client, monitor.id)
+        resp = client.get('/api/polos')
+        data = resp.get_json()
+        assert resp.status_code == 200
+        assert data['success'] is True
+        assert data['polos'] == []
+
+        resp = client.get('/api/materiais')
+        data = resp.get_json()
+        assert resp.status_code == 200
+        assert data['success'] is True
+        assert data['materiais'] == []


### PR DESCRIPTION
## Summary
- test /api/polos returns monitor's assigned polos
- test /api/materiais returns materials for monitor's polos
- verify empty lists for monitors without assignments

## Testing
- `pytest tests/test_monitor_material_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f4a1240c83248e685f6150740be5