### PR TITLE
Add unit price and update timestamp to materials

### DIFF
--- a/migrations/versions/c0f0b9fa83c0_add_preco_unitario_and_data_atualizacao_to_material.py
+++ b/migrations/versions/c0f0b9fa83c0_add_preco_unitario_and_data_atualizacao_to_material.py
@@ -1,0 +1,30 @@
+"""add unit price and update timestamp to material
+
+Revision ID: c0f0b9fa83c0
+Revises: 3e8944025bb5
+Create Date: 2025-02-15 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c0f0b9fa83c0'
+down_revision = '3e8944025bb5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('material', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('preco_unitario', sa.Float(), nullable=True))
+        batch_op.add_column(
+            sa.Column('data_atualizacao', sa.DateTime(), server_default=sa.func.now(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('material', schema=None) as batch_op:
+        batch_op.drop_column('data_atualizacao')
+        batch_op.drop_column('preco_unitario')
+

--- a/models/material.py
+++ b/models/material.py
@@ -51,6 +51,10 @@ class Material(db.Model):
     descricao = db.Column(db.Text, nullable=True)
     unidade = db.Column(db.String(50), nullable=False, default="unidade")  # unidade, kg, litro, etc.
     categoria = db.Column(db.String(100), nullable=True)  # categoria do material
+    preco_unitario = db.Column(db.Float, nullable=True)
+    data_atualizacao = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
     
     # Quantidades
     quantidade_inicial = db.Column(db.Integer, nullable=False, default=0)
@@ -106,11 +110,15 @@ class Material(db.Model):
             'quantidade_minima': self.quantidade_minima,
             'quantidade_necessaria': self.quantidade_necessaria,
             'status_estoque': self.status_estoque,
+            'preco_unitario': self.preco_unitario,
             'ativo': self.ativo,
             'polo_id': self.polo_id,
             'polo_nome': self.polo.nome if self.polo else None,
             'created_at': self.created_at.isoformat() if self.created_at else None,
-            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+            'data_atualizacao': (
+                self.data_atualizacao.isoformat() if self.data_atualizacao else None
+            )
         }
 
 

--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -533,12 +533,13 @@ def criar_material():
         polo = Polo.query.filter_by(id=data['polo_id'], cliente_id=current_user.id).first()
         if not polo:
             return jsonify({'success': False, 'message': 'Polo não encontrado'}), 404
-        
+
         material = Material(
             nome=data['nome'],
             descricao=data.get('descricao'),
             unidade=data.get('unidade', 'unidade'),
             categoria=data.get('categoria'),
+            preco_unitario=data.get('preco_unitario'),
             quantidade_inicial=data.get('quantidade_inicial', 0),
             quantidade_atual=data.get('quantidade_inicial', 0),
             quantidade_minima=data.get('quantidade_minima', 0),
@@ -588,13 +589,17 @@ def atualizar_material(material_id):
             return jsonify({'success': False, 'message': 'Material não encontrado'}), 404
         
         data = request.get_json()
-        
+
         material.nome = data.get('nome', material.nome)
         material.descricao = data.get('descricao', material.descricao)
         material.unidade = data.get('unidade', material.unidade)
         material.categoria = data.get('categoria', material.categoria)
-        material.quantidade_minima = data.get('quantidade_minima', material.quantidade_minima)
+        material.preco_unitario = data.get('preco_unitario', material.preco_unitario)
+        material.quantidade_minima = data.get(
+            'quantidade_minima', material.quantidade_minima
+        )
         material.updated_at = datetime.utcnow()
+        material.data_atualizacao = datetime.utcnow()
         
         db.session.commit()
         

--- a/templates/material/novo_material.html
+++ b/templates/material/novo_material.html
@@ -105,7 +105,7 @@
                             <div class="col-md-6">
                                 <div class="mb-3">
                                     <label for="material-preco" class="form-label">Preço Unitário (R$)</label>
-                                    <input type="number" class="form-control" id="material-preco" min="0" step="0.01" placeholder="0,00">
+                                    <input type="number" class="form-control" id="material-preco" name="preco_unitario" min="0" step="0.01" placeholder="0,00">
                                     <div class="form-text">Opcional - para controle de custos</div>
                                 </div>
                             </div>

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,0 +1,89 @@
+import io
+import pandas as pd
+import pytest
+import os
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "y")
+os.environ.setdefault("DB_PASS", "test")
+
+from flask import Flask
+from config import Config
+from extensions import db, login_manager, csrf
+from models.material import Polo
+from models.user import Cliente
+from routes.material_routes import material_routes
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test"
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = Config.build_engine_options(
+        "sqlite://"
+    )
+    login_manager.init_app(app)
+    db.init_app(app)
+    csrf.init_app(app)
+    app.register_blueprint(material_routes)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return Cliente.query.get(int(user_id))
+
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome="Cli", email="cli@test", senha="123")
+        db.session.add(cliente)
+        db.session.commit()
+        polo = Polo(nome="Polo 1", cliente_id=cliente.id)
+        db.session.add(polo)
+        db.session.commit()
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+
+
+def test_criar_material_com_preco_e_gerar_relatorio(app, client):
+    with app.app_context():
+        cliente = Cliente.query.first()
+        polo = Polo.query.first()
+
+    login(client, cliente.id)
+
+    resp = client.post(
+        "/api/materiais",
+        json={
+            "polo_id": polo.id,
+            "nome": "Papel",
+            "unidade": "un",
+            "quantidade_inicial": 5,
+            "quantidade_minima": 1,
+            "preco_unitario": 2.5,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["material"]["preco_unitario"] == 2.5
+    assert data["material"]["data_atualizacao"] is not None
+
+    resp = client.get("/relatorio", query_string={"polo_id": polo.id})
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    df = pd.read_excel(io.BytesIO(resp.data), sheet_name="Materiais")
+    assert float(df.loc[0, "Preço Unitário"]) == pytest.approx(2.5)
+    assert df.loc[0, "Última Atualização"] != ""
+


### PR DESCRIPTION
## Summary
- track material unit price and update timestamp
- include new fields in creation/update APIs and Excel report
- add migration, template support, and tests for material pricing

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: missing dependencies and indentation errors in unrelated tests)*
- `pytest tests/test_material.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6fe8d79f883249d031e3efcfc9f75