### PR TITLE
Separate material report routes

### DIFF
--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -469,12 +469,12 @@ function gerarRelatorioGeral() {
 
 // Gerar lista de compras
 function gerarListaCompras() {
-    window.open('/relatorio?tipo=compras', '_blank');
+    window.open('/relatorios/materiais/excel?tipo=compras', '_blank');
 }
 
 // Função para baixar relatório em Excel
 function baixarRelatorioExcel(tipo = 'geral', poloId = null) {
-    let url = `/relatorio?tipo=${tipo}`;
+    let url = `/relatorios/materiais/excel?tipo=${tipo}`;
     if (poloId) {
         url += `&polo_id=${poloId}`;
     }

--- a/static/js/monitor_materiais.js
+++ b/static/js/monitor_materiais.js
@@ -443,7 +443,7 @@ function copiarTextoWhatsApp() {
 async function gerarRelatorio() {
     try {
         const poloId = document.getElementById('filtro-polo').value;
-        const url = poloId ? `/relatorio?polo_id=${poloId}` : '/relatorio';
+        const url = poloId ? `/relatorios/materiais/excel?polo_id=${poloId}` : '/relatorios/materiais/excel';
         
         const response = await fetch(url);
         

--- a/tests/test_material_report_routes.py
+++ b/tests/test_material_report_routes.py
@@ -1,0 +1,74 @@
+import os
+
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
+os.environ.setdefault('DB_PASS', 'postgres')
+
+import pytest
+from werkzeug.security import generate_password_hash
+from config import Config
+from app import create_app
+from extensions import db
+from models.user import Cliente
+from models.material import Polo, Material
+
+
+@pytest.fixture
+def app():
+    Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+    Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+        Config.SQLALCHEMY_DATABASE_URI
+    )
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome='Cli',
+            email='cli@test',
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
+        )
+        polo = Polo(nome='Polo', cliente=cliente)
+        material = Material(
+            nome='Caneta',
+            unidade='unidade',
+            quantidade_atual=10,
+            quantidade_minima=5,
+            polo=polo,
+            cliente=cliente,
+        )
+        material.preco_unitario = 1
+        db.session.add_all([cliente, polo, material])
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_excel_report_route(client):
+    login(client, 'cli@test', '123')
+    resp = client.get('/relatorios/materiais/excel')
+    assert resp.status_code == 200
+    assert (
+        resp.mimetype
+        == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    )
+
+
+def test_json_report_route(client):
+    login(client, 'cli@test', '123')
+    resp = client.get('/api/materiais/relatorio')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success'] is True
+    assert isinstance(data['materiais'], list)


### PR DESCRIPTION
## Summary
- Split material report endpoints: `/relatorios/materiais/excel` for Excel downloads and `/api/materiais/relatorio` for JSON/WhatsApp
- Update front-end scripts to call the new Excel endpoint
- Add tests covering both report routes

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in unrelated tests)*
- `pytest tests/test_material_report_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fe8ead148324aea97c877aa62338