### PR TITLE
Handle monitors without polos

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -99,9 +99,18 @@ def listar_polos():
             polos = (
                 db.session.query(Polo)
                 .join(MonitorPolo, MonitorPolo.polo_id == Polo.id)
-                .filter(MonitorPolo.monitor_id == current_user.id, MonitorPolo.ativo == True, Polo.ativo == True)
+                .filter(
+                    MonitorPolo.monitor_id == current_user.id,
+                    MonitorPolo.ativo == True,
+                    Polo.ativo == True
+                )
                 .all()
             )
+            if not polos:
+                return jsonify({
+                    'success': False,
+                    'message': 'Nenhum polo associado ao monitor'
+                })
         elif verificar_acesso_admin():
             polos = Polo.query.filter_by(ativo=True).all()
         else:

--- a/static/js/monitor_materiais.js
+++ b/static/js/monitor_materiais.js
@@ -29,12 +29,6 @@ async function carregarDadosIniciais() {
     try {
         mostrarCarregando(true);
 
-        // Carregar polos e materiais
-        const [polosResponse, materiaisResponse] = await Promise.all([
-            fetch('/api/polos'),
-            fetch('/api/materiais')
-        ]);
-
         const parseAndValidate = async (response) => {
             const contentType = response.headers.get('Content-Type') || '';
             if (!contentType.includes('application/json')) {
@@ -47,9 +41,14 @@ async function carregarDadosIniciais() {
             return data;
         };
 
+        // Carregar polos primeiro
+        const polosResponse = await fetch('/api/polos');
         const polosJson = await parseAndValidate(polosResponse);
-        const materiaisJson = await parseAndValidate(materiaisResponse);
         polosData = polosJson.polos || [];
+
+        // Carregar materiais somente se houver polos
+        const materiaisResponse = await fetch('/api/materiais');
+        const materiaisJson = await parseAndValidate(materiaisResponse);
         materiaisData = materiaisJson.materiais || [];
 
         atualizarCardsPolos();


### PR DESCRIPTION
## Summary
- Return an explicit error when a monitor has no associated polos
- Load polos before materials in monitor view and surface backend error messages

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests and missing bs4/Submissao)*

------
https://chatgpt.com/codex/tasks/task_e_68b7124cf744832487ff2cc8f514be5b