### PR TITLE
Guard optional event listeners in material_gerenciar.js

### DIFF
--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -35,11 +35,11 @@ function configurarEventos() {
     
     // Forms
     // Event listeners removidos - agora usando páginas separadas
-    document.getElementById('form-movimentacao').addEventListener('submit', salvarMovimentacao);
-    
+    document.getElementById('form-movimentacao')?.addEventListener('submit', salvarMovimentacao);
+
     // Exportação WhatsApp
-    document.getElementById('tipo-exportacao').addEventListener('change', gerarTextoWhatsApp);
-    document.getElementById('polo-exportacao').addEventListener('change', gerarTextoWhatsApp);
+    document.getElementById('tipo-exportacao')?.addEventListener('change', gerarTextoWhatsApp);
+    document.getElementById('polo-exportacao')?.addEventListener('change', gerarTextoWhatsApp);
 }
 
 // Carregar dados iniciais


### PR DESCRIPTION
## Summary
- Avoid errors if optional material management DOM elements are missing

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b7178bbcb483249d996789e84ec5d2