### PR TITLE
Centralize dashboard endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A Flask-based management system.
 
 Consulte [AGENTS.md](AGENTS.md) para convenções de código, práticas de commit e requisitos de testes. Siga essas orientações ao colaborar.
 
+## Dashboard endpoints
+
+Os nomes dos endpoints do dashboard são centralizados em `utils/endpoints.py`.
+Atualize este módulo ao adicionar ou renomear rotas relacionadas ao dashboard
+para garantir que os redirecionamentos em todo o projeto permaneçam
+consistentes.
+
 
 ## Configuracao
 

--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -12,6 +12,7 @@ from services.mailjet_service import send_via_mailjet
 from services import pdf_service
 from mailjet_rest.client import ApiError
 import logging
+from utils import endpoints
 
 from utils.arquivo_utils import arquivo_permitido
 from utils.dia_semana import dia_semana
@@ -359,7 +360,7 @@ def eventos_agendamento():
     # Verificar se é um cliente
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     hoje = datetime.utcnow().date()
     
@@ -421,7 +422,7 @@ def relatorio_geral_agendamentos():
     # Verificar se é um cliente
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Filtros de data
     data_inicio_raw = request.args.get('data_inicio')
@@ -936,7 +937,7 @@ def editar_horario_agendamento():
     # Verificar se é um cliente
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     horario_id = request.form.get('horario_id', type=int)
     horario = HorarioVisitacao.query.get_or_404(horario_id)
@@ -945,7 +946,7 @@ def editar_horario_agendamento():
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Coletar dados do formulário
     horario_inicio = request.form.get('horario_inicio')
@@ -1001,7 +1002,7 @@ def excluir_horario_agendamento():
     # Verificar se é um cliente
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     horario_id = request.form.get('horario_id', type=int)
     horario = HorarioVisitacao.query.get_or_404(horario_id)
@@ -1011,7 +1012,7 @@ def excluir_horario_agendamento():
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Verificar se existem agendamentos para este horário
     agendamentos = AgendamentoVisita.query.filter(
@@ -1053,12 +1054,12 @@ def excluir_todos_horarios_agendamento(evento_id):
     """Remove todos os horários de um evento e cancela agendamentos."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     evento = Evento.query.get_or_404(evento_id)
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     try:
         horarios = HorarioVisitacao.query.filter_by(evento_id=evento_id).all()
@@ -1694,7 +1695,7 @@ def configurar_agendamentos(evento_id):
     # Apenas clientes podem configurar agendamentos
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para organizadores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     tipos_inscricao = EventoInscricaoTipo.query.filter_by(evento_id=evento_id).all()
@@ -1702,7 +1703,7 @@ def configurar_agendamentos(evento_id):
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Verificar se já existe configuração
     config = ConfiguracaoAgendamento.query.filter_by(
@@ -1792,14 +1793,14 @@ def gerar_horarios_agendamento(evento_id):
     """
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para organizadores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     config = ConfiguracaoAgendamento.query.filter_by(evento_id=evento_id).first_or_404()
     
@@ -1891,14 +1892,14 @@ def listar_horarios_agendamento(evento_id):
     """
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para organizadores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Agrupar horários por data
     horarios = HorarioVisitacao.query.filter_by(evento_id=evento_id).order_by(
@@ -1929,14 +1930,14 @@ def salas_visitacao(evento_id):
     """
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para organizadores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     if request.method == 'POST':
         nome = request.form.get('nome')
@@ -1974,14 +1975,14 @@ def gerar_relatorio_agendamentos(evento_id):
     """Gera um PDF com agendamentos que tiveram presença via QR code."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     
     # Verificar se o evento pertence ao cliente
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Filtros (mesmos da listagem)
     data_inicio = request.args.get('data_inicio')
@@ -2172,7 +2173,7 @@ def criar_agendamento():
                                         agendamento_id=agendamento.id,
                                     )
                                 )
-                            return redirect(url_for('dashboard_routes.dashboard'))
+                            return redirect(url_for(endpoints.DASHBOARD))
                         except Exception as e:
                             db.session.rollback()
                             form_erro = f"Erro ao salvar agendamento: {str(e)}"
@@ -2449,7 +2450,7 @@ def criar_evento_agendamento():
     # Verificação de permissão
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Inicialização de variáveis
     form_erro = None
@@ -2912,11 +2913,11 @@ def salvar_config_agendamento():
         # Validar dados
         if not capacidade_maxima or capacidade_maxima < 1:
             flash("A capacidade máxima deve ser um número positivo.", "danger")
-            return redirect(url_for('dashboard_routes.dashboard_agendamentos', _anchor='configuracoes'))
+            return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS, _anchor='configuracoes'))
             
         if not dias_antecedencia or dias_antecedencia < 1:
             flash("Os dias de antecedência devem ser um número positivo.", "danger")
-            return redirect(url_for('dashboard_routes.dashboard_agendamentos', _anchor='configuracoes'))
+            return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS, _anchor='configuracoes'))
             
         # Buscar configuração atual de agendamento do cliente
         config_agendamento = None
@@ -2958,7 +2959,7 @@ def salvar_config_agendamento():
         # Se você tiver campos adicionais, o código para salvá-los seria inserido aqui
             
         # Redirecionar de volta para a página de configurações
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos', _anchor='configuracoes'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS, _anchor='configuracoes'))
             
     except Exception as e:
         # Log de erro para depuração
@@ -2968,7 +2969,7 @@ def salvar_config_agendamento():
         flash(f"Erro ao salvar configurações: {str(e)}", "danger")
         
         # Redirecionar de volta para a página de configurações
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos', _anchor='configuracoes'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS, _anchor='configuracoes'))
 
 @agendamento_routes.route('/criar-periodo-agendamento', methods=['GET', 'POST'])
 @login_required
@@ -3042,7 +3043,7 @@ def criar_periodo_agendamento():
 @login_required
 def editar_periodo(periodo_id):
     flash('Funcionalidade de edição de período ainda não implementada.', 'info')
-    return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+    return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
 
 
 @agendamento_routes.route('/editar_sala_visitacao/<int:sala_id>', methods=['GET', 'POST'])
@@ -3063,7 +3064,7 @@ def excluir_todos_agendamentos():
         # Verificar se o cliente tem permissão para excluir agendamentos
         if not current_user.is_admin and not current_user.is_cliente:
             flash("Você não tem permissão para realizar esta operação.", "danger")
-            return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+            return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
         
         # Buscar todos os eventos do cliente
         eventos = Evento.query.filter_by(cliente_id=current_user.id).all()
@@ -3098,7 +3099,7 @@ def excluir_todos_agendamentos():
             flash("Operação simulada: Todos os agendamentos foram excluídos com sucesso.", "success")
         
         # Redirecionar para o dashboard de agendamentos
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
             
     except Exception as e:
         # Em caso de erro, fazer rollback das alterações
@@ -3112,7 +3113,7 @@ def excluir_todos_agendamentos():
         flash(f"Erro ao excluir agendamentos: {str(e)}", "danger")
         
         # Redirecionar para o dashboard
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
     
 @agendamento_routes.route('/resetar-configuracoes-agendamento', methods=['POST'])
 @login_required
@@ -3125,7 +3126,7 @@ def resetar_configuracoes_agendamento():
         # Verificar se o cliente tem permissão para resetar configurações
         if not current_user.is_admin and not current_user.is_cliente:
             flash("Você não tem permissão para realizar esta operação.", "danger")
-            return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+            return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
         
         # Buscar configuração atual de agendamento do cliente
         config_agendamento = None
@@ -3168,7 +3169,7 @@ def resetar_configuracoes_agendamento():
             flash("Operação simulada: Configurações resetadas para valores padrão.", "success")
         
         # Redirecionar para o dashboard de agendamentos, aba configurações
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos', _anchor='configuracoes'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS, _anchor='configuracoes'))
             
     except Exception as e:
         # Em caso de erro, fazer rollback das alterações
@@ -3182,7 +3183,7 @@ def resetar_configuracoes_agendamento():
         flash(f"Erro ao resetar configurações: {str(e)}", "danger")
         
         # Redirecionar para o dashboard
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos', _anchor='configuracoes'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS, _anchor='configuracoes'))
     
 @agendamento_routes.route('/exportar-agendamentos')
 @login_required
@@ -3202,7 +3203,7 @@ def exportar_agendamentos():
         # Validar o formato solicitado
         if formato not in ['csv', 'excel']:
             flash("Formato de exportação inválido. Use 'csv' ou 'excel'.", "danger")
-            return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+            return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
         
         # Buscar dados para exportação
         # Em uma implementação real, você buscaria os agendamentos do banco de dados
@@ -3401,7 +3402,7 @@ def exportar_agendamentos():
         flash(f"Erro ao exportar agendamentos: {str(e)}", "danger")
         
         # Redirecionar para o dashboard
-        return redirect(url_for('dashboard_routes.dashboard_agendamentos'))
+        return redirect(url_for(endpoints.DASHBOARD_AGENDAMENTOS))
 
 @agendamento_routes.route('/sala_visitacao/<int:sala_id>/excluir', methods=['POST'])
 @login_required
@@ -4137,7 +4138,7 @@ def listar_cadastros_pendentes():
     # Verificar se é um cliente ou administrador
     if current_user.tipo not in ['cliente', 'admin']:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Definir os parâmetros de filtro
     page = request.args.get('page', 1, type=int)
@@ -4410,9 +4411,9 @@ def confirmar_checkin_agendamento(token):
                 )
             if current_user.tipo == 'cliente':
                 return redirect(
-                    url_for('dashboard_routes.dashboard_cliente')
+                    url_for(endpoints.DASHBOARD_CLIENTE)
                 )
-            return redirect(url_for('dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD))
         
         except Exception as e:
             db.session.rollback()
@@ -4589,7 +4590,7 @@ def adicionar_alunos():
     """
     if current_user.tipo not in ['admin', 'cliente']:
         flash('Você não tem permissão para adicionar alunos.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     if request.method == 'POST':
         # Verifica se há upload de arquivo
@@ -4666,7 +4667,7 @@ def adicionar_alunos():
 
                 db.session.commit()
                 flash(f"✅ {alunos_adicionados} alunos importados com sucesso!", "success")
-                return redirect(url_for('dashboard_routes.dashboard'))
+                return redirect(url_for(endpoints.DASHBOARD))
 
             except Exception as e:
                 db.session.rollback()
@@ -4701,7 +4702,7 @@ def adicionar_alunos():
                 db.session.add(novo_usuario)
                 db.session.commit()
                 flash("Aluno adicionado com sucesso!", "success")
-                return redirect(url_for('dashboard_routes.dashboard'))
+                return redirect(url_for(endpoints.DASHBOARD))
 
             except Exception as e:
                 db.session.rollback()
@@ -4726,7 +4727,7 @@ def importar_alunos():
     """
     if current_user.tipo not in ['admin', 'cliente']:
         flash('Você não tem permissão para importar alunos.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     if request.method == 'POST':
         # Verifica se há upload de arquivo
@@ -4862,7 +4863,7 @@ def cancelar_agendamento(agendamento_id):
 
     if not any((is_admin, is_professor, is_cliente)):
         flash('Você não tem permissão para cancelar este agendamento.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento.status = 'cancelado'
     agendamento.data_cancelamento = datetime.utcnow()
@@ -4880,15 +4881,15 @@ def cancelar_agendamento(agendamento_id):
     if current_user.tipo == 'professor':
         return redirect(url_for('dashboard_professor.dashboard_professor'))
     if current_user.tipo == 'cliente':
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
-    return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 @agendamento_routes.route('/eventos_disponiveis', methods=['GET'])
 @login_required
 def eventos_disponiveis():
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     eventos = Evento.query.filter(Evento.data_inicio >= datetime.utcnow()).order_by(Evento.data_inicio).all()
 
@@ -4899,7 +4900,7 @@ def eventos_disponiveis():
 def listar_eventos_disponiveis():
     if current_user.tipo != 'professor':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     eventos = Evento.query.all()
     return render_template('eventos_disponiveis.html', eventos=eventos)
@@ -4989,7 +4990,7 @@ def meus_agendamentos_participante():
     """Lista agendamentos do participante logado."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     status = request.args.get('status')
 
@@ -5019,7 +5020,7 @@ def meus_agendamentos_cliente():
     """Lista agendamentos do cliente logado com paginação e filtros."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para clientes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Parâmetros de filtro e paginação
     page = request.args.get('page', 1, type=int)
@@ -5086,7 +5087,7 @@ def aprovar_agendamento_cliente(agendamento_id):
     """Permite que o cliente aprove um agendamento pendente."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para clientes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -5165,7 +5166,7 @@ def negar_agendamento_cliente(agendamento_id):
     """Permite que o cliente negue um agendamento pendente."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para clientes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -5203,7 +5204,7 @@ def adicionar_alunos_cliente(agendamento_id):
     """Permite que o cliente adicione alunos a um agendamento."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para clientes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -5287,7 +5288,7 @@ def processar_lote_agendamentos():
     # Verificar permissões
     if current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     try:
         # Obter dados do formulário
@@ -5370,7 +5371,7 @@ def cancelar_agendamento_professor(agendamento_id):
     if current_user.tipo not in ('professor', 'participante'):
         msg = 'Acesso negado! Esta área é exclusiva para professores e participantes.'
         flash(msg, 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
     
@@ -5448,7 +5449,7 @@ def cancelar_agendamento_participante(agendamento_id):
     """Permite que o participante cancele seu agendamento."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -5487,7 +5488,7 @@ def cancelar_agendamento_cliente(agendamento_id):
     """Permite que o cliente cancele um agendamento."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado! Esta área é exclusiva para clientes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -5552,7 +5553,7 @@ def marcar_presenca_aluno(aluno_id):
     """
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     aluno = AlunoVisitante.query.get_or_404(aluno_id)
     agendamento = aluno.agendamento
@@ -5563,7 +5564,7 @@ def marcar_presenca_aluno(aluno_id):
     
     if evento.cliente_id != current_user.id:
         flash('Este agendamento não pertence a um evento seu', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Alternar estado de presença
     aluno.presente = not aluno.presente
@@ -5712,22 +5713,22 @@ def importar_oficinas():
     evento = Evento.query.get(evento_id) if evento_id else None
     if not evento or evento.cliente_id != current_user.id:
         flash("Evento inválido ou não pertence a você!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # 2. Verificar se foi enviado um arquivo
     if "arquivo" not in request.files:
         flash("Nenhum arquivo enviado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     arquivo = request.files["arquivo"]
     if arquivo.filename == "":
         flash("Nenhum arquivo selecionado.", "danger")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # Verifica se a extensão é permitida (.xlsx)
     if not (arquivo_permitido(arquivo.filename) and arquivo.filename.rsplit('.', 1)[1].lower() == "xlsx"):
         flash("Formato de arquivo inválido. Envie um arquivo Excel (.xlsx)", "danger")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # 3. Salvar o arquivo em local temporário
     from werkzeug.utils import secure_filename
@@ -5765,7 +5766,7 @@ def importar_oficinas():
             if col not in df.columns:
                 flash(f"Erro: Coluna '{col}' não encontrada no arquivo Excel!", "danger")
                 os.remove(filepath)
-                return redirect(url_for('dashboard_routes.dashboard_cliente'))
+                return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
         # 4. Percorrer cada linha do DataFrame e criar as oficinas
         total_oficinas_criadas = 0
@@ -5861,7 +5862,7 @@ def importar_oficinas():
         if os.path.exists(filepath):
             os.remove(filepath)
     
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 # API endpoint para materiais de apoio
@@ -6400,5 +6401,3 @@ def historico_comunicacao(agendamento_id):
         current_app.logger.error(f"Erro ao carregar histórico de comunicação: {e}")
         flash('Erro ao carregar histórico de comunicação', 'error')
         return redirect(url_for('agendamento_routes.listar_agendamentos'))
-
-

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,3 +1,4 @@
+from utils import endpoints
 # routes/auth_routes.py
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, current_app
@@ -135,13 +136,13 @@ def login():
         flash('Login realizado com sucesso!', 'success')
 
         destino = {
-            'admin':        'dashboard_routes.dashboard',
-            'cliente':      'dashboard_routes.dashboard',
+            'admin':        endpoints.DASHBOARD,
+            'cliente':      endpoints.DASHBOARD,
             'participante': 'dashboard_participante_routes.dashboard_participante',
             'ministrante':  'dashboard_ministrante_routes.dashboard_ministrante',
             'professor':    'dashboard_professor.dashboard_professor',
-            'superadmin':   'dashboard_routes.dashboard_superadmin'
-        }.get(session.get('user_type'), 'dashboard_routes.dashboard')
+            'superadmin':   endpoints.DASHBOARD_SUPERADMIN
+        }.get(session.get('user_type'), endpoints.DASHBOARD)
 
         try:
             return redirect(next_page or url_for(destino))
@@ -173,13 +174,13 @@ def mfa():
             session['mfa_authenticated'] = True
             flash('Login realizado com sucesso!', 'success')
             destino = {
-                'admin':        'dashboard_routes.dashboard',
-                'cliente':      'dashboard_routes.dashboard',
+                'admin':        endpoints.DASHBOARD,
+                'cliente':      endpoints.DASHBOARD,
                 'participante': 'dashboard_participante_routes.dashboard_participante',
                 'ministrante':  'dashboard_ministrante_routes.dashboard_ministrante',
                 'professor':    'dashboard_professor.dashboard_professor',
-                'superadmin':   'dashboard_routes.dashboard_superadmin'
-            }.get(session.get('user_type'), 'dashboard_routes.dashboard')
+                'superadmin':   endpoints.DASHBOARD_SUPERADMIN
+            }.get(session.get('user_type'), endpoints.DASHBOARD)
             return redirect(next_page or url_for(destino))
         else:
             flash('Código inválido', 'danger')

--- a/routes/campo_routes.py
+++ b/routes/campo_routes.py
@@ -2,6 +2,7 @@ from flask import render_template, Blueprint, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from extensions import db
 from models import CampoPersonalizadoCadastro
+from utils import endpoints
 
 campo_routes = Blueprint('campo_routes', __name__)
 
@@ -10,7 +11,7 @@ campo_routes = Blueprint('campo_routes', __name__)
 def adicionar_campo_personalizado():
     if not (current_user.is_cliente() or getattr(current_user, 'tipo', None) == 'admin'):
         flash('Acesso negado', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     nome_campo = request.form.get('nome_campo')
     tipo_campo = request.form.get('tipo_campo')
     obrigatorio = bool(request.form.get('obrigatorio'))
@@ -20,7 +21,7 @@ def adicionar_campo_personalizado():
     evento = Evento.query.filter_by(id=evento_id, cliente_id=current_user.id).first()
     if not evento:
         flash('Evento inválido', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     novo_campo = CampoPersonalizadoCadastro(
         cliente_id=current_user.id,
@@ -33,27 +34,27 @@ def adicionar_campo_personalizado():
     db.session.commit()
 
     flash('Campo personalizado adicionado com sucesso!', 'success')
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 @campo_routes.route('/remover_campo_personalizado/<int:campo_id>', methods=['POST'])
 @login_required
 def remover_campo_personalizado(campo_id):
     if not (current_user.is_cliente() or getattr(current_user, 'tipo', None) == 'admin'):
         flash('Acesso negado', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     evento_id = request.form.get('evento_id', type=int)
     campo = CampoPersonalizadoCadastro.query.filter_by(id=campo_id, evento_id=evento_id).first_or_404()
 
     if campo.cliente_id != current_user.id and getattr(current_user, 'tipo', None) != 'admin':
         flash('Você não tem permissão para remover este campo.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     db.session.delete(campo)
     db.session.commit()
 
     flash('Campo personalizado removido com sucesso!', 'success')
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @campo_routes.route('/toggle_obrigatorio_campo/<int:campo_id>', methods=['POST'])
@@ -62,20 +63,20 @@ def toggle_obrigatorio_campo(campo_id):
     """Alterna a obrigatoriedade de um campo personalizado de cadastro."""
     if not (current_user.is_cliente() or getattr(current_user, 'tipo', None) == 'admin'):
         flash('Acesso negado', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     evento_id = request.form.get('evento_id', type=int)
     campo = CampoPersonalizadoCadastro.query.filter_by(id=campo_id, evento_id=evento_id).first_or_404()
 
     if campo.cliente_id != current_user.id and getattr(current_user, 'tipo', None) != 'admin':
         flash('Você não tem permissão para alterar este campo.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     campo.obrigatorio = not campo.obrigatorio
     db.session.commit()
 
     flash('Campo atualizado com sucesso!', 'success')
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 
@@ -88,7 +89,7 @@ def preview_cadastro():
     """Mostra uma prévia do formulário de cadastro de participante."""
     if not (current_user.is_cliente() or getattr(current_user, 'tipo', None) == 'admin'):
         flash('Acesso negado', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     from models import Evento, EventoInscricaoTipo, ConfiguracaoCliente
     from utils import preco_com_taxa
@@ -125,4 +126,3 @@ def preview_cadastro():
         cliente_id=current_user.id,
         disable_submit=True
     )
-

--- a/routes/certificado_routes.py
+++ b/routes/certificado_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, send_file, after_this_request
+from utils import endpoints
 
 from flask_login import login_required, current_user
 
@@ -562,7 +563,7 @@ def config_geral():
                              eventos=eventos)
     except Exception as e:
         flash(f'Erro ao carregar configurações: {str(e)}', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 @certificado_routes.route('/templates_personalizaveis')
 @login_required
@@ -806,7 +807,7 @@ def configurar_certificados(evento_id):
     evento = Evento.query.filter_by(id=evento_id, cliente_id=current_user.id).first()
     if not evento:
         flash('Evento não encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     config = ConfiguracaoCertificadoAvancada.query.filter_by(
         evento_id=evento_id, cliente_id=current_user.id
@@ -908,7 +909,7 @@ def gerar_certificado_geral_evento(evento_id):
     evento = Evento.query.filter_by(id=evento_id, cliente_id=current_user.id).first()
     if not evento:
         flash('Evento não encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Verificar se há configuração específica para este evento
     config = ConfiguracaoCertificadoAvancada.query.filter_by(
@@ -917,7 +918,7 @@ def gerar_certificado_geral_evento(evento_id):
     
     if not config or not config.liberacao_geral:
         flash('Certificado geral não está habilitado para este evento', 'warning')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Buscar participantes que fizeram check-in no evento
     participantes_query = db.session.query(
@@ -930,7 +931,7 @@ def gerar_certificado_geral_evento(evento_id):
     
     if not participantes_ids:
         flash('Nenhum participante encontrado para este evento', 'warning')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Gerar certificados para todos os participantes elegíveis
     certificados_gerados = []
@@ -982,7 +983,7 @@ def gerar_certificado_geral_evento(evento_id):
         return send_file(zip_path, as_attachment=True, download_name=f'certificados_{evento.nome}.zip')
     else:
         flash('Nenhum participante atende aos critérios para certificado', 'warning')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @certificado_routes.route('/preview_certificado_geral/<int:evento_id>')
@@ -996,7 +997,7 @@ def preview_certificado_geral(evento_id):
     evento = Evento.query.filter_by(id=evento_id, cliente_id=current_user.id).first()
     if not evento:
         flash('Evento não encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     config = ConfiguracaoCertificadoAvancada.query.filter_by(
         evento_id=evento_id, cliente_id=current_user.id
@@ -1035,7 +1036,7 @@ def preview_certificado_geral(evento_id):
         return send_file(pdf_path, mimetype="application/pdf")
     else:
         flash('Nenhum template encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @certificado_routes.route('/configuracoes_evento/<int:evento_id>')
@@ -1536,7 +1537,7 @@ def gerenciar_regras_certificado(evento_id):
     evento = Evento.query.filter_by(id=evento_id, cliente_id=current_user.id).first()
     if not evento:
         flash('Evento não encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     regras = RegraCertificado.query.filter_by(
         evento_id=evento_id, cliente_id=current_user.id
@@ -2090,7 +2091,7 @@ def gerar_declaracao_individual(evento_id, usuario_id):
     
     if not participacao['participou']:
         flash('Usuário não participou deste evento', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Buscar template ativo
     template = DeclaracaoTemplate.query.filter_by(
@@ -2099,7 +2100,7 @@ def gerar_declaracao_individual(evento_id, usuario_id):
     
     if not template:
         flash('Nenhum template de declaração encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Gerar declaração
     pdf_path = gerar_declaracao_personalizada(usuario, evento, participacao, template, current_user)
@@ -2129,7 +2130,7 @@ def gerar_declaracoes_lote(evento_id):
     
     if not participantes_ids:
         flash('Nenhum participante encontrado para este evento', 'warning')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Buscar template ativo
     template = DeclaracaoTemplate.query.filter_by(
@@ -2138,7 +2139,7 @@ def gerar_declaracoes_lote(evento_id):
     
     if not template:
         flash('Nenhum template de declaração encontrado', 'error')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Gerar declarações
     declaracoes_geradas = []
@@ -2175,7 +2176,7 @@ def gerar_declaracoes_lote(evento_id):
         return send_file(zip_path, as_attachment=True, download_name=f'declaracoes_{evento.nome}.zip')
     else:
         flash('Nenhuma declaração pôde ser gerada', 'warning')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @certificado_routes.route('/declaracoes/preview/<int:template_id>/<int:evento_id>')

--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -8,6 +8,7 @@ from flask import (
     session,
     url_for,
 )
+from utils import endpoints
 
 from flask_login import current_user, login_required
 
@@ -34,7 +35,7 @@ def _admin_required():
         "superadmin",
     ):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     return None
 
 
@@ -68,7 +69,7 @@ def cadastrar_cliente():
         db.session.commit()
 
         flash("Cliente cadastrado com sucesso!", "success")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     return render_template("auth/cadastrar_cliente.html")
 
@@ -114,7 +115,7 @@ def editar_cliente(cliente_id):
             db.session.rollback()
             logger.error("Erro ao atualizar cliente: %s", e, exc_info=True)
             flash(f"Erro ao atualizar cliente: {str(e)}", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     return render_template("auth/editar_cliente.html", cliente=cliente)
 
@@ -125,7 +126,7 @@ def editar_cliente(cliente_id):
 def excluir_cliente(cliente_id):
     if current_user.tipo != "admin":
         flash("Apenas administradores podem excluir clientes.", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
 
     cliente = Cliente.query.get_or_404(cliente_id)
@@ -381,7 +382,7 @@ def excluir_cliente(cliente_id):
         db.session.rollback()
         flash(f"Erro ao excluir cliente: {str(e)}", "danger")
 
-    return redirect(url_for("dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 @cliente_routes.route("/listar_usuarios/<int:cliente_id>")
@@ -393,7 +394,7 @@ def listar_usuarios(cliente_id: int):
     """Exibe os usuários vinculados a um cliente específico."""
     if current_user.tipo != "admin":
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     from models import Usuario, Cliente, usuario_clientes
 
@@ -424,7 +425,7 @@ def restringir_clientes():
     ids = request.form.getlist("cliente_ids")
     if not ids:
         flash("Nenhum cliente selecionado!", "warning")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     clientes = Cliente.query.filter(Cliente.id.in_(ids)).all()
     for cliente in clientes:
@@ -432,7 +433,7 @@ def restringir_clientes():
     db.session.commit()
 
     flash(f"{len(clientes)} cliente(s) atualizados com sucesso!", "success")
-    return redirect(url_for("dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 @cliente_routes.route("/excluir_clientes", methods=["POST"])
@@ -449,13 +450,13 @@ def excluir_clientes():
     ids = request.form.getlist("cliente_ids")
     if not ids:
         flash("Nenhum cliente selecionado!", "warning")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     for cid in ids:
         excluir_cliente(int(cid))
 
     flash(f"{len(ids)} cliente(s) excluídos!", "success")
-    return redirect(url_for("dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 # ---------------------------------------------------------------------------
@@ -486,4 +487,4 @@ def toggle_usuario(usuario_id: int):
     # Redireciona para a lista de usuários do cliente ao qual pertence
     if usuario.cliente_id:
         return redirect(url_for("cliente_routes.listar_usuarios", cliente_id=usuario.cliente_id))
-    return redirect(url_for("dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD))

--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -10,6 +10,7 @@ from flask import (
 )
 from flask_login import login_required, current_user
 from extensions import db
+from utils import endpoints
 
 from models import (
     ConfiguracaoCliente,
@@ -242,7 +243,7 @@ def toggle_certificado_individual():
 
     status = "ativado" if config.habilitar_certificado_individual else "desativado"
     flash(f"Certificado individual {status} com sucesso!", "success")
-    return redirect(url_for("dashboard_routes.dashboard_cliente"))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @config_cliente_routes.route("/toggle_feedback", methods=["POST"])
@@ -259,7 +260,7 @@ def toggle_feedback():
     db.session.commit()
     status = "ativado" if config.habilitar_feedback else "desativado"
     flash(f"Feedback global {status} com sucesso!", "success")
-    return redirect(url_for("dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 @config_cliente_routes.route("/toggle_cliente/<int:cliente_id>")
@@ -267,7 +268,7 @@ def toggle_feedback():
 def toggle_cliente(cliente_id):
     if current_user.tipo != "admin":
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     cliente = Cliente.query.get_or_404(cliente_id)
     logging.debug("Antes: %s", cliente.ativo)
@@ -278,7 +279,7 @@ def toggle_cliente(cliente_id):
     flash(
         f"Cliente {'ativado' if cliente.ativo else 'desativado'} com sucesso", "success"
     )
-    return redirect(url_for("dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 @config_cliente_routes.route("/toggle_submissao_trabalhos", methods=["POST"])
@@ -975,7 +976,7 @@ def config_submissao():
     """Página de configuração das opções de submissão e revisão"""
     if current_user.tipo != "cliente":
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     config_cliente = ConfiguracaoCliente.query.filter_by(
         cliente_id=current_user.id

--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -11,6 +11,7 @@ from flask import (
 from flask_login import login_required, current_user
 from extensions import db
 import logging
+from utils import endpoints
 
 logger = logging.getLogger(__name__)
 from sqlalchemy import func, and_, or_
@@ -45,7 +46,7 @@ from .dashboard_routes import dashboard_routes
 def dashboard_cliente():
     """Renderiza o painel do cliente com estatísticas e candidaturas."""
     if current_user.tipo != 'cliente':
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     logger.debug("Cliente autenticado: %s (ID: %s)", current_user.email, current_user.id)
     logger.debug("Usuário logado: %s", current_user.email)
@@ -749,7 +750,7 @@ def dashboard_agendamentos():
 def update_reviewer_application(app_id):
     """Atualiza o estágio ou status de uma candidatura de revisor."""
     if current_user.tipo not in ('cliente', 'admin'):
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     action = request.form.get('action')
     if request.is_json and not action:
@@ -774,4 +775,4 @@ def update_reviewer_application(app_id):
 
     if request.is_json:
         return {'success': True}
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))

--- a/routes/dashboard_participante.py
+++ b/routes/dashboard_participante.py
@@ -5,6 +5,7 @@ from sqlalchemy import and_
 from typing import Optional
 import logging
 from sqlalchemy.exc import ProgrammingError
+from utils import endpoints
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ def dashboard_participante():
     
     if current_user.tipo != 'participante':
         logger.debug(f"DEBUG [2] -> Redirecionando: usuário não é participante (tipo: {current_user.tipo})")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     logger.debug(f"DEBUG [3] -> Usuário é participante, cliente_id = {current_user.cliente_id}")
 

--- a/routes/dashboard_professor.py
+++ b/routes/dashboard_professor.py
@@ -2,6 +2,7 @@ from flask import Blueprint, render_template, redirect, url_for
 from flask_login import login_required, current_user
 from models import AgendamentoVisita
 from models.review import Review
+from utils import endpoints
 
 dashboard_professor_routes = Blueprint("dashboard_professor", __name__)
 
@@ -9,7 +10,7 @@ dashboard_professor_routes = Blueprint("dashboard_professor", __name__)
 @login_required
 def dashboard_professor():
     if current_user.tipo != 'professor':
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Buscando os agendamentos do professor logado
     agendamentos_professor = AgendamentoVisita.query.filter_by(
@@ -22,5 +23,3 @@ def dashboard_professor():
         agendamentos=agendamentos_professor,
         reviews=reviews,
     )
-
-

--- a/routes/dashboard_routes.py
+++ b/routes/dashboard_routes.py
@@ -13,6 +13,7 @@ from flask import (
 from flask_login import login_required, current_user, login_user
 from utils.taxa_service import calcular_taxa_cliente, calcular_taxas_clientes
 from services.template_service import TemplateService
+from utils import endpoints
 
 dashboard_routes = Blueprint(
     'dashboard_routes',
@@ -28,10 +29,10 @@ def dashboard():
     tipo = getattr(current_user, "tipo", None)
 
     if tipo == "admin":
-        return redirect(url_for("dashboard_routes.dashboard_admin"))
+        return redirect(url_for(endpoints.DASHBOARD_ADMIN))
 
     elif tipo == "cliente":
-        return redirect(url_for("dashboard_routes.dashboard_cliente"))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     elif tipo == "participante":
         return redirect(
@@ -47,7 +48,7 @@ def dashboard():
         return redirect(url_for("dashboard_professor.dashboard_professor"))
 
     elif tipo == "superadmin":
-        return redirect(url_for("dashboard_routes.dashboard_superadmin"))
+        return redirect(url_for(endpoints.DASHBOARD_SUPERADMIN))
 
     abort(403)
 
@@ -239,7 +240,7 @@ def login_as_cliente(cliente_id: int):
     login_user(cliente)
     session['user_type'] = 'cliente'
 
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @dashboard_routes.route('/login_as_usuario/<int:usuario_id>')
@@ -260,7 +261,7 @@ def login_as_usuario(usuario_id: int):
     login_user(usuario)
     session['user_type'] = usuario.tipo
 
-    return redirect(url_for('dashboard_routes.dashboard'))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 @dashboard_routes.route('/encerrar_impersonacao')
@@ -271,7 +272,7 @@ def encerrar_impersonacao():
     impersonator_type = session.get('impersonator_type', 'admin')
 
     if not impersonator_id:
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     from models import Usuario
     admin = Usuario.query.get_or_404(int(impersonator_id))
@@ -282,6 +283,4 @@ def encerrar_impersonacao():
     session.pop('impersonator_id', None)
     session.pop('impersonator_type', None)
 
-    return redirect(url_for('dashboard_routes.dashboard_admin'))
-
-
+    return redirect(url_for(endpoints.DASHBOARD_ADMIN))

--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -2,6 +2,7 @@ import logging
 import os
 from collections import defaultdict
 from datetime import datetime, date, time
+from utils import endpoints
 
 from flask import Blueprint, render_template, redirect, url_for, flash, request, jsonify
 from flask_login import login_required, current_user
@@ -181,7 +182,7 @@ def listar_eventos():
 def configurar_evento():
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # Lista apenas eventos ativos do cliente
     eventos = Evento.query.filter_by(cliente_id=current_user.id, status='ativo').all()
@@ -648,7 +649,7 @@ def configurar_evento():
                 )
                 
             flash('Evento salvo com sucesso!', 'success')
-            return redirect(url_for('dashboard_routes.dashboard_cliente'))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
         
         except Exception as e:
             db.session.rollback()
@@ -671,7 +672,7 @@ def configurar_evento():
 def salvar_config_certificado(evento_id):
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     config = ConfiguracaoCertificadoEvento.query.filter_by(evento_id=evento_id).first()
     if not config:
@@ -695,7 +696,7 @@ def excluir_evento(evento_id):
 
     if current_user.tipo == 'cliente' and evento.cliente_id != current_user.id:
         flash('Você não tem permissão para excluir este evento.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     try:
         # Desassociar usuários do evento
@@ -766,7 +767,7 @@ def excluir_evento(evento_id):
         db.session.rollback()
         flash(f'Erro ao excluir evento: {str(e)}', 'danger')
 
-    return redirect(url_for('dashboard_routes.dashboard_cliente' if current_user.tipo == 'cliente' else 'dashboard_routes.dashboard'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD))
 
 @evento_routes.route('/exibir_evento/<int:evento_id>')
 @login_required
@@ -846,7 +847,7 @@ def preview_evento(evento_id):
 def criar_evento():
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # Para evitar o erro 'evento is undefined' no template
     evento = None
@@ -857,7 +858,7 @@ def criar_evento():
         count_ev = Evento.query.filter_by(cliente_id=current_user.id).count()
         if config_cli and config_cli.limite_eventos is not None and count_ev >= config_cli.limite_eventos:
             flash('Limite de eventos atingido.', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard_cliente'))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
         nome = request.form.get('nome')
         descricao = request.form.get('descricao')
@@ -1020,7 +1021,7 @@ def criar_evento():
             db.session.commit()
             flash('Evento criado com sucesso!', 'success')
             flash('Agora você pode configurar as regras de inscrição para este evento.', 'info')
-            return redirect(url_for('dashboard_routes.dashboard_cliente'))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
         
         except Exception as e:
             db.session.rollback()
@@ -1080,7 +1081,7 @@ def detalhes_evento(evento_id):
 def meus_eventos():
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     eventos = Evento.query.filter_by(cliente_id=current_user.id).order_by(Evento.data_inicio.desc()).all()
     return render_template('evento/meus_eventos.html', eventos=eventos)
@@ -1108,12 +1109,12 @@ def configurar_barema_evento(evento_id):
     """Configurar barema de avaliação para um evento."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     if evento.cliente_id != current_user.id:
         flash('Este evento não pertence a você!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     
     # Buscar ou criar barema do evento
     barema = EventoBarema.query.filter_by(evento_id=evento_id).first()

--- a/routes/feedback_routes.py
+++ b/routes/feedback_routes.py
@@ -3,6 +3,7 @@ from flask_login import login_required, current_user
 from extensions import db
 from models import Feedback, Oficina
 from models.user import Cliente
+from utils import endpoints
 
 feedback_routes = Blueprint('feedback_routes', __name__)
 
@@ -48,7 +49,7 @@ def feedback(oficina_id):
     oficina = Oficina.query.get_or_404(oficina_id)
     if current_user.tipo != 'participante':
         flash('Apenas participantes podem enviar feedback.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     if request.method == 'POST':
         try:
             rating = int(request.form.get('rating', 0))

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -14,6 +14,7 @@ import logging
 import os
 import uuid
 from datetime import datetime
+from utils import endpoints
 
 from flask_login import login_required, current_user
 from utils.mfa import mfa_required
@@ -509,7 +510,7 @@ def preencher_formulario(formulario_id):
 def listar_formularios_participante():
     if current_user.tipo != "participante":
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Busca apenas formulários disponíveis para o participante
     # Filtra formulários criados pelo mesmo cliente ao qual o participante está associado
@@ -851,7 +852,7 @@ def dar_feedback_resposta(resposta_id):
     # só Ministrantes ou Clientes
     if not (isinstance(current_user, Ministrante) or current_user.tipo == "cliente"):
         flash("Apenas clientes e ministrantes podem dar feedback.", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     resposta = RespostaFormulario.query.get_or_404(resposta_id)
 
@@ -859,7 +860,7 @@ def dar_feedback_resposta(resposta_id):
     if current_user.tipo == "cliente":
         if resposta.formulario.cliente_id != current_user.id:
             flash("Acesso negado", "danger")
-            return redirect(url_for("dashboard_routes.dashboard_cliente"))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # Ministrantes só podem avaliar respostas de eventos/oficinas que ministram
     elif isinstance(current_user, Ministrante):
@@ -923,7 +924,7 @@ def dar_feedback_resposta(resposta_id):
 def listar_templates():
     if current_user.tipo not in ["admin", "cliente"]:
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Filter by cliente if not admin
     if current_user.tipo == "cliente":
@@ -942,7 +943,7 @@ def listar_templates():
 def criar_template():
     if current_user.tipo not in ["admin", "cliente"]:
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     if request.method == "POST":
         nome = request.form.get("nome")
@@ -1125,7 +1126,7 @@ def listar_respostas():
     # Verifica se o usuário é cliente ou ministrante
     if current_user.tipo not in ["cliente", "ministrante"]:
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # --- Se for cliente ---
     if current_user.tipo == "cliente":
@@ -1155,7 +1156,7 @@ def listar_respostas():
     # Se não houver respostas
     if not respostas:
         flash("Não há respostas disponíveis no momento.", "info")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     formulario = respostas[0].formulario
 
@@ -1171,7 +1172,7 @@ def definir_status_inline():
     # 0) Verifica se o usuário possui permissão
     if getattr(current_user, "tipo", None) not in ("cliente", "ministrante"):
         flash("Acesso negado!", "danger")
-        return redirect(request.referrer or url_for("dashboard_routes.dashboard"))
+        return redirect(request.referrer or url_for(endpoints.DASHBOARD))
 
     # 1) Pega valores do form
     resposta_id = request.form.get("resposta_id")
@@ -1180,13 +1181,13 @@ def definir_status_inline():
     # 2) Valida
     if not resposta_id or not novo_status:
         flash("Dados incompletos!", "danger")
-        return redirect(request.referrer or url_for("dashboard_routes.dashboard"))
+        return redirect(request.referrer or url_for(endpoints.DASHBOARD))
 
     # 3) Busca a resposta no banco
     resposta = RespostaFormulario.query.get(resposta_id)
     if not resposta:
         flash("Resposta não encontrada!", "warning")
-        return redirect(request.referrer or url_for("dashboard_routes.dashboard"))
+        return redirect(request.referrer or url_for(endpoints.DASHBOARD))
 
     # 4) Atualiza e registra log
     resposta.status_avaliacao = novo_status

--- a/routes/importar_usuarios_routes.py
+++ b/routes/importar_usuarios_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, redirect, url_for, flash
 from werkzeug.security import generate_password_hash
 from werkzeug.utils import secure_filename
+from utils import endpoints
 
 import pandas as pd
 import os
@@ -24,11 +25,11 @@ importar_usuarios_routes = Blueprint('importar_usuarios_routes', __name__)
 def importar_usuarios():
     if "arquivo" not in request.files:
         flash("Nenhum arquivo enviado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     arquivo = request.files["arquivo"]
     if arquivo.filename == "":
         flash("Nenhum arquivo selecionado.", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     if arquivo and arquivo_permitido(arquivo.filename):
         filename = secure_filename(arquivo.filename)
         filepath = os.path.join(current_app.config["UPLOAD_FOLDER"], filename)
@@ -40,7 +41,7 @@ def importar_usuarios():
             colunas_obrigatorias = ["nome", "cpf", "email", "senha", "formacao", "tipo"]
             if not all(col in df.columns for col in colunas_obrigatorias):
                 flash("Erro: O arquivo deve conter as colunas: " + ", ".join(colunas_obrigatorias), "danger")
-                return redirect(url_for('dashboard_routes.dashboard'))
+                return redirect(url_for(endpoints.DASHBOARD))
             total_importados = 0
             for _, row in df.iterrows():
                 cpf_str = str(row["cpf"]).strip()
@@ -73,6 +74,4 @@ def importar_usuarios():
         os.remove(filepath)
     else:
         flash("Formato de arquivo inválido. Envie um arquivo Excel (.xlsx)", "danger")
-    return redirect(url_for('dashboard_routes.dashboard'))
-
-
+    return redirect(url_for(endpoints.DASHBOARD))

--- a/routes/mercadopago_routes.py
+++ b/routes/mercadopago_routes.py
@@ -4,6 +4,7 @@ from extensions import db
 from models import Inscricao, Configuracao, ConfiguracaoCliente
 from models.user import Cliente
 import os
+from utils import endpoints
 
 from services.mp_service import get_sdk
 from decimal import Decimal
@@ -77,7 +78,7 @@ def atualizar_taxa():
         assert 0 <= perc <= 100
     except:
         flash("Percentual da taxa geral inválido", "danger")
-        return redirect(request.referrer or url_for('dashboard_routes.dashboard_admin'))
+        return redirect(request.referrer or url_for(endpoints.DASHBOARD_ADMIN))
 
     cfg = Configuracao.query.first()
     if not cfg:
@@ -108,7 +109,7 @@ def atualizar_taxa():
                 # Verifica se a taxa diferenciada é menor que a taxa geral
                 if perc_cliente >= perc:
                     flash("A taxa diferenciada deve ser menor que a taxa geral do sistema", "danger")
-                    return redirect(request.referrer or url_for('dashboard_routes.dashboard_admin'))
+                    return redirect(request.referrer or url_for(endpoints.DASHBOARD_ADMIN))
                     
                 # Busca a configuração do cliente ou cria uma nova
                 if not config_cliente:
@@ -120,8 +121,8 @@ def atualizar_taxa():
                 flash(f"Taxa diferenciada para cliente ID {cliente_id} salva com sucesso!", "success")
             except:
                 flash("Erro ao salvar a taxa diferenciada. Verifique os valores informados.", "danger")
-                return redirect(request.referrer or url_for('dashboard_routes.dashboard_admin'))
+                return redirect(request.referrer or url_for(endpoints.DASHBOARD_ADMIN))
     
     db.session.commit()
     flash("Percentual geral salvo!", "success")
-    return redirect(request.referrer or url_for('dashboard_routes.dashboard_admin'))
+    return redirect(request.referrer or url_for(endpoints.DASHBOARD_ADMIN))

--- a/routes/ministrante_routes.py
+++ b/routes/ministrante_routes.py
@@ -7,6 +7,7 @@ from extensions import db
 from werkzeug.security import generate_password_hash
 import os
 import uuid
+from utils import endpoints
 
 ministrante_routes = Blueprint(
     "ministrante_routes",
@@ -20,7 +21,7 @@ ministrante_routes = Blueprint(
 def cadastro_ministrante():
     if current_user.tipo not in ['admin', 'cliente']:
         flash('Apenas administradores e clientes podem cadastrar ministrantes!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     clientes = Cliente.query.all() if current_user.tipo == 'admin' else []
 
@@ -80,7 +81,7 @@ def cadastro_ministrante():
             db.session.commit()
             flash('Cadastro realizado com sucesso!', 'success')
             # Redireciona para o dashboard adequado (admin / cliente)
-            return redirect(url_for('dashboard_routes.dashboard_cliente' if current_user.tipo == 'cliente' else 'dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD))
         except Exception as e:
             db.session.rollback()
             flash(f'Erro ao cadastrar ministrante: {str(e)}', 'danger')
@@ -94,7 +95,7 @@ def editar_ministrante(ministrante_id):
 
     if current_user.tipo == 'cliente' and ministrante.cliente_id != current_user.id:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     clientes = Cliente.query.all() if current_user.tipo == 'admin' else None
     ids_extras = request.form.getlist('ministrantes_ids[]')
@@ -146,7 +147,7 @@ def excluir_ministrante(ministrante_id):
 
     if current_user.tipo == 'cliente' and ministrante.cliente_id != current_user.id:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     db.session.delete(ministrante)
     db.session.commit()
@@ -159,7 +160,7 @@ def excluir_ministrante(ministrante_id):
 def gerenciar_ministrantes():
     if current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     ministrantes = Ministrante.query.filter_by(cliente_id=current_user.id).all() if current_user.tipo == 'cliente' else Ministrante.query.all()
 
@@ -249,4 +250,3 @@ def upload_material(oficina_id):
             flash('Nenhum arquivo foi enviado.', 'danger')
     
     return render_template('upload_material.html', oficina=oficina)
-

--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -1,3 +1,4 @@
+from utils import endpoints
 # -*- coding: utf-8 -*-
 # routes/monitor_routes.py
 
@@ -547,7 +548,7 @@ def gerenciar_monitores():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado. Apenas administradores e clientes podem acessar esta página.', 'error')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Filtros
     status_filter = request.args.get('status')
@@ -623,7 +624,7 @@ def novo_monitor():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado. Apenas administradores e clientes podem acessar esta página.', 'error')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     return render_template('monitor/novo_monitor.html')
 
@@ -634,7 +635,7 @@ def cadastrar_monitor():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado.', 'error')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     try:
         # Obter dados do formulário
@@ -1252,7 +1253,7 @@ def distribuicao_automatica():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado.', 'error')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Obter estatísticas para exibir na página
     hoje = datetime.now().date()

--- a/routes/oficina_routes.py
+++ b/routes/oficina_routes.py
@@ -23,6 +23,7 @@ from models import (
 from models.user import Ministrante, Cliente
 from extensions import db
 import logging
+from utils import endpoints
 logger = logging.getLogger(__name__)
 
 from datetime import datetime
@@ -41,7 +42,7 @@ def lista_participantes(oficina_id):
     """
     if current_user.tipo not in ['admin', 'cliente']:
         flash("Acesso não autorizado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
         
     # Busca a oficina com seus inscritos
     oficina = Oficina.query.get_or_404(oficina_id)
@@ -49,7 +50,7 @@ def lista_participantes(oficina_id):
     # Verificar se a oficina pertence ao cliente atual
     if current_user.tipo == 'cliente' and oficina.cliente_id != current_user.id:
         flash("Você não tem permissão para acessar esta oficina!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     return render_template(
         'oficina/lista_participantes.html',
@@ -61,7 +62,7 @@ def lista_participantes(oficina_id):
 def criar_oficina():
     if current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     estados = obter_estados()
     ministrantes_disponiveis = (
@@ -237,7 +238,7 @@ def criar_oficina():
             db.session.commit()
             flash('Atividade criada com sucesso!', 'success')
             return redirect(
-                url_for('dashboard_routes.dashboard_cliente' if current_user.tipo == 'cliente' else 'dashboard_routes.dashboard')
+                url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD)
             )
 
         except Exception as e:
@@ -271,7 +272,7 @@ def editar_oficina(oficina_id):
 
     if current_user.tipo == 'cliente' and oficina.cliente_id != current_user.id:
         flash('Você não tem permissão para editar esta atividade.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     estados = obter_estados()
     if current_user.tipo == 'cliente':
@@ -408,7 +409,7 @@ def editar_oficina(oficina_id):
 
             db.session.commit()
             flash('Oficina editada com sucesso!', 'success')
-            return redirect(url_for('dashboard_routes.dashboard_cliente' if current_user.tipo == 'cliente' else 'dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD))
 
         except Exception as e:
             db.session.rollback()
@@ -439,7 +440,7 @@ def excluir_oficina(oficina_id):
     # 🚨 Cliente só pode excluir oficinas que ele criou
     if current_user.tipo == 'cliente' and oficina.cliente_id != current_user.id:
         flash('Você não tem permissão para excluir esta oficina.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     try:
         logger.debug("Excluindo oficina ID: %s", oficina_id)
@@ -490,7 +491,7 @@ def excluir_oficina(oficina_id):
         logger.error("Erro ao excluir oficina %s: %s", oficina_id, str(e))
         flash(f'Erro ao excluir oficina: {str(e)}', 'danger')
 
-    return redirect(url_for('dashboard_routes.dashboard_cliente' if current_user.tipo == 'cliente' else 'dashboard_routes.dashboard'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD))
 
 
 @oficina_routes.route("/excluir_todas_oficinas", methods=["POST"])
@@ -508,7 +509,7 @@ def excluir_todas_oficinas():
 
         if not oficinas:
             flash("Não há oficinas para excluir.", "warning")
-            return redirect(url_for("dashboard_routes.dashboard_cliente" if current_user.tipo == 'cliente' else "dashboard_routes.dashboard"))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD))
 
         for oficina in oficinas:
             db.session.query(Checkin).filter_by(oficina_id=oficina.id).delete()
@@ -527,7 +528,7 @@ def excluir_todas_oficinas():
         db.session.rollback()
         flash(f"Erro ao excluir oficinas: {str(e)}", "danger")
 
-    return redirect(url_for("dashboard_routes.dashboard_cliente" if current_user.tipo == 'cliente' else "dashboard_routes.dashboard"))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE if current_user.tipo == 'cliente' else endpoints.DASHBOARD))
 
 @oficina_routes.route('/api/oficinas_mesmo_evento/<int:oficina_id>')
 @login_required
@@ -594,4 +595,3 @@ def listar_oficinas():
         oficinas = Oficina.query.all()
 
     return render_template('oficinas.html', oficinas=oficinas)
-

--- a/routes/participante_routes.py
+++ b/routes/participante_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+from utils import endpoints
 participante_routes = Blueprint("participante_routes", __name__)
 
 from flask import render_template, request, redirect, url_for, flash, jsonify
@@ -19,7 +20,7 @@ def gerenciar_participantes():
     # Verifique se é admin
     if current_user.tipo != 'admin':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Busca todos os usuários cujo tipo é 'participante'
     participantes = Usuario.query.filter_by(tipo='participante').all()
@@ -33,30 +34,30 @@ def gerenciar_participantes():
 def excluir_participante(participante_id):
     if current_user.tipo != 'admin':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     participante = Usuario.query.get_or_404(participante_id)
     if participante.tipo != 'participante':
         flash('Esse usuário não é um participante.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     PasswordResetToken.query.filter_by(usuario_id=participante.id).delete()
     db.session.delete(participante)
     db.session.commit()
     flash('Participante excluído com sucesso!', 'success')
-    return redirect(url_for('dashboard_routes.dashboard'))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 @participante_routes.route('/editar_participante_admin/<int:participante_id>', methods=['POST'])
 @login_required
 def editar_participante_admin(participante_id):
     if current_user.tipo != 'admin':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     participante = Usuario.query.get_or_404(participante_id)
     if participante.tipo != 'participante':
         flash('Esse usuário não é um participante.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Captura os dados do form
     nome = request.form.get('nome')
@@ -75,7 +76,7 @@ def editar_participante_admin(participante_id):
 
     db.session.commit()
     flash('Participante atualizado com sucesso!', 'success')
-    return redirect(url_for('dashboard_routes.dashboard'))
+    return redirect(url_for(endpoints.DASHBOARD))
 
 
 
@@ -87,7 +88,7 @@ def meus_certificados():
     """Página principal de certificados do participante."""
     if current_user.tipo != 'participante':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Buscar certificados liberados
     certificados_disponiveis = CertificadoParticipante.query.filter_by(
@@ -165,7 +166,7 @@ def meus_certificados_evento(evento_id):
     """Certificados específicos de um evento."""
     if current_user.tipo != 'participante':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     
@@ -239,7 +240,7 @@ def minha_participacao(evento_id):
     """Detalhes da participação do usuário em um evento."""
     if current_user.tipo != 'participante':
         flash('Acesso negado!', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     

--- a/routes/patrocinador_routes.py
+++ b/routes/patrocinador_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+from utils import endpoints
 patrocinador_routes = Blueprint("patrocinador_routes", __name__)
 
 from flask import render_template, request, redirect, url_for, flash, current_app
@@ -23,12 +24,12 @@ categoria_map = {
 def adicionar_patrocinadores_categorizados():
     if current_user.tipo not in ['admin', 'cliente']:
         flash("Acesso negado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     evento_id = request.form.get('evento_id')
     if not evento_id:
         flash("Evento não selecionado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     qtd_realizacao = int(request.form.get('qtd_realizacao', 0))
     qtd_patrocinio = int(request.form.get('qtd_patrocinio', 0))
@@ -69,7 +70,7 @@ def adicionar_patrocinadores_categorizados():
     db.session.commit()
 
     flash(f"Patrocinadores adicionados com sucesso! Total: {total_importados}", "success")
-    return redirect(url_for('dashboard_routes.dashboard_cliente'))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @patrocinador_routes.route('/remover_patrocinador/<int:patrocinador_id>', methods=['POST'])
@@ -77,7 +78,7 @@ def adicionar_patrocinadores_categorizados():
 def remover_patrocinador(patrocinador_id):
     if current_user.tipo not in ['admin', 'cliente']:
         flash("Acesso negado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     patrocinador = Patrocinador.query.get_or_404(patrocinador_id)
 
@@ -105,7 +106,7 @@ def listar_patrocinadores():
     # Verifica se é admin ou cliente
     if current_user.tipo not in ['admin', 'cliente']:
         flash("Acesso negado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Se for admin, traz todos; se for cliente, traz só do cliente
     if current_user.tipo == 'admin':
@@ -128,7 +129,7 @@ def gerenciar_patrocinadores():
     """Lista todos os patrocinadores, de todas as categorias."""
     if current_user.tipo not in ['admin','cliente']:
         flash("Acesso negado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Se for admin, traz todos. Se for cliente, filtra pelos eventos do cliente
     if current_user.tipo == 'admin':
@@ -147,7 +148,7 @@ def remover_foto_patrocinador(patrocinador_id):
     """Remove a foto de patrocinador (categoria: Realização, Organização, Apoio, Patrocínio)."""
     if current_user.tipo not in ['admin','cliente']:
         flash("Acesso negado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     pat = Patrocinador.query.get_or_404(patrocinador_id)
 
@@ -192,8 +193,6 @@ def remover_fotos_selecionadas():
     flash('Fotos removidas com sucesso!', 'success')
     return redirect(url_for('patrocinador_routes.gerenciar_patrocinadores'))
     # Se não houver fotos selecionadas, redireciona para a página de gerenciamento
-
-
 
 
 

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -11,6 +11,7 @@ from flask import (
 from werkzeug.security import generate_password_hash
 from flask_login import login_required, current_user
 from extensions import db
+from utils import endpoints
 
 from models import (
     Usuario,
@@ -61,7 +62,7 @@ def submission_control():
     """
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Get current client ID
     cliente_id = getattr(current_user, "id", None)
@@ -413,7 +414,7 @@ def assign_reviews():
     """
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     usuario = Usuario.query.get(getattr(current_user, "id", None))
     uid = usuario.id if usuario else None  # salva log mesmo sem usuário
@@ -502,7 +503,7 @@ def assign_by_filters():
     """Distribui submissões a revisores aprovados com base em filtros."""
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     data = request.get_json() or {}
     filtros: dict = data.get("filters", {})
@@ -618,7 +619,7 @@ def auto_assign(evento_id):
     """
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     usuario = Usuario.query.get(getattr(current_user, "id", None))
     uid = usuario.id if usuario else None  # salva log mesmo sem usuário
@@ -689,7 +690,7 @@ def create_review():
     """Cria uma revisão única para uma submissão e um revisor."""
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     data = request.get_json(silent=True) or {}
     submission_id = request.form.get("submission_id") or data.get("submission_id")
@@ -859,7 +860,7 @@ def editor_reviews(evento_id):
     """
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     trabalhos = Submission.query.filter_by(evento_id=evento_id).all()
     return render_template("peer_review/dashboard_editor.html", trabalhos=trabalhos)
@@ -871,7 +872,7 @@ def client_reviews_panel():
     """Painel para clientes acompanharem o progresso das revisões."""
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     submissions = (
         Submission.query.join(Evento)

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -1,3 +1,4 @@
+from utils import endpoints
 # -*- coding: utf-8 -*-
 """Routes for managing event visits by professors and participants."""
 
@@ -37,7 +38,7 @@ def eventos_disponiveis_professor():
     # Apenas participantes (professores) podem acessar
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Buscar eventos disponíveis para agendamento
     eventos = Evento.query.filter(
@@ -65,7 +66,7 @@ def detalhes_evento_professor(evento_id):
     # Apenas participantes (professores) podem acessar
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     evento = Evento.query.get_or_404(evento_id)
     
@@ -100,7 +101,7 @@ def horarios_disponiveis_professor(evento_id):
     # Apenas participantes (professores) podem acessar
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Verificar se o professor está bloqueado
     bloqueio = ProfessorBloqueado.query.filter_by(
@@ -165,7 +166,7 @@ def criar_agendamento_professor(horario_id):
     """Permite que o professor crie um agendamento."""
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     horario = HorarioVisitacao.query.get_or_404(horario_id)
     evento = horario.evento
@@ -305,7 +306,7 @@ def adicionar_alunos_professor(agendamento_id):
     """Permite que o professor adicione alunos a um agendamento."""
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -406,7 +407,7 @@ def adicionar_alunos_participante(agendamento_id):
     """Permite que o participante adicione alunos a um agendamento."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -507,7 +508,7 @@ def remover_aluno_professor(aluno_id):
     """Remove um aluno de um agendamento (professor)."""
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     aluno = AlunoVisitante.query.get_or_404(aluno_id)
     agendamento = aluno.agendamento
@@ -541,7 +542,7 @@ def remover_aluno_participante(aluno_id):
     """Remove um aluno de um agendamento (participante)."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     aluno = AlunoVisitante.query.get_or_404(aluno_id)
     agendamento = aluno.agendamento
@@ -585,7 +586,7 @@ def importar_alunos_agendamento(agendamento_id):
     # Apenas participantes (professores) podem acessar
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
     
@@ -691,7 +692,7 @@ def confirmacao_agendamento_professor(agendamento_id):
     """
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -722,7 +723,7 @@ def confirmacao_agendamento_participante(agendamento_id):
     """Exibe a página de confirmação do agendamento para participantes."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -752,7 +753,7 @@ def imprimir_agendamento_professor(agendamento_id):
     """Gera o comprovante de um agendamento."""
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -800,7 +801,7 @@ def imprimir_agendamento_participante(agendamento_id):
     """Gera o comprovante de um agendamento para participantes."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -854,7 +855,7 @@ def qrcode_agendamento_professor(agendamento_id):
     """Exibe o QR Code de um agendamento."""
     if current_user.tipo != 'professor':
         flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -879,7 +880,7 @@ def qrcode_agendamento_participante(agendamento_id):
     """Exibe o QR Code de um agendamento para participantes."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
 
@@ -924,7 +925,7 @@ def horarios_disponiveis_participante(evento_id):
     """Lista horários disponíveis para participantes."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     evento = Evento.query.get_or_404(evento_id)
 
@@ -972,7 +973,7 @@ def criar_agendamento_participante(horario_id):
     """Permite que o participante faça um agendamento de visita em grupo."""
     if current_user.tipo != 'participante':
         flash('Acesso negado! Esta área é exclusiva para participantes.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     horario = HorarioVisitacao.query.get_or_404(horario_id)
     evento = horario.evento

--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, send_file, flash, redirect, url_for, request
 from flask_login import login_required, current_user
 from io import BytesIO
+from utils import endpoints
 
 from openpyxl import Workbook
 from reportlab.lib.pagesizes import A4
@@ -56,12 +57,12 @@ def exportar_participantes_evento():
     formato = request.args.get('formato', 'xlsx')
     if not evento_id:
         flash('Evento não encontrado.', 'warning')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     evento = Evento.query.get_or_404(evento_id)
     if current_user.tipo == 'cliente' and evento.cliente_id != current_user.id:
         flash('Acesso negado ao evento.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     inscricoes = (
         Inscricao.query
@@ -123,7 +124,7 @@ def exportar_financeiro():
     """Exporta o resumo financeiro do cliente em PDF ou XLSX."""
     if current_user.tipo != 'cliente':
         flash('Acesso negado.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     formato = request.args.get('formato', 'xlsx')
 
@@ -187,7 +188,7 @@ def gerar_relatorio_evento(evento_id):
     evento = Evento.query.get_or_404(evento_id)
     if current_user.tipo == 'cliente' and evento.cliente_id != current_user.id:
         flash('Acesso negado ao evento.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     payload = request.get_json() or {}
     dados_selecionados = payload.get('dados', [])

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -7,6 +7,7 @@ da perspectiva de participantes.
 """
 
 from __future__ import annotations
+from utils import endpoints
 
 import os
 import uuid
@@ -90,7 +91,7 @@ def _ensure_secret_key(setup_state):  # pragma: no cover
 def config_revisor():
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Um cliente pode ter no máximo 1 processo configurado.
     processo: RevisorProcess | None = RevisorProcess.query.filter_by(
@@ -169,7 +170,7 @@ def manage_barema(process_id: int):
     """
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     processo = RevisorProcess.query.get_or_404(process_id)
     barema = ProcessoBarema.query.filter_by(process_id=process_id).first()
     if barema is None:
@@ -192,7 +193,7 @@ def manage_barema(process_id: int):
 def add_requisito(barema_id: int):
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     barema = ProcessoBarema.query.get_or_404(barema_id)
 
     if request.method == "POST":
@@ -233,7 +234,7 @@ def edit_requisito(req_id: int):
         flash("Acesso negado!", "danger")
 
 
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     if request.method == "POST":
         requisito.nome = request.form.get("nome") or requisito.nome
         requisito.descricao = request.form.get("descricao")
@@ -277,7 +278,7 @@ def delete_requisito(req_id: int):
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
 
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     process_id = requisito.barema.process_id
     db.session.delete(requisito)
     db.session.commit()
@@ -293,7 +294,7 @@ def delete_requisito(req_id: int):
 def delete_barema(process_id: int):
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
     barema = ProcessoBarema.query.filter_by(process_id=process_id).first_or_404()
 
     db.session.delete(barema)
@@ -516,7 +517,7 @@ def approve(cand_id: int):
             and aprovados >= config_cli.limite_total_revisores
         ):
             flash("Limite de revisores atingido.", "danger")
-            return redirect(url_for("dashboard_routes.dashboard_cliente"))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     cand.status = "aprovado"
     cand.etapa_atual = cand.process.num_etapas  # type: ignore[attr-defined]
 
@@ -548,7 +549,7 @@ def approve(cand_id: int):
                 if request.is_json:
                     return jsonify({"success": False, "error": err_msg}), 500
                 flash(err_msg, "danger")
-                return redirect(url_for("dashboard_routes.dashboard_cliente"))
+                return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
             db.session.add(reviewer)
             db.session.flush()
         else:
@@ -624,7 +625,7 @@ def approve(cand_id: int):
         resp["message"] = msg
         return jsonify(resp)
     flash(msg, "success")
-    return redirect(url_for("dashboard_routes.dashboard_cliente"))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @revisor_routes.route("/revisor/reject/<int:cand_id>", methods=["POST"])
@@ -649,7 +650,7 @@ def reject(cand_id: int):
         )
     if request.is_json:
         return jsonify({"success": True})
-    return redirect(url_for("dashboard_routes.dashboard_cliente"))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @revisor_routes.route("/revisor/advance/<int:cand_id>", methods=["POST"])
@@ -705,7 +706,7 @@ def advance(cand_id: int):
         )
     if request.is_json:
         return jsonify({"success": True, "etapa_atual": cand.etapa_atual})
-    return redirect(url_for("dashboard_routes.dashboard_cliente"))
+    return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @revisor_routes.route("/revisor/view/<int:cand_id>")
@@ -714,7 +715,7 @@ def view_candidatura(cand_id: int):
     """Exibe os detalhes e respostas de uma candidatura."""
     if current_user.tipo not in {"cliente", "admin", "superadmin"}:  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
     return render_template("revisor/candidatura_detail.html", candidatura=cand)
@@ -734,7 +735,7 @@ def avaliar(submission_id: int):
     ).first()
     if not assignment:
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     barema = EventoBarema.query.filter_by(evento_id=submission.evento_id).first()
     review = Review.query.filter_by(
@@ -824,7 +825,7 @@ def ranking_trabalhos():
 
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     ordenar_por = request.args.get("ordenar_por", "total_nota")
 

--- a/routes/sorteio_routes.py
+++ b/routes/sorteio_routes.py
@@ -5,6 +5,7 @@ import random
 from models import Sorteio, Inscricao, Evento, Oficina
 from models.user import Usuario
 from extensions import db
+from utils import endpoints
 
 # Criação do blueprint
 sorteio_routes = Blueprint('sorteio_routes', __name__, template_folder="../templates/sorteio")
@@ -76,7 +77,7 @@ def criar_sorteio():
     # Verificar se o usuário é um cliente
     if current_user.tipo != 'cliente':
         flash('Acesso negado. Apenas clientes podem gerenciar sorteios.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Listar eventos do cliente para o formulário
     eventos = Evento.query.filter_by(cliente_id=current_user.id).all()
@@ -133,7 +134,7 @@ def gerenciar_sorteios():
     # Verificar se o usuário é um cliente
     if current_user.tipo != 'cliente':
         flash('Acesso negado. Apenas clientes podem gerenciar sorteios.', 'danger')
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
     
     # Filtros da URL
     evento_id = request.args.get('evento_id', type=int)

--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+from utils import endpoints
 
 import pandas as pd
 from flask import (
@@ -47,7 +48,7 @@ def submeter_trabalho():
     """Participante faz upload do PDF e registra o trabalho no banco."""
     if current_user.tipo not in ["participante", "ministrante"]:
         flash("Acesso negado. Apenas participantes podem submeter trabalhos.", "error")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     config = current_user.cliente.configuracao if current_user.cliente else None
     formulario = None
@@ -55,17 +56,17 @@ def submeter_trabalho():
         formulario = config.formulario_submissao
         if not formulario or not formulario.is_submission_form:
             flash("Formulário de submissão inválido.", "danger")
-            return redirect(url_for("dashboard_routes.dashboard"))
+            return redirect(url_for(endpoints.DASHBOARD))
         if (
             formulario.eventos
             and current_user.evento_id not in [ev.id for ev in formulario.eventos]
         ):
             flash("Formulário indisponível para seu evento.", "danger")
-            return redirect(url_for("dashboard_routes.dashboard"))
+            return redirect(url_for(endpoints.DASHBOARD))
 
     if not formulario:
         flash("Submissão de trabalhos desabilitada.", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     if request.method == "POST":
         evento_id = getattr(current_user, "evento_id", None)
@@ -183,7 +184,7 @@ def meus_trabalhos():
     """Lista trabalhos do participante logado com informações detalhadas."""
     if current_user.tipo not in ["participante", "ministrante"]:
         return redirect(
-            url_for("dashboard_routes.dashboard")
+            url_for(endpoints.DASHBOARD)
         )
 
     # Buscar submissões com informações relacionadas

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -7,6 +7,7 @@ import logging
 import psutil
 import os
 import time
+from utils import endpoints
 
 logger = logging.getLogger(__name__)
 
@@ -905,12 +906,12 @@ def gerar_certificados(oficina_id):
     oficina = Oficina.query.get(oficina_id)
     if not oficina:
         flash("Oficina não encontrada!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     inscritos = oficina.inscritos
     if not inscritos:
         flash("Não há inscritos nesta oficina para gerar certificados!", "warning")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     pdf_path = f"static/certificados/certificados_oficina_{oficina.id}.pdf"
     os.makedirs(os.path.dirname(pdf_path), exist_ok=True)
@@ -1037,12 +1038,12 @@ def gerar_certificados(oficina_id):
     oficina = Oficina.query.get(oficina_id)
     if not oficina:
         flash("Oficina não encontrada!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     inscritos = oficina.inscritos
     if not inscritos:
         flash("Não há inscritos nesta oficina para gerar certificados!", "warning")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     pdf_path = f"static/certificados/certificados_oficina_{oficina.id}.pdf"
     os.makedirs(os.path.dirname(pdf_path), exist_ok=True)
@@ -1404,7 +1405,7 @@ def gerar_pdf_checkins_qr():
 
     if not checkins_qr:
         flash("Não há check-ins via QR Code para gerar o relatório.", "warning")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # (continua com sua lógica atual do PDF sem alterações)
     # 2. Configuração do documento
@@ -1881,7 +1882,7 @@ def exportar_checkins_pdf_opcoes():
 
     if not current_user.is_cliente():
         flash("Acesso negado.", "danger")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Query base
     base_query = Checkin.query.filter(Checkin.cliente_id == current_user.id)
@@ -1896,7 +1897,7 @@ def exportar_checkins_pdf_opcoes():
 
     if not checkins:
         flash("Nenhum check-in encontrado para os filtros aplicados.", "info")
-        return redirect(url_for('dashboard_routes.dashboard'))
+        return redirect(url_for(endpoints.DASHBOARD))
 
     # Gerar PDF
     buffer = BytesIO()
@@ -2059,7 +2060,7 @@ def exportar_checkins_evento_pdf(evento_id):
             if not evento:
                 flash("Evento não encontrado ou não pertence ao seu acesso.", "danger")
                 logger.info("[DEBUG] Evento não pertence ao cliente logado.")
-                return redirect(url_for('dashboard_routes.dashboard_cliente'))
+                return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
     else:
         evento = Evento.query.get_or_404(evento_id)
 
@@ -2075,7 +2076,7 @@ def exportar_checkins_evento_pdf(evento_id):
 
     if not checkins:
         flash("Nenhum check-in encontrado para este evento.", "warning")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # DEBUG de alguns dados dos check-ins
     for c in checkins[:5]:
@@ -3621,12 +3622,12 @@ def gerar_etiquetas(cliente_id):
     """Gera um PDF de etiquetas para o cliente"""
     if current_user.tipo != 'cliente' or current_user.id != cliente_id:
         flash("Acesso negado!", "danger")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     pdf_path = gerar_etiquetas_pdf(cliente_id)
     if not pdf_path:
         flash("Nenhum usuário encontrado para gerar etiquetas!", "warning")
-        return redirect(url_for('dashboard_routes.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     return send_file(pdf_path, as_attachment=True)
 
@@ -4464,4 +4465,3 @@ def formatar_brasilia(dt):
         dt = dt.replace(tzinfo=pytz.utc)
     brasilia = pytz.timezone("America/Sao_Paulo")
     return dt.astimezone(brasilia).strftime('%d/%m/%Y %H:%M:%S')
-

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -2,6 +2,7 @@ from functools import wraps
 from flask import session, redirect, url_for, flash, abort, request, jsonify
 from flask_login import current_user, login_required as flask_login_required
 import logging
+from utils import endpoints
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ def admin_required(f):
             if request.is_json:
                 return jsonify({'error': 'Acesso negado - privilégios de administrador necessários'}), 403
             flash('Acesso negado - privilégios de administrador necessários!', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD))
         
         return f(*args, **kwargs)
     return wrapper
@@ -55,7 +56,7 @@ def superadmin_required(f):
             if request.is_json:
                 return jsonify({'error': 'Acesso negado - privilégios de super administrador necessários'}), 403
             flash('Acesso negado - privilégios de super administrador necessários!', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD))
         
         return f(*args, **kwargs)
     return wrapper
@@ -77,7 +78,7 @@ def cliente_required(f):
             if request.is_json:
                 return jsonify({'error': 'Acesso negado - acesso restrito a clientes'}), 403
             flash('Acesso negado - acesso restrito a clientes!', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD))
         
         return f(*args, **kwargs)
     return wrapper
@@ -99,7 +100,7 @@ def ministrante_required(f):
             if request.is_json:
                 return jsonify({'error': 'Acesso negado - acesso restrito a ministrantes'}), 403
             flash('Acesso negado - acesso restrito a ministrantes!', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD))
         
         return f(*args, **kwargs)
     return wrapper
@@ -121,7 +122,7 @@ def participante_required(f):
             if request.is_json:
                 return jsonify({'error': 'Acesso negado - acesso restrito a participantes'}), 403
             flash('Acesso negado - acesso restrito a participantes!', 'danger')
-            return redirect(url_for('dashboard_routes.dashboard'))
+            return redirect(url_for(endpoints.DASHBOARD))
         
         return f(*args, **kwargs)
     return wrapper
@@ -148,7 +149,7 @@ def role_required(*allowed_roles):
                         'error': f'Acesso negado - roles permitidos: {", ".join(allowed_roles)}'
                     }), 403
                 flash(f'Acesso negado - roles permitidos: {", ".join(allowed_roles)}!', 'danger')
-                return redirect(url_for('dashboard_routes.dashboard'))
+                return redirect(url_for(endpoints.DASHBOARD))
             
             return f(*args, **kwargs)
         return wrapper
@@ -233,7 +234,7 @@ def require_permission(permission_name, resource_id=None):
                         'error': f'Permissão negada - {permission_name} necessária'
                     }), 403
                 flash(f'Permissão negada - {permission_name} necessária!', 'danger')
-                return redirect(url_for('dashboard_routes.dashboard'))
+                return redirect(url_for(endpoints.DASHBOARD))
             
             return f(*args, **kwargs)
         return wrapper
@@ -314,7 +315,7 @@ def require_resource_access(resource_type, resource_id_param='id', action='view'
                         'error': f'Acesso negado ao {resource_type} {resource_id}'
                     }), 403
                 flash(f'Acesso negado ao {resource_type}!', 'danger')
-                return redirect(url_for('dashboard_routes.dashboard'))
+                return redirect(url_for(endpoints.DASHBOARD))
             
             return f(*args, **kwargs)
         return wrapper

--- a/utils/endpoints.py
+++ b/utils/endpoints.py
@@ -1,0 +1,21 @@
+"""Centralized Flask endpoint names for dashboard pages.
+
+This module defines constants for dashboard-related endpoints used across the
+application. Import these constants instead of hard-coding strings so updates to
+endpoint names can be made in one place.
+"""
+
+DASHBOARD = "dashboard_routes.dashboard"
+"""Endpoint for the general dashboard."""
+
+DASHBOARD_CLIENTE = "dashboard_routes.dashboard_cliente"
+"""Endpoint for the client dashboard."""
+
+DASHBOARD_ADMIN = "dashboard_routes.dashboard_admin"
+"""Endpoint for the admin dashboard."""
+
+DASHBOARD_SUPERADMIN = "dashboard_routes.dashboard_superadmin"
+"""Endpoint for the superadmin dashboard."""
+
+DASHBOARD_AGENDAMENTOS = "dashboard_routes.dashboard_agendamentos"
+"""Endpoint for the scheduling dashboard."""


### PR DESCRIPTION
## Summary
- add `utils/endpoints.py` for dashboard endpoint constants
- refactor routes to use centralized endpoint constants
- document endpoint module in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: unexpected indent in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b71fd8aaa88324bea1e2a2316b360b