### PR TITLE
Use centralized dashboard endpoint

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -4925,7 +4925,7 @@ def detalhes_agendamento(agendamento_id):
     if current_user.tipo == "cliente":
         if not evento or evento.cliente_id != current_user.id:
             flash("Acesso negado!", "danger")
-            return redirect(url_for("dashboard_cliente.dashboard_cliente"))
+            return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
     # Buscar lista de alunos vinculados ao agendamento
     alunos = AlunoVisitante.query.filter_by(agendamento_id=agendamento.id).all()

--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -11,6 +11,7 @@ import json
 from extensions import db, csrf
 from models.user import Cliente, Monitor
 from models.material import Polo, Material, MovimentacaoMaterial, MonitorPolo
+from utils import endpoints
 
 material_routes = Blueprint('material_routes', __name__)
 
@@ -78,7 +79,7 @@ def gerenciar_materiais():
     except Exception as e:
         current_app.logger.error(f"Erro ao carregar página de materiais: {str(e)}")
         flash('Erro ao carregar dados', 'error')
-        return redirect(url_for('dashboard_cliente.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
 @material_routes.route('/api/polos', methods=['GET'])

--- a/routes/validacao_routes.py
+++ b/routes/validacao_routes.py
@@ -11,6 +11,7 @@ from extensions import db
 from datetime import datetime, timedelta
 from flask_login import login_required, current_user
 from decorators import cliente_required
+from utils import endpoints
 
 validacao_bp = Blueprint('validacao', __name__, url_prefix='/validacao')
 
@@ -143,7 +144,7 @@ def relatorio_validacoes():
                              
     except Exception as e:
         flash('Erro ao gerar relatório de validações', 'error')
-        return redirect(url_for('dashboard.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 @validacao_bp.route('/admin/integridade')
 @login_required
@@ -158,7 +159,7 @@ def verificar_integridade():
                              
     except Exception as e:
         flash('Erro ao verificar integridade dos certificados', 'error')
-        return redirect(url_for('dashboard.dashboard_cliente'))
+        return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 @validacao_bp.route('/admin/api/integridade')
 @login_required


### PR DESCRIPTION
## Summary
- Replace hard-coded client dashboard endpoints with `endpoints.DASHBOARD_CLIENTE`
- Import `utils.endpoints` where necessary to centralize route references

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py and others)*
- `python - <<'PY' ...` *(URL generation for client dashboard succeeds)*


------
https://chatgpt.com/codex/tasks/task_e_68b72724222c8324beb4327be6e4c460