### PR TITLE
Add reviewer process deletion with cascading cleanup

### DIFF
--- a/models/review.py
+++ b/models/review.py
@@ -102,7 +102,10 @@ class RevisorEtapa(db.Model):
     nome = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=True)
 
-    process = db.relationship("RevisorProcess", backref=db.backref("etapas", lazy=True))
+    process = db.relationship(
+        "RevisorProcess",
+        backref=db.backref("etapas", cascade="all, delete-orphan", lazy=True),
+    )
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<RevisorEtapa process={self.process_id} numero={self.numero}>"
@@ -116,7 +119,10 @@ class RevisorCriterio(db.Model):
     process_id = db.Column(db.Integer, db.ForeignKey("revisor_process.id"), nullable=False)
     nome = db.Column(db.String(255), nullable=False)
 
-    process = db.relationship("RevisorProcess", backref=db.backref("criterios", lazy=True))
+    process = db.relationship(
+        "RevisorProcess",
+        backref=db.backref("criterios", cascade="all, delete-orphan", lazy=True),
+    )
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<RevisorCriterio process={self.process_id} nome={self.nome}>"
@@ -160,7 +166,8 @@ class RevisorCandidatura(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     process = db.relationship(
-        "RevisorProcess", backref=db.backref("candidaturas", lazy=True)
+        "RevisorProcess",
+        backref=db.backref("candidaturas", cascade="all, delete-orphan", lazy=True),
     )
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -180,7 +187,10 @@ class RevisorCandidaturaEtapa(db.Model):
     observacoes = db.Column(db.Text, nullable=True)
 
     candidatura = db.relationship(
-        "RevisorCandidatura", backref=db.backref("etapas_status", lazy=True)
+        "RevisorCandidatura",
+        backref=db.backref(
+            "etapas_status", cascade="all, delete-orphan", lazy=True
+        ),
     )
     etapa = db.relationship("RevisorEtapa")
 

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -154,6 +154,22 @@ def config_revisor():
     )
 
 
+@revisor_routes.route("/revisor/<int:process_id>/delete", methods=["POST"])
+@login_required
+def delete_process(process_id: int):
+    if current_user.tipo != "cliente":  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for(endpoints.DASHBOARD))
+    processo = RevisorProcess.query.get_or_404(process_id)
+    if processo.cliente_id != current_user.id:  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for(endpoints.DASHBOARD))
+    db.session.delete(processo)
+    db.session.commit()
+    flash("Processo removido", "success")
+    return redirect(url_for("revisor_routes.config_revisor"))
+
+
 # -----------------------------------------------------------------------------
 # CONFIGURAÇÃO DE BAREMAS
 # -----------------------------------------------------------------------------

--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -31,12 +31,26 @@
 <div class="container py-4">
   <div class="row">
     <div class="col-12">
-      <div class="d-flex align-items-center mb-4">
-        <div class="step-indicator me-3">1</div>
-        <div>
-          <h1 class="h3 mb-0">Configurar Processo de Revisores</h1>
-          <p class="text-muted mb-0">Configure as etapas e critérios do processo seletivo</p>
+      <div class="d-flex align-items-center justify-content-between mb-4">
+        <div class="d-flex align-items-center">
+          <div class="step-indicator me-3">1</div>
+          <div>
+            <h1 class="h3 mb-0">Configurar Processo de Revisores</h1>
+            <p class="text-muted mb-0">Configure as etapas e critérios do processo seletivo</p>
+          </div>
         </div>
+        {% if processo %}
+        <form
+          method="post"
+          action="{{ url_for('revisor_routes.delete_process', process_id=processo.id) }}"
+          onsubmit="return confirm('Excluir processo?');"
+        >
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn btn-danger btn-sm">
+            <i class="bi bi-trash"></i> Excluir
+          </button>
+        </form>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/tests/test_revisor_process_delete.py
+++ b/tests/test_revisor_process_delete.py
@@ -1,0 +1,97 @@
+import os
+
+import pytest
+from flask import Flask
+from jinja2 import ChoiceLoader, DictLoader
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "y")
+os.environ.setdefault("DB_PASS", "test")
+
+from config import Config
+from extensions import csrf, db, login_manager
+from models import (
+    Cliente,
+    RevisorCandidatura,
+    RevisorCandidaturaEtapa,
+    RevisorCriterio,
+    RevisorEtapa,
+    RevisorProcess,
+)
+from routes.revisor_routes import revisor_routes
+
+
+@pytest.fixture
+def app():
+    templates_path = os.path.join(os.path.dirname(__file__), "..", "templates")
+    app = Flask(__name__, template_folder=templates_path)
+    app.jinja_loader = ChoiceLoader([
+        DictLoader({"base.html": "{% block content %}{% endblock %}"}),
+        app.jinja_loader,
+    ])
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="test",
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_ENGINE_OPTIONS=Config.build_engine_options("sqlite://"),
+    )
+    login_manager.init_app(app)
+
+    @login_manager.user_loader  # pragma: no cover
+    def load_user(user_id):
+        return Cliente.query.get(int(user_id))
+
+    db.init_app(app)
+    csrf.init_app(app)
+    app.register_blueprint(revisor_routes)
+
+    with app.app_context():
+        db.create_all()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_delete_process_removes_related_data(app, client):
+    with app.app_context():
+        cliente = Cliente(
+            nome="Cli",
+            email="cli@test",
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+        proc = RevisorProcess(cliente_id=cliente.id, num_etapas=1)
+        db.session.add(proc)
+        db.session.commit()
+        etapa = RevisorEtapa(process_id=proc.id, numero=1, nome="E1")
+        criterio = RevisorCriterio(process_id=proc.id, nome="C1")
+        cand = RevisorCandidatura(
+            process_id=proc.id, nome="Cand", email="cand@test"
+        )
+        db.session.add_all([etapa, criterio, cand])
+        db.session.commit()
+        status = RevisorCandidaturaEtapa(candidatura_id=cand.id, etapa_id=etapa.id)
+        db.session.add(status)
+        db.session.commit()
+
+    with client:
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(cliente.id)
+            sess["_fresh"] = True
+        resp = client.post(f"/revisor/{proc.id}/delete")
+        assert resp.status_code == 302
+
+    with app.app_context():
+        assert RevisorProcess.query.get(proc.id) is None
+        assert RevisorEtapa.query.count() == 0
+        assert RevisorCriterio.query.count() == 0
+        assert RevisorCandidatura.query.count() == 0
+        assert RevisorCandidaturaEtapa.query.count() == 0
+


### PR DESCRIPTION
## Summary
- allow clients to delete their reviewer process via POST `/revisor/<process_id>/delete`
- cascade removal of stages, criteria and applications when deleting a process
- add delete button with CSRF token on reviewer configuration page
- test deletion behavior ensures related data is purged

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in existing tests)*
- `pytest tests/test_revisor_process_delete.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7367339f48324bc3c11f2e246a547