### PR TITLE
Support checkbox and radio fields in reviewer applications

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -346,6 +346,23 @@ def submit_application(process_id: int):
                     path = os.path.join(dir_path, unique_name)
                     arquivo.save(path)
                     valor = path
+            elif campo.tipo == "checkbox":
+                valores = request.form.getlist(key)
+                if is_required and not valores:
+                    flash(f"O campo {campo.nome} é obrigatório.", "danger")
+                    return redirect(request.url)
+                valor = valores
+            elif campo.tipo == "radio":
+                raw_val = request.form.get(key)
+                if is_required and not raw_val:
+                    flash(f"O campo {campo.nome} é obrigatório.", "danger")
+                    return redirect(request.url)
+                if raw_val and campo.opcoes:
+                    opcoes_validas = [o.strip() for o in campo.opcoes.split(",")]
+                    if raw_val not in opcoes_validas:
+                        flash("Opção inválida.", "danger")
+                        return redirect(request.url)
+                valor = raw_val
             else:
                 raw_val = request.form.get(key)
                 if is_required and not raw_val:

--- a/templates/revisor/candidatura_form.html
+++ b/templates/revisor/candidatura_form.html
@@ -57,6 +57,10 @@
                 <i class="bi bi-calendar-date text-muted me-2"></i>
               {% elif campo.tipo == 'dropdown' %}
                 <i class="bi bi-list text-muted me-2"></i>
+              {% elif campo.tipo == 'checkbox' %}
+                <i class="bi bi-check-square text-muted me-2"></i>
+              {% elif campo.tipo == 'radio' %}
+                <i class="bi bi-record-circle text-muted me-2"></i>
               {% endif %}
               {{ campo.nome }}
               {% if campo.obrigatorio %}
@@ -132,7 +136,7 @@
               {% elif campo.tipo == 'dropdown' %}
               <div class="input-group">
                 <span class="input-group-text"><i class="bi bi-list"></i></span>
-                <select id="campo-{{ campo.id }}" name="{{ campo.id }}" 
+                <select id="campo-{{ campo.id }}" name="{{ campo.id }}"
                         class="form-select campo-input"
                         {% if campo.obrigatorio %}required{% endif %}>
                   <option value="" disabled selected>Selecione uma opção</option>
@@ -140,6 +144,38 @@
                   <option value="{{ opcao.strip() }}">{{ opcao.strip() }}</option>
                   {% endfor %}
                 </select>
+              </div>
+              {% elif campo.tipo == 'checkbox' %}
+              <div class="checkbox-group">
+                {% for opcao in campo.opcoes.split(',') %}
+                <div class="form-check">
+                  <input class="form-check-input campo-input" type="checkbox"
+                         id="check-{{ campo.id }}-{{ loop.index }}" name="{{ campo.id }}"
+                         value="{{ opcao.strip() }}">
+                  <label class="form-check-label" for="check-{{ campo.id }}-{{ loop.index }}">
+                    {{ opcao.strip() }}
+                  </label>
+                </div>
+                {% endfor %}
+              </div>
+              {% elif campo.tipo == 'radio' %}
+              <div class="radio-group">
+                {% for opcao in campo.opcoes.split(',') %}
+                <div class="form-check">
+                  <input class="form-check-input campo-input" type="radio"
+                         id="radio-{{ campo.id }}-{{ loop.index }}" name="{{ campo.id }}"
+                         value="{{ opcao.strip() }}"{% if campo.obrigatorio %} required{% endif %}>
+                  <label class="form-check-label" for="radio-{{ campo.id }}-{{ loop.index }}">
+                    {{ opcao.strip() }}
+                  </label>
+                </div>
+                {% endfor %}
+              </div>
+              {% else %}
+              <div class="input-group">
+                <input type="{{ campo.tipo }}" id="campo-{{ campo.id }}" name="{{ campo.id }}"
+                       class="form-control campo-input"
+                       {% if campo.obrigatorio %}required{% endif %}>
               </div>
               {% endif %}
               


### PR DESCRIPTION
## Summary
- Render checkbox and radio inputs in reviewer application form
- Handle checkbox lists and radio option validation when submitting applications
- Test that reviewer applications capture checkbox and radio answers

## Testing
- `pytest tests/test_revisor_process.py::test_application_with_checkbox_and_radio -q`
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py; missing dependencies like bs4)*

------
https://chatgpt.com/codex/tasks/task_e_68b73677ca788324b9bec2090751a2d4