### PR TITLE
Allow reviewer process setup without preselected form

### DIFF
--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -116,7 +116,7 @@
               <i class="bi bi-clipboard-data me-1"></i>
               Formulário de Candidatura
             </label>
-            <select class="form-select" name="formulario_id" required>
+            <select class="form-select" name="formulario_id">
               <option value="">Selecione um formulário...</option>
               {% for f in formularios %}
               <option value="{{ f.id }}" {% if processo and f.id == processo.formulario_id %}selected{% endif %}>{{ f.nome }}</option>

--- a/tests/test_reviewer_auto_form_creation.py
+++ b/tests/test_reviewer_auto_form_creation.py
@@ -1,0 +1,85 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+from flask import Flask
+from jinja2 import ChoiceLoader, DictLoader
+from flask_migrate import upgrade
+
+from config import Config
+from extensions import db, login_manager, migrate
+from models import Cliente, Formulario, RevisorProcess
+from routes.revisor_routes import revisor_routes
+
+os.environ.setdefault("DB_PASS", "test")
+
+
+@pytest.fixture
+def app():
+    templates_path = os.path.join(os.path.dirname(__file__), "..", "templates")
+    app = Flask(__name__, template_folder=templates_path)
+    app.jinja_loader = ChoiceLoader(
+        [DictLoader({"base.html": "{% block content %}{% endblock %}"}), app.jinja_loader]
+    )
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = Config.build_engine_options("sqlite://")
+    app.jinja_env.globals["csrf_token"] = lambda: ""
+
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return Cliente.query.get(int(user_id))
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+    app.register_blueprint(revisor_routes)
+
+    with app.app_context():
+        try:
+            upgrade(revision="heads")
+        except SystemExit:
+            db.create_all()
+        cliente = Cliente(
+            nome="Cli",
+            email="cli@test",
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_config_revisor_creates_basic_form(app, client):
+    """Posting without formulario_id creates a basic form automatically."""
+    from flask_login import login_user, logout_user
+
+    with app.app_context():
+        cliente = Cliente.query.filter_by(email="cli@test").first()
+        assert Formulario.query.filter_by(cliente_id=cliente.id).count() == 0
+
+        with client:
+            with app.test_request_context():
+                login_user(cliente)
+            resp = client.post(
+                "/config_revisor",
+                data={"formulario_id": "", "num_etapas": 1, "stage_name": ["Etapa 1"]},
+            )
+            with app.test_request_context():
+                logout_user()
+
+        assert resp.status_code in (200, 302)
+        form = Formulario.query.filter_by(cliente_id=cliente.id).first()
+        assert form is not None
+        campos = {c.nome: c for c in form.campos}
+        assert {"nome", "email"} <= set(campos)
+        assert campos["nome"].obrigatorio is True
+        assert campos["email"].obrigatorio is True
+        proc = RevisorProcess.query.filter_by(cliente_id=cliente.id).first()
+        assert proc is not None and proc.formulario_id == form.id

--- a/tests/test_revisor_helpers.py
+++ b/tests/test_revisor_helpers.py
@@ -78,6 +78,14 @@ def test_parse_revisor_form_missing_stage(app):
         with pytest.raises(ValueError):
             parse_revisor_form(request)
 
+
+def test_parse_revisor_form_without_formulario_id(app):
+    with app.test_request_context(
+        method="POST", data={"num_etapas": 1, "stage_name": ["Etapa 1"]}
+    ):
+        dados = parse_revisor_form(request)
+    assert dados["formulario_id"] is None
+
 def test_update_and_recreate_stages(app):
     with app.app_context():
         cliente, form = _create_cliente_formulario()

--- a/utils/revisor_helpers.py
+++ b/utils/revisor_helpers.py
@@ -19,7 +19,11 @@ from models import (
 
 def parse_revisor_form(req: Request) -> Dict[str, Any]:
     """Extracts and normalizes form data for reviewer process configuration."""
-    formulario_id = req.form.get("formulario_id", type=int)
+    raw_form_id = req.form.get("formulario_id")
+    try:
+        formulario_id = int(raw_form_id) if raw_form_id else None
+    except (TypeError, ValueError):
+        formulario_id = None
     num_etapas = req.form.get("num_etapas", type=int, default=1)
     stage_names: List[str] = [s.strip() for s in req.form.getlist("stage_name")]
     if len(stage_names) < num_etapas or any(


### PR DESCRIPTION
## Summary
- Allow `config_revisor` to create a basic application form when none is selected
- Remove required attribute from reviewer config form select
- Handle empty `formulario_id` in form parsing and cover with tests

## Testing
- `pytest` *(fails: IndentationError in unrelated tests)*
- `DB_PASS=test pytest tests/test_reviewer_auto_form_creation.py tests/test_revisor_helpers.py::test_parse_revisor_form_without_formulario_id -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7368fd5cc8324b7fe82eceb6931ff