### PR TITLE
Allow extra scheduling slots

### DIFF
--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -42,16 +42,25 @@
                 <input type="date" class="form-control" id="data_inicial" name="data_inicial" required>
                 <div class="form-text">Data de início para geração dos horários.</div>
               </div>
-              
+
               <div class="col-md-6">
                 <label for="data_final" class="form-label">Data Final</label>
                 <input type="date" class="form-control" id="data_final" name="data_final" required>
                 <div class="form-text">Data final para geração dos horários.</div>
               </div>
             </div>
-            
+
+            <div class="mb-3">
+              <label class="form-label">Datas com Horários Extras</label>
+              <div id="datas-extra-container"></div>
+              <button type="button" class="btn btn-secondary mb-2" id="add-extra">
+                <i class="bi bi-plus"></i> Adicionar Data Extra
+              </button>
+              <div class="form-text">Datas que terão horários adicionais.</div>
+            </div>
+
             <div class="alert alert-warning">
-              <i class="bi bi-exclamation-triangle"></i> Atenção: 
+              <i class="bi bi-exclamation-triangle"></i> Atenção:
               <ul>
                 <li>Serão gerados horários apenas para os dias da semana selecionados nas configurações.</li>
                 <li>Horários já existentes não serão duplicados.</li>
@@ -108,6 +117,33 @@
       dataFinal.min = this.value;
       if (dataFinal.value < this.value) {
         dataFinal.value = this.value;
+      }
+    });
+
+    const container = document.getElementById('datas-extra-container');
+    document.getElementById('add-extra').addEventListener('click', function() {
+      const row = document.createElement('div');
+      row.className = 'row g-2 mb-2 extra-row';
+      row.innerHTML = `
+        <div class="col-md-4">
+          <input type="date" class="form-control" name="datas_extra[]">
+        </div>
+        <div class="col-md-3">
+          <input type="time" class="form-control" name="horario_inicio_extra[]">
+        </div>
+        <div class="col-md-3">
+          <input type="time" class="form-control" name="horario_fim_extra[]">
+        </div>
+        <div class="col-md-2">
+          <button type="button" class="btn btn-outline-danger w-100 remove-extra"><i class="bi bi-trash"></i></button>
+        </div>
+      `;
+      container.appendChild(row);
+    });
+
+    container.addEventListener('click', function(e) {
+      if (e.target.closest('.remove-extra')) {
+        e.target.closest('.extra-row').remove();
       }
     });
   });


### PR DESCRIPTION
## Summary
- Support optional extra date/time slots in agendamento generation and avoid schedule conflicts
- Add UI controls for specifying extra dates and times during slot generation

## Testing
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b7397e5d008324b39e903648c69d6a