### PR TITLE
Add fechado flag to visitation schedule and support closing slots

### DIFF
--- a/migrations/versions/f592acec47c1_add_fechado_to_horario_visitacao.py
+++ b/migrations/versions/f592acec47c1_add_fechado_to_horario_visitacao.py
@@ -1,0 +1,21 @@
+"""add fechado to horario_visitacao
+
+Revision ID: f592acec47c1
+Revises: e89dc0a9d598, c0f0b9fa83c0, 085998713db1
+Create Date: 2025-02-15 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f592acec47c1'
+down_revision = ('e89dc0a9d598', 'c0f0b9fa83c0', '085998713db1')
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('horario_visitacao', sa.Column('fechado', sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column('horario_visitacao', 'fechado')

--- a/models/event.py
+++ b/models/event.py
@@ -924,6 +924,7 @@ class HorarioVisitacao(db.Model):
     horario_fim = db.Column(db.Time, nullable=False)
     capacidade_total = db.Column(db.Integer, nullable=False)
     vagas_disponiveis = db.Column(db.Integer, nullable=False)
+    fechado = db.Column(db.Boolean, default=False, nullable=False)
 
     # Relações
     evento = db.relationship(

--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -2275,7 +2275,8 @@ def configurar_horarios_agendamento():
                         'horario_inicio': h.horario_inicio.strftime('%H:%M'),
                         'horario_fim': h.horario_fim.strftime('%H:%M'),
                         'capacidade': h.capacidade_total,
-                        'agendamentos': h.capacidade_total - h.vagas_disponiveis
+                        'agendamentos': h.capacidade_total - h.vagas_disponiveis,
+                        'fechado': h.fechado
                     } for h in horarios_existentes
                 ]
     except Exception as e:
@@ -2351,7 +2352,31 @@ def configurar_horarios_agendamento():
                     
                     # Redirecionar para a mesma página com o evento selecionado
                     return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
-            
+
+            elif acao == 'fechar':
+                horario_id = request.form.get('horario_id')
+                evento_id = request.form.get('evento_id')
+                horario = HorarioVisitacao.query.get(horario_id)
+                if horario:
+                    horario.fechado = True
+                    db.session.commit()
+                    flash('Horário fechado com sucesso!', 'success')
+                else:
+                    flash('Horário não encontrado.', 'danger')
+                return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
+
+            elif acao == 'reabrir':
+                horario_id = request.form.get('horario_id')
+                evento_id = request.form.get('evento_id')
+                horario = HorarioVisitacao.query.get(horario_id)
+                if horario:
+                    horario.fechado = False
+                    db.session.commit()
+                    flash('Horário reaberto com sucesso!', 'success')
+                else:
+                    flash('Horário não encontrado.', 'danger')
+                return redirect(url_for('agendamento_routes.configurar_horarios_agendamento', evento_id=evento_id))
+
             elif acao == 'adicionar_periodo':
                 # Obter dados do formulário para adicionar vários horários em um período
                 evento_id = request.form.get('evento_id')

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -123,10 +123,10 @@ def horarios_disponiveis_professor(evento_id):
     # Filtrar por data
     data_filtro = request.args.get('data')
     
-    # Base da consulta - horários com vagas disponíveis
+    # Base da consulta - horários não fechados
     query = HorarioVisitacao.query.filter_by(
         evento_id=evento_id
-    ).filter(HorarioVisitacao.vagas_disponiveis > 0)
+    ).filter(HorarioVisitacao.fechado.is_(False))
     
     # Permitir visualização de todos os horários (passados, presentes e futuros)
     # Removido filtro automático de datas futuras para mostrar histórico completo
@@ -193,7 +193,11 @@ def criar_agendamento_professor(horario_id):
         )
         return redirect(url_for('routes.eventos_disponiveis_professor'))
     
-    # Verificar se ainda há vagas
+    # Verificar se o horário está fechado ou sem vagas
+    if horario.fechado:
+        flash('Este horário está fechado para agendamentos.', 'warning')
+        return redirect(url_for('routes.horarios_disponiveis_professor', evento_id=evento.id))
+
     if horario.vagas_disponiveis <= 0:
         flash('Não há mais vagas disponíveis para este horário!', 'warning')
         return redirect(url_for('routes.horarios_disponiveis_professor', evento_id=evento.id))
@@ -944,7 +948,7 @@ def horarios_disponiveis_participante(evento_id):
     data_filtro = request.args.get('data')
 
     query = HorarioVisitacao.query.filter_by(evento_id=evento_id).filter(
-        HorarioVisitacao.vagas_disponiveis > 0,
+        HorarioVisitacao.fechado.is_(False),
         HorarioVisitacao.data >= datetime.utcnow().date() + timedelta(days=1)
     )
 
@@ -990,7 +994,11 @@ def criar_agendamento_participante(horario_id):
         flash('Você não está inscrito neste evento.', 'warning')
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
 
-    # Verificar vagas disponíveis
+    # Verificar se o horário está fechado ou sem vagas
+    if horario.fechado:
+        flash('Este horário está fechado para agendamentos.', 'warning')
+        return redirect(url_for('routes.horarios_disponiveis_participante', evento_id=evento.id))
+
     if horario.vagas_disponiveis <= 0:
         flash('Não há mais vagas disponíveis para este horário!', 'warning')
         return redirect(url_for('routes.horarios_disponiveis_participante', evento_id=evento.id))

--- a/templates/agendamento/configurar_horarios_agendamento.html
+++ b/templates/agendamento/configurar_horarios_agendamento.html
@@ -83,6 +83,19 @@
                   <a href="{{ url_for('agendamento_routes.editar_horario_agendamento', horario_id=horario.id) if has_editar_horario else '#' }}" class="btn btn-warning">
                     <i class="bi bi-pencil"></i>
                   </a>
+                  <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="d-inline">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="hidden" name="acao" value="{{ 'reabrir' if horario.fechado else 'fechar' }}">
+                    <input type="hidden" name="horario_id" value="{{ horario.id }}">
+                    <input type="hidden" name="evento_id" value="{{ evento_selecionado.id }}">
+                    <button type="submit" class="btn btn-secondary">
+                      {% if horario.fechado %}
+                      <i class="bi bi-unlock"></i>
+                      {% else %}
+                      <i class="bi bi-lock"></i>
+                      {% endif %}
+                    </button>
+                  </form>
                   <form method="POST" action="{{ url_for('agendamento_routes.configurar_horarios_agendamento') }}" class="d-inline" onsubmit="return confirm('Tem certeza que deseja excluir este horário?');">
                       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <input type="hidden" name="acao" value="excluir">

--- a/templates/participante/horarios_disponiveis.html
+++ b/templates/participante/horarios_disponiveis.html
@@ -47,10 +47,13 @@
                         </thead>
                         <tbody>
                             {% for horario in horarios %}
+                                {% set sem_vagas = horario.fechado or horario.vagas_disponiveis <= 0 %}
                                 <tr>
                                     <td>{{ horario.horario_inicio.strftime('%H:%M') }}</td>
                                     <td class="text-center">
-                                        {% if horario.vagas_disponiveis > 10 %}
+                                        {% if sem_vagas %}
+                                            <span class="badge bg-secondary">Vagas esgotadas</span>
+                                        {% elif horario.vagas_disponiveis > 10 %}
                                             <span class="badge bg-success">{{ horario.vagas_disponiveis }} vagas</span>
                                         {% elif horario.vagas_disponiveis > 5 %}
                                             <span class="badge bg-warning text-dark">{{ horario.vagas_disponiveis }} vagas</span>
@@ -59,9 +62,15 @@
                                         {% endif %}
                                     </td>
                                     <td class="text-end">
-                                        <a href="{{ url_for('routes.criar_agendamento_participante', horario_id=horario.id) }}" class="btn btn-sm btn-primary">
-                                            <i class="fas fa-calendar-plus"></i> Agendar
-                                        </a>
+                                        {% if sem_vagas %}
+                                            <a class="btn btn-sm btn-primary disabled" href="#" tabindex="-1" aria-disabled="true">
+                                                <i class="fas fa-calendar-plus"></i> Agendar
+                                            </a>
+                                        {% else %}
+                                            <a href="{{ url_for('routes.criar_agendamento_participante', horario_id=horario.id) }}" class="btn btn-sm btn-primary">
+                                                <i class="fas fa-calendar-plus"></i> Agendar
+                                            </a>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/templates/professor/horarios_disponiveis.html
+++ b/templates/professor/horarios_disponiveis.html
@@ -47,10 +47,13 @@
                         </thead>
                         <tbody>
                             {% for horario in horarios %}
+                                {% set sem_vagas = horario.fechado or horario.vagas_disponiveis <= 0 %}
                                 <tr>
                                     <td>{{ horario.horario_inicio.strftime('%H:%M') }}</td>
                                     <td class="text-center">
-                                        {% if horario.vagas_disponiveis > 10 %}
+                                        {% if sem_vagas %}
+                                            <span class="badge bg-secondary">Vagas esgotadas</span>
+                                        {% elif horario.vagas_disponiveis > 10 %}
                                             <span class="badge bg-success">{{ horario.vagas_disponiveis }} vagas</span>
                                         {% elif horario.vagas_disponiveis > 5 %}
                                             <span class="badge bg-warning text-dark">{{ horario.vagas_disponiveis }} vagas</span>
@@ -59,9 +62,15 @@
                                         {% endif %}
                                     </td>
                                     <td class="text-end">
-                                        <a href="{{ url_for('routes.criar_agendamento_professor', horario_id=horario.id) }}" class="btn btn-sm btn-primary">
-                                            <i class="fas fa-calendar-plus"></i> Agendar
-                                        </a>
+                                        {% if sem_vagas %}
+                                            <a class="btn btn-sm btn-primary disabled" href="#" tabindex="-1" aria-disabled="true">
+                                                <i class="fas fa-calendar-plus"></i> Agendar
+                                            </a>
+                                        {% else %}
+                                            <a href="{{ url_for('routes.criar_agendamento_professor', horario_id=horario.id) }}" class="btn btn-sm btn-primary">
+                                                <i class="fas fa-calendar-plus"></i> Agendar
+                                            </a>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}


### PR DESCRIPTION
## Summary
- add `fechado` boolean field to HorarioVisitacao and migration
- allow closing and reopening visit slots in agendamento config
- show closed or full slots as unavailable in professor and participant views

## Testing
- `pytest` *(fails: IndentationError and missing module bs4)*

------
https://chatgpt.com/codex/tasks/task_e_68b7397fd1a0832497a3e25f5aeecd28