### PR TITLE
Handle empty monitor polo list

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -109,7 +109,8 @@ def listar_polos():
             )
             if not polos:
                 return jsonify({
-                    'success': False,
+                    'success': True,
+                    'polos': [],
                     'message': 'Nenhum polo associado ao monitor'
                 })
         elif verificar_acesso_admin():


### PR DESCRIPTION
## Summary
- Ensure `/api/polos` returns success with an empty list when a monitor has no assigned polos

## Testing
- `pytest tests/test_monitor_material_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b783c4bc348324b32e3f07cd777df7