### PR TITLE
Add modal for editing materials

### DIFF
--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -34,7 +34,8 @@ function configurarEventos() {
     });
     
     // Forms
-    // Event listeners removidos - agora usando páginas separadas
+    // Event listeners
+    document.getElementById('form-material')?.addEventListener('submit', salvarMaterial);
     document.getElementById('form-movimentacao')?.addEventListener('submit', salvarMovimentacao);
 
     // Exportação WhatsApp
@@ -368,6 +369,49 @@ async function salvarMovimentacao(event) {
     }
 }
 
+// Salvar material
+async function salvarMaterial(event) {
+    event.preventDefault();
+
+    const form = document.getElementById('form-material');
+    const materialId = form.getAttribute('data-edit-id');
+
+    const formData = {
+        polo_id: document.getElementById('material-polo').value,
+        nome: document.getElementById('material-nome').value,
+        descricao: document.getElementById('material-descricao').value,
+        unidade: document.getElementById('material-unidade').value,
+        categoria: document.getElementById('material-categoria').value,
+        quantidade_minima: parseInt(document.getElementById('material-quantidade-minima').value) || 0,
+        preco_unitario: parseFloat(document.getElementById('material-preco').value) || null,
+        fornecedor: document.getElementById('material-fornecedor').value || null
+    };
+
+    try {
+        const response = await fetch(`/api/materiais/${materialId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(formData)
+        });
+
+        if (response.ok) {
+            showAlert('Material atualizado com sucesso!', 'success');
+            form.reset();
+            form.removeAttribute('data-edit-id');
+            bootstrap.Modal.getInstance(document.getElementById('modalMaterial')).hide();
+            carregarDados();
+        } else {
+            const error = await response.json();
+            showAlert(error.message || 'Erro ao atualizar material', 'danger');
+        }
+    } catch (error) {
+        console.error('Erro:', error);
+        showAlert('Erro ao atualizar material', 'danger');
+    }
+}
+
 // Editar material
 function editarMaterial(materialId) {
     const material = materiaisData.find(m => m.id === materialId);
@@ -381,6 +425,8 @@ function editarMaterial(materialId) {
     document.getElementById('material-categoria').value = material.categoria || '';
     document.getElementById('material-quantidade-inicial').value = material.quantidade_atual;
     document.getElementById('material-quantidade-minima').value = material.quantidade_minima;
+    document.getElementById('material-preco').value = material.preco_unitario || '';
+    document.getElementById('material-fornecedor').value = material.fornecedor || '';
     
     // Alterar título e ação do modal
     document.querySelector('#modalMaterial .modal-title').textContent = 'Editar Material';

--- a/templates/material/gerenciar_materiais.html
+++ b/templates/material/gerenciar_materiais.html
@@ -262,6 +262,108 @@
 
 
 
+<!-- Modal Material -->
+<div class="modal fade" id="modalMaterial" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Editar Material</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id="form-material">
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <label for="material-polo" class="form-label">Polo *</label>
+                                <select id="material-polo" class="form-select" required>
+                                    <option value="">Selecione um polo</option>
+                                    {% for polo in polos %}
+                                    <option value="{{ polo.id }}">{{ polo.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <label for="material-categoria" class="form-label">Categoria</label>
+                                <select id="material-categoria" class="form-select">
+                                    <option value="">Selecione uma categoria</option>
+                                    <option value="Papelaria">Papelaria</option>
+                                    <option value="Limpeza">Limpeza</option>
+                                    <option value="Informática">Informática</option>
+                                    <option value="Móveis">Móveis</option>
+                                    <option value="Equipamentos">Equipamentos</option>
+                                    <option value="Consumíveis">Consumíveis</option>
+                                    <option value="Outros">Outros</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="material-nome" class="form-label">Nome do Material *</label>
+                        <input type="text" class="form-control" id="material-nome" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="material-descricao" class="form-label">Descrição</label>
+                        <textarea class="form-control" id="material-descricao" rows="3"></textarea>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-4">
+                            <div class="mb-3">
+                                <label for="material-unidade" class="form-label">Unidade *</label>
+                                <select id="material-unidade" class="form-select" required>
+                                    <option value="">Selecione</option>
+                                    <option value="un">Unidade</option>
+                                    <option value="cx">Caixa</option>
+                                    <option value="pct">Pacote</option>
+                                    <option value="kg">Quilograma</option>
+                                    <option value="l">Litro</option>
+                                    <option value="m">Metro</option>
+                                    <option value="m²">Metro²</option>
+                                    <option value="resma">Resma</option>
+                                    <option value="dz">Dúzia</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="mb-3">
+                                <label for="material-quantidade-inicial" class="form-label">Quantidade Atual</label>
+                                <input type="number" class="form-control" id="material-quantidade-inicial" min="0" disabled>
+                                <div class="form-text">Quantidade atual em estoque</div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="mb-3">
+                                <label for="material-quantidade-minima" class="form-label">Estoque Mínimo</label>
+                                <input type="number" class="form-control" id="material-quantidade-minima" min="0">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <label for="material-preco" class="form-label">Preço Unitário (R$)</label>
+                                <input type="number" class="form-control" id="material-preco" min="0" step="0.01">
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <label for="material-fornecedor" class="form-label">Fornecedor</label>
+                                <input type="text" class="form-control" id="material-fornecedor">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-success">Salvar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <!-- Modal Movimentação -->
 <div class="modal fade" id="modalMovimentacao" tabindex="-1">
     <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- add `modalMaterial` to materials management page with full form inputs
- handle material editing in `material_gerenciar.js`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests and missing bs4)*

------
https://chatgpt.com/codex/tasks/task_e_68b7865de4108324b139d123d1bad858