### PR TITLE
Restrict monitor materials to client and improve empty-state handling

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -102,16 +102,19 @@ def listar_polos():
                 .join(MonitorPolo, MonitorPolo.polo_id == Polo.id)
                 .filter(
                     MonitorPolo.monitor_id == current_user.id,
-                    MonitorPolo.ativo == True,
-                    Polo.ativo == True
+                    MonitorPolo.ativo.is_(True),
+                    Polo.ativo.is_(True),
+                    Polo.cliente_id == current_user.cliente_id,
                 )
                 .all()
             )
             if not polos:
-                return jsonify({
-                    'success': False,
-                    'message': 'Nenhum polo associado ao monitor'
-                })
+                return jsonify(
+                    {
+                        'success': False,
+                        'message': 'Nenhum polo associado ao monitor',
+                    }
+                )
         elif verificar_acesso_admin():
             polos = Polo.query.filter_by(ativo=True).all()
         else:
@@ -512,19 +515,24 @@ def listar_materiais():
         polo_id = request.args.get('polo_id')
         
         if verificar_acesso_cliente():
-            query = Material.query.filter_by(cliente_id=current_user.id, ativo=True)
-        else:  # Monitor
-            # Buscar polos atribuídos ao monitor
-            polos_monitor = db.session.query(MonitorPolo.polo_id).filter_by(
-                monitor_id=current_user.id, ativo=True
-            ).subquery()
-            query = Material.query.filter(
-                Material.polo_id.in_(polos_monitor),
-                Material.ativo == True
+            query = Material.query.filter_by(
+                cliente_id=current_user.id, ativo=True
             )
-        
+        else:
+            query = (
+                Material.query.join(
+                    MonitorPolo, MonitorPolo.polo_id == Material.polo_id
+                )
+                .filter(
+                    MonitorPolo.monitor_id == current_user.id,
+                    MonitorPolo.ativo.is_(True),
+                    Material.ativo.is_(True),
+                    Material.cliente_id == current_user.cliente_id,
+                )
+            )
+
         if polo_id:
-            query = query.filter_by(polo_id=polo_id)
+            query = query.filter(Material.polo_id == polo_id)
         
         materiais = query.all()
         

--- a/static/js/monitor_materiais.js
+++ b/static/js/monitor_materiais.js
@@ -29,52 +29,52 @@ async function carregarDadosIniciais() {
     try {
         mostrarCarregando(true);
 
-
-        // Carregar polos e materiais
-        const [polosResponse, materiaisResponse] = await Promise.all([
-            fetch('/api/polos'),
-            fetch('/api/materiais')
-        ]);
-
-        if (polosResponse.status === 403 || materiaisResponse.status === 403) {
+        const polosResponse = await fetch('/api/polos');
+        if (polosResponse.status === 403) {
             mostrarAlerta('Sessão expirada, faça login novamente', 'error');
             return;
         }
 
-        const parseJSON = async (response) => {
-
-            const contentType = response.headers.get('Content-Type') || '';
-            if (!contentType.includes('application/json')) {
-                throw new Error('Sessão expirada');
-            }
-            return response.json();
-        };
-
-
-        const polosJson = await parseJSON(polosResponse);
-        const materiaisJson = await parseJSON(materiaisResponse);
-
-        if (!polosJson.success || !materiaisJson.success) {
-            throw new Error(
-                polosJson.message ||
-                    materiaisJson.message ||
-                    'Erro ao carregar dados'
+        const polosJson = await polosResponse.json();
+        if (!polosJson.success) {
+            mostrarAlerta(
+                polosJson.message || 'Nenhum polo atribuído ao monitor',
+                'info'
             );
+            polosData = [];
+            materiaisData = [];
+            atualizarCardsPolos();
+            atualizarTabelaMateriais();
+            return;
         }
-
 
         polosData = polosJson.polos || [];
-
-        // Carregar materiais somente se houver polos
-        const materiaisResponse = await fetch('/api/materiais');
-        const materiaisJson = await parseAndValidate(materiaisResponse);
-        materiaisData = materiaisJson.materiais || [];
-
         if (polosData.length === 0) {
             mostrarAlerta('Nenhum polo atribuído ao monitor', 'info');
+            materiaisData = [];
+            atualizarCardsPolos();
+            atualizarTabelaMateriais();
+            return;
         }
-        if (materiaisData.length === 0) {
-            mostrarAlerta('Nenhum material disponível', 'info');
+
+        const materiaisResponse = await fetch('/api/materiais');
+        if (materiaisResponse.status === 403) {
+            mostrarAlerta('Sessão expirada, faça login novamente', 'error');
+            return;
+        }
+
+        const materiaisJson = await materiaisResponse.json();
+        if (!materiaisJson.success) {
+            mostrarAlerta(
+                materiaisJson.message || 'Erro ao carregar materiais',
+                'error'
+            );
+            materiaisData = [];
+        } else {
+            materiaisData = materiaisJson.materiais || [];
+            if (materiaisData.length === 0) {
+                mostrarAlerta('Nenhum material disponível', 'info');
+            }
         }
 
         atualizarCardsPolos();
@@ -86,7 +86,6 @@ async function carregarDadosIniciais() {
         } else {
             mostrarAlerta(error.message || 'Erro ao carregar dados', 'error');
         }
-        return;
     } finally {
         mostrarCarregando(false);
     }


### PR DESCRIPTION
## Summary
- Ensure monitor material and polo queries filter by assigned polos and the monitor's client
- Handle empty or error responses in monitor material JS UI
- Test monitor APIs for assigned and unassigned polos across clients

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` (fails: unexpected indent in unrelated tests)
- `pytest tests/test_monitor_material_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7865f15248324bb1f5a4858a0bba4