### PR TITLE
Simplify agendamento and add manual horario

### DIFF
--- a/templates/agendamento/adicionar_horario_agendamento.html
+++ b/templates/agendamento/adicionar_horario_agendamento.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+
+{% block title %}Adicionar Horário - {{ evento.nome }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-lg-8 mx-auto">
+      <h2 class="mb-4"><i class="bi bi-clock"></i> Adicionar Horário - {{ evento.nome }}</h2>
+      <div class="card">
+        <div class="card-header bg-primary text-white">
+          <i class="bi bi-plus-circle"></i> Novo Horário
+        </div>
+        <div class="card-body">
+          <form method="POST" action="{{ url_for('agendamento_routes.adicionar_horario_agendamento', evento_id=evento.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+              <label for="data" class="form-label">Data</label>
+              <input type="date" class="form-control" id="data" name="data" required>
+            </div>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label for="horario_inicio" class="form-label">Horário de Início</label>
+                  <input type="time" class="form-control" id="horario_inicio" name="horario_inicio" required>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="mb-3">
+                  <label for="horario_fim" class="form-label">Horário de Fim</label>
+                  <input type="time" class="form-control" id="horario_fim" name="horario_fim" required>
+                </div>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="capacidade" class="form-label">Capacidade</label>
+              <input type="number" class="form-control" id="capacidade" name="capacidade" min="1" required>
+            </div>
+            <div class="d-grid gap-2 d-md-flex">
+              <button type="submit" class="btn btn-success">
+                <i class="bi bi-save"></i> Salvar
+              </button>
+              <a href="{{ url_for('agendamento_routes.listar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-secondary">
+                <i class="bi bi-arrow-left"></i> Voltar
+              </a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/agendamento/gerar_horarios_agendamento.html
+++ b/templates/agendamento/gerar_horarios_agendamento.html
@@ -50,15 +50,6 @@
               </div>
             </div>
 
-            <div class="mb-3">
-              <label class="form-label">Datas com Horários Extras</label>
-              <div id="datas-extra-container"></div>
-              <button type="button" class="btn btn-secondary mb-2" id="add-extra">
-                <i class="bi bi-plus"></i> Adicionar Data Extra
-              </button>
-              <div class="form-text">Datas que terão horários adicionais.</div>
-            </div>
-
             <div class="alert alert-warning">
               <i class="bi bi-exclamation-triangle"></i> Atenção:
               <ul>
@@ -120,32 +111,6 @@
       }
     });
 
-    const container = document.getElementById('datas-extra-container');
-    document.getElementById('add-extra').addEventListener('click', function() {
-      const row = document.createElement('div');
-      row.className = 'row g-2 mb-2 extra-row';
-      row.innerHTML = `
-        <div class="col-md-4">
-          <input type="date" class="form-control" name="datas_extra[]">
-        </div>
-        <div class="col-md-3">
-          <input type="time" class="form-control" name="horario_inicio_extra[]">
-        </div>
-        <div class="col-md-3">
-          <input type="time" class="form-control" name="horario_fim_extra[]">
-        </div>
-        <div class="col-md-2">
-          <button type="button" class="btn btn-outline-danger w-100 remove-extra"><i class="bi bi-trash"></i></button>
-        </div>
-      `;
-      container.appendChild(row);
-    });
-
-    container.addEventListener('click', function(e) {
-      if (e.target.closest('.remove-extra')) {
-        e.target.closest('.extra-row').remove();
-      }
-    });
   });
 </script>
 {% endblock %}

--- a/templates/agendamento/listar_horarios_agendamento.html
+++ b/templates/agendamento/listar_horarios_agendamento.html
@@ -21,6 +21,9 @@
       </div>
       
       <div class="d-flex justify-content-end mb-4">
+        <a href="{{ url_for('agendamento_routes.adicionar_horario_agendamento', evento_id=evento.id) }}" class="btn btn-primary me-2">
+          <i class="bi bi-plus-circle"></i> Adicionar Horário
+        </a>
         <a href="{{ url_for('agendamento_routes.gerar_horarios_agendamento', evento_id=evento.id) }}" class="btn btn-success me-2">
           <i class="bi bi-calendar-plus"></i> Gerar Novos Horários
         </a>


### PR DESCRIPTION
## Summary
- remove support for extra date ranges when generating visit schedules
- add dedicated endpoint and page to insert single HorarioVisitacao
- link manual schedule page from main schedule list

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: unexpected indent in tests and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b7866b1ce483248d0d8ec36e6cf0d9