### PR TITLE
Add horario toggle and prevent scheduling when closed

### DIFF
--- a/templates/agendamento/listar_horarios_agendamento.html
+++ b/templates/agendamento/listar_horarios_agendamento.html
@@ -87,6 +87,14 @@
                             </div>
                           </td>
                           <td class="text-center">
+                            <form method="POST" action="{{ url_for('agendamento_routes.toggle_horario_agendamento') }}" class="d-inline">
+                              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                              <input type="hidden" name="horario_id" value="{{ horario.id }}">
+                              <button type="submit" class="btn btn-sm {% if horario.fechado %}btn-success{% else %}btn-warning{% endif %}" data-bs-toggle="tooltip" title="{% if horario.fechado %}Reabrir{% else %}Fechar{% endif %}">
+                                <i class="bi bi-{% if horario.fechado %}unlock{% else %}lock{% endif %}"></i>
+                              </button>
+                            </form>
+
                             <button class="btn btn-sm btn-primary" data-bs-toggle="tooltip" title="Editar"
                                     onclick="editarHorario({{ horario.id }}, '{{ horario.horario_inicio.strftime('%H:%M') }}', '{{ horario.horario_fim.strftime('%H:%M') }}', {{ horario.capacidade_total }}, {{ horario.vagas_disponiveis }})">
                               <i class="bi bi-pencil"></i>


### PR DESCRIPTION
## Summary
- add endpoint to toggle `HorarioVisitacao.fechado`
- show lock/unlock button on horarios list
- block agendamentos when horario is closed and test toggle workflow

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in unrelated test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b78670d31883248f665102e8582b67