### PR TITLE
Add fields to reviewer process model

### DIFF
--- a/migrations/versions/a5b321c0b871_add_nome_descricao_status_to_revisor_process.py
+++ b/migrations/versions/a5b321c0b871_add_nome_descricao_status_to_revisor_process.py
@@ -1,0 +1,36 @@
+"""add nome descricao status to revisor_process
+
+Revision ID: a5b321c0b871
+Revises: 79c3c0f95577
+Create Date: 2024-05-09 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a5b321c0b871"
+down_revision = "79c3c0f95577"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "revisor_process",
+        sa.Column("nome", sa.String(length=255), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "revisor_process",
+        sa.Column("descricao", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "revisor_process",
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="ativo"),
+    )
+
+
+def downgrade():
+    op.drop_column("revisor_process", "status")
+    op.drop_column("revisor_process", "descricao")
+    op.drop_column("revisor_process", "nome")

--- a/models/review.py
+++ b/models/review.py
@@ -368,6 +368,9 @@ class RevisorProcess(db.Model):
         nullable=True,
     )
     evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=True)
+    nome = db.Column(db.String(255), nullable=False)
+    descricao = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(50), nullable=False)
     num_etapas = db.Column(db.Integer, default=1)
 
     # Controle de disponibilidade do processo

--- a/tests/test_assign_by_filters.py
+++ b/tests/test_assign_by_filters.py
@@ -15,7 +15,7 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
 
 from app import create_app
 from extensions import db
-
+from models import (
     Cliente,
     ConfiguracaoCliente,
     RevisorProcess,
@@ -51,7 +51,11 @@ def app():
         evento2 = Evento(cliente_id=cliente.id, nome='E2')
         db.session.add_all([evento1, evento2])
         db.session.flush()
-        proc = RevisorProcess(cliente_id=cliente.id)
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(proc)
         db.session.flush()
         proc.eventos.append(evento1)

--- a/tests/test_formulario_campo_revisor.py
+++ b/tests/test_formulario_campo_revisor.py
@@ -55,7 +55,13 @@ def app():
         )
         db.session.add_all([campo_email, campo_nome])
         db.session.commit()
-        proc = RevisorProcess(cliente_id=cliente.id, formulario_id=form.id, num_etapas=1)
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(proc)
         db.session.commit()
     yield app

--- a/tests/test_mandatory_field_deletion.py
+++ b/tests/test_mandatory_field_deletion.py
@@ -62,7 +62,11 @@ def app():
         db.session.commit()
 
         processo = RevisorProcess(
-            cliente_id=cliente.id, formulario_id=form.id, num_etapas=1
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add(processo)
         db.session.commit()

--- a/tests/test_peer_review_flow.py
+++ b/tests/test_peer_review_flow.py
@@ -125,7 +125,11 @@ def app():
         db.session.add(evento)
         db.session.commit()
 
-        process = RevisorProcess(cliente_id=cliente.id)
+        process = RevisorProcess(
+            cliente_id=cliente.id,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(process)
         db.session.commit()
 

--- a/tests/test_requisito_validation.py
+++ b/tests/test_requisito_validation.py
@@ -10,7 +10,7 @@ os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
 
 from config import Config
 from extensions import db, login_manager, csrf
-
+from models import (
     Cliente,
     Formulario,
     RevisorProcess,
@@ -65,6 +65,8 @@ def app():
             cliente_id=cliente.id,
             formulario_id=form.id,
             num_etapas=1,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add(proc)
         db.session.commit()

--- a/tests/test_reviewer_applications.py
+++ b/tests/test_reviewer_applications.py
@@ -69,7 +69,7 @@ sys.modules.setdefault('utils.arquivo_utils', arquivo_utils_stub)
 
 from app import create_app
 from extensions import db, login_manager
-
+from models import (
     Usuario,
     Cliente,
     ReviewerApplication,
@@ -185,7 +185,13 @@ def test_revisor_approval_without_email(client, app):
         campo_nome = CampoFormulario(formulario_id=form.id, nome='nome', tipo='text')
         db.session.add(campo_nome)
         db.session.commit()
-        proc = RevisorProcess(cliente_id=cliente.id, formulario_id=form.id, num_etapas=1)
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(proc)
         db.session.commit()
         campo_id = campo_nome.id
@@ -225,7 +231,11 @@ def test_approve_revisor_cpf_collision(client, app, monkeypatch):
         db.session.add(form)
         db.session.commit()
         proc = RevisorProcess(
-            cliente_id=cliente.id, formulario_id=form.id, num_etapas=1
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add(proc)
         db.session.commit()
@@ -272,7 +282,11 @@ def test_approve_revisor_cpf_collision_error(client, app, monkeypatch, caplog):
         db.session.add(form)
         db.session.commit()
         proc = RevisorProcess(
-            cliente_id=cliente.id, formulario_id=form.id, num_etapas=1
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add(proc)
         db.session.commit()

--- a/tests/test_reviewer_auto_form_creation.py
+++ b/tests/test_reviewer_auto_form_creation.py
@@ -69,7 +69,13 @@ def test_config_revisor_creates_basic_form(app, client):
                 login_user(cliente)
             resp = client.post(
                 "/config_revisor",
-                data={"formulario_id": "", "num_etapas": 1, "stage_name": ["Etapa 1"]},
+                data={
+                    "formulario_id": "",
+                    "nome": "Proc",
+                    "status": "ativo",
+                    "num_etapas": 1,
+                    "stage_name": ["Etapa 1"],
+                },
             )
             with app.test_request_context():
                 logout_user()

--- a/tests/test_reviewer_required_fields.py
+++ b/tests/test_reviewer_required_fields.py
@@ -85,6 +85,8 @@ def test_config_revisor_adds_default_fields(app, client):
                 "/config_revisor",
                 data={
                     "formulario_id": formulario.id,
+                    "nome": "Proc",
+                    "status": "ativo",
                     "num_etapas": 1,
                     "stage_name": ["Etapa 1"],
                 },

--- a/tests/test_revisor_email_notifications.py
+++ b/tests/test_revisor_email_notifications.py
@@ -42,7 +42,7 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
 
 from app import create_app
 from extensions import db
-
+from models import (
     Cliente,
     Formulario,
     CampoFormulario,
@@ -85,6 +85,8 @@ def app():
             formulario_id=form.id,
             num_etapas=3,
             exibir_para_participantes=True,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add(proc)
         db.session.commit()

--- a/tests/test_revisor_helpers.py
+++ b/tests/test_revisor_helpers.py
@@ -50,6 +50,9 @@ def test_parse_revisor_form(app):
         method="POST",
         data={
             "formulario_id": 1,
+            "nome": "Proc",
+            "descricao": "Desc",
+            "status": "ativo",
             "num_etapas": 2,
             "stage_name": ["Etapa 1", "Etapa 2"],
             "availability_start": "2024-01-10",
@@ -62,6 +65,9 @@ def test_parse_revisor_form(app):
     ):
         dados = parse_revisor_form(request)
     assert dados["formulario_id"] == 1
+    assert dados["nome"] == "Proc"
+    assert dados["descricao"] == "Desc"
+    assert dados["status"] == "ativo"
     assert dados["num_etapas"] == 2
     assert dados["stage_names"] == ["Etapa 1", "Etapa 2"]
     assert dados["availability_start"].date() == date(2024, 1, 10)
@@ -73,7 +79,12 @@ def test_parse_revisor_form(app):
 def test_parse_revisor_form_missing_stage(app):
     with app.test_request_context(
         method="POST",
-        data={"num_etapas": 2, "stage_name": ["Etapa 1"]},
+        data={
+            "num_etapas": 2,
+            "stage_name": ["Etapa 1"],
+            "nome": "Proc",
+            "status": "ativo",
+        },
     ):
         with pytest.raises(ValueError):
             parse_revisor_form(request)
@@ -81,7 +92,13 @@ def test_parse_revisor_form_missing_stage(app):
 
 def test_parse_revisor_form_without_formulario_id(app):
     with app.test_request_context(
-        method="POST", data={"num_etapas": 1, "stage_name": ["Etapa 1"]}
+        method="POST",
+        data={
+            "num_etapas": 1,
+            "stage_name": ["Etapa 1"],
+            "nome": "Proc",
+            "status": "ativo",
+        },
     ):
         dados = parse_revisor_form(request)
     assert dados["formulario_id"] is None
@@ -89,7 +106,11 @@ def test_parse_revisor_form_without_formulario_id(app):
 def test_update_and_recreate_stages(app):
     with app.app_context():
         cliente, form = _create_cliente_formulario()
-        processo = RevisorProcess(cliente_id=cliente.id)
+        processo = RevisorProcess(
+            cliente_id=cliente.id,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(processo)
         db.session.commit()
 
@@ -97,6 +118,8 @@ def test_update_and_recreate_stages(app):
             method="POST",
             data={
                 "formulario_id": form.id,
+                "nome": "Proc",
+                "status": "ativo",
                 "num_etapas": 2,
                 "stage_name": ["E1", "E2"],
                 "exibir_para_participantes": "on",
@@ -113,6 +136,8 @@ def test_update_and_recreate_stages(app):
             method="POST",
             data={
                 "formulario_id": form.id,
+                "nome": "Proc",
+                "status": "ativo",
                 "num_etapas": 1,
                 "stage_name": ["Novo"],
             },
@@ -132,7 +157,11 @@ def test_update_process_eventos(app):
         e2 = Evento(cliente_id=cliente.id, nome="E2", inscricao_gratuita=True, publico=True)
         db.session.add_all([e1, e2])
         db.session.commit()
-        processo = RevisorProcess(cliente_id=cliente.id)
+        processo = RevisorProcess(
+            cliente_id=cliente.id,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(processo)
         db.session.commit()
 

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -118,6 +118,8 @@ def app():
             availability_start=now - timedelta(days=1),
             availability_end=now + timedelta(days=1),
             exibir_para_participantes=True,
+            nome="Proc",
+            status="ativo",
         )
         proc.eventos.append(evento)
         db.session.add(proc)
@@ -248,6 +250,9 @@ def test_navbar_shows_link_for_participant_when_disabled(client, app):
 def test_is_available_method():
     now = datetime.utcnow()
     proc = RevisorProcess(
+        cliente_id=1,
+        nome="Proc",
+        status="ativo",
         availability_start=now - timedelta(hours=1),
         availability_end=now + timedelta(hours=1),
     )

--- a/tests/test_revisor_process_delete.py
+++ b/tests/test_revisor_process_delete.py
@@ -67,7 +67,12 @@ def test_delete_process_removes_related_data(app, client):
         )
         db.session.add(cliente)
         db.session.commit()
-        proc = RevisorProcess(cliente_id=cliente.id, num_etapas=1)
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(proc)
         db.session.commit()
         etapa = RevisorEtapa(process_id=proc.id, numero=1, nome="E1")

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -78,20 +78,21 @@ def app():
                 availability_start=date.today() - timedelta(days=1),
                 availability_end=date.today() + timedelta(days=1),
                 exibir_para_participantes=True,
+                nome="Proc",
+                status="ativo",
             )
         )
 
         proc1 = RevisorProcess(
-
             cliente_id=c1.id,
             formulario_id=f1.id,
             num_etapas=1,
             availability_start=date.today() - timedelta(days=1),
             availability_end=date.today() + timedelta(days=1),
-
             exibir_para_participantes=True,
             eventos=[e1],
-
+            nome="Proc",
+            status="ativo",
         )
 
         proc2 = RevisorProcess(
@@ -102,13 +103,16 @@ def app():
             availability_end=date.today() - timedelta(days=1),
             exibir_para_participantes=True,
             eventos=[e2],
+            nome="Proc",
+            status="ativo",
         )
         proc3 = RevisorProcess(
             cliente_id=c1.id,
             formulario_id=f1.id,
             num_etapas=1,
             exibir_para_participantes=False,
-
+            nome="Proc",
+            status="ativo",
         )
         db.session.add_all([proc1, proc2, proc3])
         db.session.commit()
@@ -203,6 +207,8 @@ def test_config_route_saves_availability(client, app):
                 '/config_revisor',
                 data={
                     'formulario_id': formulario.id,
+                    'nome': 'Proc',
+                    'status': 'ativo',
                     'num_etapas': 1,
                     'stage_name': ['Etapa 1'],
                     'availability_start': start.strftime('%Y-%m-%d'),
@@ -234,6 +240,8 @@ def test_config_route_saves_eventos(client, app):
                 '/config_revisor',
                 data={
                     'formulario_id': formulario.id,
+                    'nome': 'Proc',
+                    'status': 'ativo',
                     'num_etapas': 1,
                     'stage_name': ['Etapa 1'],
                     'eventos_ids': [evento.id],

--- a/tests/test_revisor_score_limits.py
+++ b/tests/test_revisor_score_limits.py
@@ -16,7 +16,7 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
 
 from app import create_app
 from extensions import db
-
+from models import (
     Usuario,
     Cliente,
     Evento,
@@ -52,7 +52,12 @@ def app():
             formacao="X",
             tipo="revisor",
         )
-        process = RevisorProcess(cliente_id=cliente.id, num_etapas=1)
+        process = RevisorProcess(
+            cliente_id=cliente.id,
+            num_etapas=1,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add_all([reviewer, process])
         db.session.flush()
         barema_proc = ProcessoBarema(process_id=process.id)

--- a/tests/test_revisor_select_event_filter.py
+++ b/tests/test_revisor_select_event_filter.py
@@ -92,6 +92,8 @@ def app():
             availability_end=date.today() + timedelta(days=1),
             exibir_para_participantes=True,
             evento_id=linked_direct.id,
+            nome="Proc",
+            status="ativo",
         )
         proc_assoc = RevisorProcess(
             cliente_id=cliente.id,
@@ -100,6 +102,8 @@ def app():
             availability_start=date.today() - timedelta(days=1),
             availability_end=date.today() + timedelta(days=1),
             exibir_para_participantes=True,
+            nome="Proc",
+            status="ativo",
         )
         proc_inactive = RevisorProcess(
             cliente_id=cliente.id,
@@ -109,6 +113,8 @@ def app():
             availability_end=date.today() - timedelta(days=1),
             exibir_para_participantes=True,
             evento_id=inactive.id,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add_all([proc_direct, proc_assoc, proc_inactive])
         db.session.commit()
@@ -166,6 +172,8 @@ def test_open_process_without_valid_events(app):
             availability_end=date.today() + timedelta(days=1),
             exibir_para_participantes=True,
             evento_id=invalid_event.id,
+            nome="Proc",
+            status="ativo",
         )
         db.session.add(proc)
         db.session.commit()

--- a/tests/test_sortear_revisores.py
+++ b/tests/test_sortear_revisores.py
@@ -13,7 +13,7 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
 
 from app import create_app
 from extensions import db
-
+from models import (
     Cliente,
     ConfiguracaoCliente,
     RevisorProcess,
@@ -49,7 +49,11 @@ def app():
         evento = Evento(cliente_id=cliente.id, nome='E1')
         db.session.add(evento)
         db.session.flush()
-        proc = RevisorProcess(cliente_id=cliente.id)
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(proc)
         db.session.flush()
         proc.eventos.append(evento)

--- a/tests/test_submission_control_reviewers.py
+++ b/tests/test_submission_control_reviewers.py
@@ -43,7 +43,11 @@ def app():
         )
         db.session.add_all([admin, cliente])
         db.session.flush()
-        proc = RevisorProcess(cliente_id=cliente.id)
+        proc = RevisorProcess(
+            cliente_id=cliente.id,
+            nome="Proc",
+            status="ativo",
+        )
         db.session.add(proc)
         db.session.flush()
         db.session.add_all(

--- a/utils/revisor_helpers.py
+++ b/utils/revisor_helpers.py
@@ -24,6 +24,11 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
         formulario_id = int(raw_form_id) if raw_form_id else None
     except (TypeError, ValueError):
         formulario_id = None
+    nome = req.form.get("nome", "").strip()
+    if not nome:
+        raise ValueError("Nome do processo é obrigatório")
+    descricao = req.form.get("descricao")
+    status = req.form.get("status", "ativo")
     num_etapas = req.form.get("num_etapas", type=int, default=1)
     stage_names: List[str] = [s.strip() for s in req.form.getlist("stage_name")]
     if len(stage_names) < num_etapas or any(
@@ -54,6 +59,9 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
 
     return {
         "formulario_id": formulario_id,
+        "nome": nome,
+        "descricao": descricao,
+        "status": status,
         "num_etapas": num_etapas,
         "stage_names": stage_names,
         "availability_start": _parse_dt(start_raw),
@@ -67,6 +75,9 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
 def update_revisor_process(processo: RevisorProcess, dados: Dict[str, Any]) -> None:
     """Updates a reviewer process with parsed data."""
     processo.formulario_id = dados.get("formulario_id")
+    processo.nome = dados.get("nome", processo.nome)
+    processo.descricao = dados.get("descricao")
+    processo.status = dados.get("status", processo.status)
     processo.num_etapas = dados.get("num_etapas")
     processo.availability_start = dados.get("availability_start")
     processo.availability_end = dados.get("availability_end")


### PR DESCRIPTION
## Summary
- track reviewer processes with `nome`, `descricao` and `status`
- parse and persist new reviewer process fields
- update tests to supply required reviewer process data

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: unexpected indent errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7867be2548324b9760abb20e063a6