### PR TITLE
Add reviewer process CRUD routes and expand tests

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -84,71 +84,110 @@ def _ensure_secret_key(setup_state):  # pragma: no cover
 
 
 # -----------------------------------------------------------------------------
-# CONFIGURAÇÃO DO PROCESSO PELO CLIENTE
+# PROCESSOS DO REVISOR
 # -----------------------------------------------------------------------------
-@revisor_routes.route("/config_revisor", methods=["GET", "POST"])
+
+
+@revisor_routes.route("/revisor/processos", methods=["GET"])
 @login_required
-def config_revisor():
-    """Render or update reviewer process configuration."""
+def list_processes() -> Any:
+    """List all review processes for the logged client."""
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
         return redirect(url_for(endpoints.DASHBOARD))
 
-    # Um cliente pode ter no máximo 1 processo configurado.
-    processo: RevisorProcess | None = RevisorProcess.query.filter_by(
+    processos = RevisorProcess.query.filter_by(
         cliente_id=current_user.id  # type: ignore[attr-defined]
-    ).first()
+    ).all()
+    data = [{"id": p.id, "formulario_id": p.formulario_id} for p in processos]
+    return jsonify(data)
+
+
+@revisor_routes.route("/revisor/processos", methods=["POST"])
+@login_required
+def create_process() -> Any:
+    """Create a new review process for the current client."""
+    if current_user.tipo != "cliente":  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for(endpoints.DASHBOARD))
+    try:
+        dados = parse_revisor_form(request)
+    except ValueError as exc:
+        flash(str(exc), "danger")
+        return jsonify({"error": str(exc)}), 400
+
+    created_form: Formulario | None = None
+    if not dados.get("formulario_id"):
+        created_form = Formulario(
+            nome="Formulário de Candidatura",
+            cliente_id=current_user.id,  # type: ignore[attr-defined]
+        )
+        db.session.add(created_form)
+        db.session.flush()
+        rh.ensure_reviewer_required_fields(created_form)
+        dados["formulario_id"] = created_form.id
+
+    processo = RevisorProcess(cliente_id=current_user.id)  # type: ignore[attr-defined]
+    db.session.add(processo)
+    db.session.flush()
+
+    update_revisor_process(processo, dados)
+    update_process_eventos(processo, dados.get("eventos_ids", []))
+    recreate_stages(processo, dados.get("stage_names", []))
+    recreate_criterios(processo, dados.get("criterios", []))
+    if created_form is None and processo.formulario_id:
+        formulario = Formulario.query.get(processo.formulario_id)
+        if formulario:
+            rh.ensure_reviewer_required_fields(formulario)
+    db.session.commit()
+    return jsonify({"id": processo.id}), 201
+
+
+@revisor_routes.route("/revisor/processos/<int:process_id>", methods=["GET", "POST"])
+@login_required
+def edit_process(process_id: int):
+    """Render or update a specific review process."""
+    if current_user.tipo != "cliente":  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for(endpoints.DASHBOARD))
+    processo = RevisorProcess.query.get_or_404(process_id)
+    if processo.cliente_id != current_user.id:  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for(endpoints.DASHBOARD))
+
     formularios: List[Formulario] = Formulario.query.filter_by(
         cliente_id=current_user.id  # type: ignore[attr-defined]
     ).all()
     eventos: List[Evento] = Evento.query.filter_by(
         cliente_id=current_user.id  # type: ignore[attr-defined]
     ).all()
-
-    selected_event_ids: List[int] = [e.id for e in processo.eventos] if processo else []
-
+    selected_event_ids: List[int] = [e.id for e in processo.eventos]
 
     if request.method == "POST":
         try:
             dados = parse_revisor_form(request)
         except ValueError as exc:
             flash(str(exc), "danger")
-            return redirect(url_for("revisor_routes.config_revisor"))
-
-        created_form: Formulario | None = None
-        if not dados.get("formulario_id"):
-            created_form = Formulario(
-                nome="Formulário de Candidatura",
-                cliente_id=current_user.id,  # type: ignore[attr-defined]
+            return redirect(
+                url_for("revisor_routes.edit_process", process_id=processo.id)
             )
-            db.session.add(created_form)
-            db.session.flush()
-            rh.ensure_reviewer_required_fields(created_form)
-            dados["formulario_id"] = created_form.id
-
-        if not processo:
-            processo = RevisorProcess(cliente_id=current_user.id)  # type: ignore[attr-defined]
-            db.session.add(processo)
-
         update_revisor_process(processo, dados)
-        update_process_eventos(processo, dados["eventos_ids"])
-        recreate_stages(processo, dados["stage_names"])
-        recreate_criterios(processo, dados["criterios"])
-        if created_form is None and processo.formulario_id:
+        update_process_eventos(processo, dados.get("eventos_ids", []))
+        recreate_stages(processo, dados.get("stage_names", []))
+        recreate_criterios(processo, dados.get("criterios", []))
+        if processo.formulario_id:
             formulario = Formulario.query.get(processo.formulario_id)
             if formulario:
                 rh.ensure_reviewer_required_fields(formulario)
         db.session.commit()
         flash("Processo atualizado", "success")
-        return redirect(url_for("revisor_routes.config_revisor"))
+        return redirect(
+            url_for("revisor_routes.edit_process", process_id=processo.id)
+        )
 
-    etapas: List[RevisorEtapa] = (
-        processo.etapas if processo else []
-    )  # type: ignore[index]
+    etapas: List[RevisorEtapa] = processo.etapas  # type: ignore[index]
     try:
-        criterios = (
-            processo.criterios if processo else []
-        )  # type: ignore[attr-defined]
+        criterios = processo.criterios  # type: ignore[attr-defined]
     except ProgrammingError as exc:  # pragma: no cover - depends on db state
         current_app.logger.error("Erro ao acessar criterios: %s", exc)
         flash(
@@ -161,7 +200,6 @@ def config_revisor():
         processo=processo,
         formularios=formularios,
         etapas=etapas,
-
         criterios=criterios,
         eventos=eventos,
         selected_event_ids=selected_event_ids,
@@ -169,8 +207,10 @@ def config_revisor():
 
 
 @revisor_routes.route("/revisor/<int:process_id>/delete", methods=["POST"])
+@revisor_routes.route("/revisor/processos/<int:process_id>", methods=["DELETE"])
 @login_required
 def delete_process(process_id: int):
+    """Remove a review process owned by the current client."""
     if current_user.tipo != "cliente":  # type: ignore[attr-defined]
         flash("Acesso negado!", "danger")
         return redirect(url_for(endpoints.DASHBOARD))
@@ -180,8 +220,10 @@ def delete_process(process_id: int):
         return redirect(url_for(endpoints.DASHBOARD))
     db.session.delete(processo)
     db.session.commit()
+    if request.method == "DELETE":
+        return "", 204
     flash("Processo removido", "success")
-    return redirect(url_for("revisor_routes.config_revisor"))
+    return redirect(url_for("revisor_routes.list_processes"))
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_formulario_vinculo_revisor.py
+++ b/tests/test_formulario_vinculo_revisor.py
@@ -64,6 +64,6 @@ def test_form_creation_does_not_create_revisor_process(client, app):
     with app.app_context():
         form = Formulario.query.filter_by(nome='F1').first()
         assert form is not None
-        proc = RevisorProcess.query.filter_by(cliente_id=form.cliente_id).first()
-        assert proc is None
+        procs = RevisorProcess.query.filter_by(cliente_id=form.cliente_id).all()
+        assert procs == []
 

--- a/tests/test_reviewer_auto_form_creation.py
+++ b/tests/test_reviewer_auto_form_creation.py
@@ -68,18 +68,19 @@ def test_config_revisor_creates_basic_form(app, client):
             with app.test_request_context():
                 login_user(cliente)
             resp = client.post(
-                "/config_revisor",
+                "/revisor/processos",
                 data={"formulario_id": "", "num_etapas": 1, "stage_name": ["Etapa 1"]},
             )
             with app.test_request_context():
                 logout_user()
 
-        assert resp.status_code in (200, 302)
+        assert resp.status_code == 201
+        proc_id = resp.get_json()["id"]
         form = Formulario.query.filter_by(cliente_id=cliente.id).first()
         assert form is not None
         campos = {c.nome: c for c in form.campos}
         assert {"nome", "email"} <= set(campos)
         assert campos["nome"].obrigatorio is True
         assert campos["email"].obrigatorio is True
-        proc = RevisorProcess.query.filter_by(cliente_id=cliente.id).first()
+        proc = RevisorProcess.query.get(proc_id)
         assert proc is not None and proc.formulario_id == form.id

--- a/tests/test_reviewer_required_fields.py
+++ b/tests/test_reviewer_required_fields.py
@@ -82,7 +82,7 @@ def test_config_revisor_adds_default_fields(app, client):
             with app.test_request_context():
                 login_user(cliente)
             resp = client.post(
-                "/config_revisor",
+                "/revisor/processos",
                 data={
                     "formulario_id": formulario.id,
                     "num_etapas": 1,
@@ -92,7 +92,7 @@ def test_config_revisor_adds_default_fields(app, client):
             with app.test_request_context():
                 logout_user()
 
-        assert resp.status_code in (200, 302)
+        assert resp.status_code == 201
         campos = CampoFormulario.query.filter_by(formulario_id=formulario.id).all()
         campos = {c.nome: c for c in campos}
         assert {"nome", "email"} <= set(campos)

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -200,7 +200,7 @@ def test_config_route_saves_availability(client, app):
             with app.test_request_context():
                 login_user(cliente)
             resp = client.post(
-                '/config_revisor',
+                '/revisor/processos',
                 data={
                     'formulario_id': formulario.id,
                     'num_etapas': 1,
@@ -213,8 +213,9 @@ def test_config_route_saves_availability(client, app):
             with app.test_request_context():
                 logout_user()
 
-        assert resp.status_code in (302, 200)
-        proc = RevisorProcess.query.filter_by(cliente_id=cliente.id).first()
+        assert resp.status_code == 201
+        proc_id = resp.get_json()['id']
+        proc = RevisorProcess.query.get(proc_id)
         assert proc.availability_start.date() == start
         assert proc.availability_end.date() == end
 
@@ -231,7 +232,7 @@ def test_config_route_saves_eventos(client, app):
             with app.test_request_context():
                 login_user(cliente)
             resp = client.post(
-                '/config_revisor',
+                '/revisor/processos',
                 data={
                     'formulario_id': formulario.id,
                     'num_etapas': 1,
@@ -242,8 +243,9 @@ def test_config_route_saves_eventos(client, app):
             with app.test_request_context():
                 logout_user()
 
-        assert resp.status_code in (302, 200)
-        proc = RevisorProcess.query.filter_by(cliente_id=cliente.id).first()
+        assert resp.status_code == 201
+        proc_id = resp.get_json()['id']
+        proc = RevisorProcess.query.get(proc_id)
         assert [e.id for e in proc.eventos] == [evento.id]
 
 
@@ -257,7 +259,12 @@ def test_config_route_renders_eventos(client, app):
         with client:
             with app.test_request_context():
                 login_user(cliente)
-            resp = client.get('/config_revisor')
+            proc = (
+                RevisorProcess.query.filter_by(cliente_id=cliente.id)
+                .filter(RevisorProcess.eventos.any())
+                .all()[0]
+            )
+            resp = client.get(f'/revisor/processos/{proc.id}')
             with app.test_request_context():
                 logout_user()
 


### PR DESCRIPTION
## Summary
- add endpoints to list, create, edit and delete reviewer processes
- remove single-process assumption in revisor routes
- update tests to handle multiple processes per client

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError and missing modules during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b78681890c8324be2cbcf4cff8a383