### PR TITLE
Filter reviewer process listings by active status

### DIFF
--- a/models/review.py
+++ b/models/review.py
@@ -374,6 +374,7 @@ class RevisorProcess(db.Model):
     availability_start = db.Column(db.DateTime, nullable=True)
     availability_end = db.Column(db.DateTime, nullable=True)
     exibir_para_participantes = db.Column(db.Boolean, default=False)
+    status = db.Column(db.String(50), default="ativo")
 
     cliente = db.relationship(
         "Cliente", backref=db.backref("revisor_processes", lazy=True)

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -75,7 +75,10 @@ def submission_control():
     processos_seletivos = (
         db.session.query(RevisorProcess, Formulario)
         .join(Formulario, RevisorProcess.formulario_id == Formulario.id)
-        .filter(RevisorProcess.cliente_id == cliente_id)
+        .filter(
+            RevisorProcess.cliente_id == cliente_id,
+            RevisorProcess.status == "ativo",
+        )
         .all()
     )
     

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -492,6 +492,7 @@ def select_event():
     processos = (
         RevisorProcess.query.options(selectinload(RevisorProcess.eventos))
         .filter(
+            RevisorProcess.status == "ativo",
             RevisorProcess.exibir_para_participantes.is_(True),
             or_(
                 RevisorProcess.availability_start.is_(None),
@@ -843,6 +844,7 @@ def eligible_events():
         .filter(
             Evento.status == "ativo",
             Evento.publico.is_(True),
+            RevisorProcess.status == "ativo",
             RevisorProcess.exibir_para_participantes.is_(True),
             or_(
                 RevisorProcess.availability_start.is_(None),

--- a/tests/test_reviewer_applications.py
+++ b/tests/test_reviewer_applications.py
@@ -6,6 +6,7 @@ import pytest
 from io import BytesIO
 from flask import send_file
 from werkzeug.security import generate_password_hash
+from datetime import datetime, timedelta
 from config import Config
 Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
 Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
@@ -26,6 +27,7 @@ utils_stub.gerar_comprovante_pdf = lambda *a, **k: ''
 utils_stub.enviar_email = lambda *a, **k: None
 utils_stub.formatar_brasilia = lambda *a, **k: ''
 utils_stub.determinar_turno = lambda *a, **k: ''
+utils_stub.endpoints = types.SimpleNamespace(DASHBOARD='dashboard')
 sys.modules.setdefault('utils', utils_stub)
 utils_security = types.ModuleType('utils.security')
 utils_security.sanitize_input = lambda x: x
@@ -70,6 +72,7 @@ sys.modules.setdefault('utils.arquivo_utils', arquivo_utils_stub)
 from app import create_app
 from extensions import db, login_manager
 
+from models import (
     Usuario,
     Cliente,
     ReviewerApplication,
@@ -77,6 +80,7 @@ from extensions import db, login_manager
     CampoFormulario,
     RevisorProcess,
     RevisorCandidatura,
+    Evento,
 )
 from routes.auth_routes import auth_routes
 
@@ -307,3 +311,60 @@ def test_approve_revisor_cpf_collision_error(client, app, monkeypatch, caplog):
         cand_db = RevisorCandidatura.query.get(cand_id)
         assert cand_db.status == 'pendente'
         assert Usuario.query.filter_by(email='cand2@test').first() is None
+
+
+def test_eligible_events_filters_by_status(client, app):
+    with app.app_context():
+        cliente = Cliente.query.filter_by(email='cli@test').first()
+        form = Formulario(nome='Form2', cliente_id=cliente.id)
+        cliente2 = Cliente(nome='Cli2', email='cli2@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        db.session.add_all([form, cliente2])
+        db.session.commit()
+        form2 = Formulario(nome='Form3', cliente_id=cliente2.id)
+        db.session.add(form2)
+        db.session.commit()
+        e_active = Evento(
+            cliente_id=cliente.id,
+            nome='EA',
+            inscricao_gratuita=True,
+            publico=True,
+            status='ativo',
+        )
+        e_inactive = Evento(
+            cliente_id=cliente2.id,
+            nome='EI',
+            inscricao_gratuita=True,
+            publico=True,
+            status='ativo',
+        )
+        db.session.add_all([e_active, e_inactive])
+        db.session.commit()
+        proc_active = RevisorProcess(
+            cliente_id=cliente.id,
+            formulario_id=form.id,
+            num_etapas=1,
+            availability_start=datetime.utcnow() - timedelta(days=1),
+            availability_end=datetime.utcnow() + timedelta(days=1),
+            exibir_para_participantes=True,
+            status='ativo',
+            eventos=[e_active],
+        )
+        proc_inactive = RevisorProcess(
+            cliente_id=cliente2.id,
+            formulario_id=form2.id,
+            num_etapas=1,
+            availability_start=datetime.utcnow() - timedelta(days=1),
+            availability_end=datetime.utcnow() + timedelta(days=1),
+            exibir_para_participantes=True,
+            status='finalizado',
+            eventos=[e_inactive],
+        )
+        db.session.add_all([proc_active, proc_inactive])
+        db.session.commit()
+        e_active_id, e_inactive_id = e_active.id, e_inactive.id
+
+    resp = client.get('/revisor/eligible_events')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert {'id': e_active_id, 'nome': 'EA'} in data
+    assert {'id': e_inactive_id, 'nome': 'EI'} not in data

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -63,11 +63,19 @@ def app():
             publico=True,
             status='ativo',
         )
-        db.session.add_all([e1, e2])
+        e3 = Evento(
+            cliente_id=c2.id,
+            nome='E3',
+            inscricao_gratuita=True,
+            publico=True,
+            status='ativo',
+        )
+        db.session.add_all([e1, e2, e3])
         db.session.commit()
 
         e1.formularios.append(f1)
         e2.formularios.append(f2)
+        e3.formularios.append(f2)
         db.session.commit()
 
         db.session.add(
@@ -108,9 +116,18 @@ def app():
             formulario_id=f1.id,
             num_etapas=1,
             exibir_para_participantes=False,
-
         )
-        db.session.add_all([proc1, proc2, proc3])
+        proc_inactive = RevisorProcess(
+            cliente_id=c2.id,
+            formulario_id=f2.id,
+            num_etapas=1,
+            availability_start=date.today() - timedelta(days=1),
+            availability_end=date.today() + timedelta(days=1),
+            exibir_para_participantes=True,
+            status='finalizado',
+            eventos=[e3],
+        )
+        db.session.add_all([proc1, proc2, proc3, proc_inactive])
         db.session.commit()
     yield app
 
@@ -138,6 +155,7 @@ def test_visibility_flag_filters(app):
             .filter(
                 RevisorProcess.exibir_para_participantes.is_(True),
                 RevisorProcess.eventos.any(),
+                RevisorProcess.status == 'ativo',
             )
             .all()
         )
@@ -159,7 +177,9 @@ def test_eligible_events_route(client, app):
     data = resp.get_json()
     with app.app_context():
         e1 = Evento.query.filter_by(nome='E1').first()
+        e3 = Evento.query.filter_by(nome='E3').first()
     assert data == [{'id': e1.id, 'nome': 'E1'}]
+    assert {'id': e3.id, 'nome': 'E3'} not in data
 
 
 def test_select_event_route(client):
@@ -168,6 +188,7 @@ def test_select_event_route(client):
     html = resp.get_data(as_text=True)
     assert 'E1' in html
     assert 'E2' not in html
+    assert 'E3' not in html
 
 
 def test_revisorprocess_eventos_relationship(app):


### PR DESCRIPTION
## Summary
- add `status` field to `RevisorProcess`
- filter participant process listings to only active processes
- extend tests to cover active vs inactive process visibility

## Testing
- `SECRET_KEY=test DB_PASS=test GOOGLE_CLIENT_ID=1 GOOGLE_CLIENT_SECRET=1 pytest tests/test_revisor_process_extra.py::test_visibility_flag_filters tests/test_revisor_process_extra.py::test_eligible_events_route tests/test_revisor_process_extra.py::test_select_event_route tests/test_reviewer_applications.py::test_eligible_events_filters_by_status -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7868b704c83248ba4885ce8b92619