### PR TITLE
Support process metadata in reviewer flows

### DIFF
--- a/models/review.py
+++ b/models/review.py
@@ -370,6 +370,11 @@ class RevisorProcess(db.Model):
     evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=True)
     num_etapas = db.Column(db.Integer, default=1)
 
+    # Dados descritivos do processo
+    nome = db.Column(db.String(255), nullable=True)
+    descricao = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(50), nullable=True)
+
     # Controle de disponibilidade do processo
     availability_start = db.Column(db.DateTime, nullable=True)
     availability_end = db.Column(db.DateTime, nullable=True)

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -513,7 +513,9 @@ def select_event():
             if ev:
                 eventos.append(ev)
 
-        status = "Aberto" if proc.is_available() else "Encerrado"
+        status = proc.status if getattr(proc, "status", None) else (
+            "Aberto" if proc.is_available() else "Encerrado"
+        )
         if not eventos:
             registros.append({"evento": None, "processo": proc, "status": status})
             continue

--- a/templates/peer_review/submission_control.html
+++ b/templates/peer_review/submission_control.html
@@ -432,7 +432,8 @@
                     <option value="">Todos os processos seletivos</option>
                     {% for processo, formulario in processos_seletivos %}
                       <option value="{{ processo.id }}">
-                        {{ formulario.nome if formulario.nome else 'Processo ' + processo.id|string }}
+                        {{ processo.nome or (formulario.nome if formulario.nome else 'Processo ' + processo.id|string) }}
+                        {% if processo.status %}- {{ processo.status }}{% endif %}
                         {% if processo.evento_id %}
                           - {{ processo.evento.nome if processo.evento else 'Evento ' + processo.evento_id|string }}
                         {% endif %}

--- a/templates/revisor/candidatura_detail.html
+++ b/templates/revisor/candidatura_detail.html
@@ -10,6 +10,12 @@
           <i class="bi bi-person-badge me-2"></i>Detalhes da Candidatura
         </h1>
         <p class="text-muted">Informações completas do candidato</p>
+        {% if candidatura.process.nome %}
+        <h2 class="h5 mt-3">{{ candidatura.process.nome }}</h2>
+        {% endif %}
+        {% if candidatura.process.descricao %}
+        <p class="text-muted">{{ candidatura.process.descricao }}</p>
+        {% endif %}
       </div>
       
       <!-- Informações principais -->

--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -56,6 +56,40 @@
   </div>
 
   <form method="post" id="configForm" novalidate>
+    <!-- Informações do Processo -->
+    <div class="card config-card mb-4">
+      <div class="card-header bg-light">
+        <h5 class="card-title mb-0">
+          <i class="bi bi-info-circle me-2"></i>
+          Informações do Processo
+        </h5>
+      </div>
+      <div class="card-body">
+        <div class="row mb-3">
+          <div class="col-md-6 mb-3 mb-md-0">
+            <label class="form-label fw-semibold">Nome do Processo</label>
+            <input type="text" class="form-control" name="nome" value="{{ processo.nome if processo else '' }}" required>
+            <div class="invalid-feedback">Por favor, informe o nome do processo.</div>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-semibold">Status</label>
+            {% set pstatus = processo.status if processo else '' %}
+            <select class="form-select" name="status" required>
+              <option value="">Selecione...</option>
+              <option value="Aberto" {% if pstatus == 'Aberto' %}selected{% endif %}>Aberto</option>
+              <option value="Pendente" {% if pstatus == 'Pendente' %}selected{% endif %}>Pendente</option>
+              <option value="Encerrado" {% if pstatus == 'Encerrado' %}selected{% endif %}>Encerrado</option>
+            </select>
+            <div class="invalid-feedback">Por favor, selecione o status.</div>
+          </div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Descrição</label>
+          <textarea class="form-control" name="descricao" rows="3">{{ processo.descricao if processo else '' }}</textarea>
+        </div>
+      </div>
+    </div>
+
     <!-- Configurações Básicas -->
     <div class="card config-card mb-4">
       <div class="card-header bg-light">

--- a/templates/revisor/progress.html
+++ b/templates/revisor/progress.html
@@ -10,6 +10,12 @@
           <i class="bi bi-clipboard-check me-2"></i>Acompanhamento da Candidatura
         </h1>
         <p class="text-muted">Acompanhe o status da sua candidatura ao processo seletivo</p>
+        {% if candidatura.process.nome %}
+        <h2 class="h5 mt-3">{{ candidatura.process.nome }}</h2>
+        {% endif %}
+        {% if candidatura.process.descricao %}
+        <p class="text-muted">{{ candidatura.process.descricao }}</p>
+        {% endif %}
       </div>
       
       <!-- Card com informações da candidatura -->

--- a/templates/revisor/select_event.html
+++ b/templates/revisor/select_event.html
@@ -76,8 +76,8 @@
               <div class="d-flex align-items-center">
                 <i class="bi bi-{{ 'calendar-event' if item.evento else 'file-text' }} text-primary fs-4 me-2"></i>
                 <div>
-                  <h5 class="mb-0">{{ item.evento.nome if item.evento else item.processo.formulario.nome }}</h5>
-                  <small class="text-muted">Processo #{{ item.processo.id }}</small>
+                  <h5 class="mb-0">{{ item.processo.nome or (item.evento.nome if item.evento else item.processo.formulario.nome) }}</h5>
+                  <small class="text-muted">#{{ item.processo.id }}</small>
                 </div>
               </div>
               {% set status_class = 'success' if item.status == 'Aberto' else 'secondary' %}
@@ -123,7 +123,19 @@
               </div>
             </div>
             {% endif %}
-            
+
+            {% if item.processo.descricao %}
+            <div class="mb-3">
+              <div class="d-flex align-items-center">
+                <i class="bi bi-text-left text-muted me-2"></i>
+                <div>
+                  <small class="text-muted d-block">Descrição</small>
+                  <strong class="small">{{ item.processo.descricao }}</strong>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
             <div class="mb-3">
               <div class="d-flex align-items-center">
                 <i class="bi bi-info-circle text-muted me-2"></i>

--- a/tests/test_revisor_helpers.py
+++ b/tests/test_revisor_helpers.py
@@ -49,6 +49,9 @@ def test_parse_revisor_form(app):
     with app.test_request_context(
         method="POST",
         data={
+            "nome": "Processo A",
+            "descricao": "Desc",
+            "status": "Aberto",
             "formulario_id": 1,
             "num_etapas": 2,
             "stage_name": ["Etapa 1", "Etapa 2"],
@@ -61,6 +64,9 @@ def test_parse_revisor_form(app):
         },
     ):
         dados = parse_revisor_form(request)
+    assert dados["nome"] == "Processo A"
+    assert dados["descricao"] == "Desc"
+    assert dados["status"] == "Aberto"
     assert dados["formulario_id"] == 1
     assert dados["num_etapas"] == 2
     assert dados["stage_names"] == ["Etapa 1", "Etapa 2"]
@@ -79,9 +85,18 @@ def test_parse_revisor_form_missing_stage(app):
             parse_revisor_form(request)
 
 
+def test_parse_revisor_form_missing_nome(app):
+    with app.test_request_context(
+        method="POST", data={"status": "Aberto", "num_etapas": 1, "stage_name": ["E1"]}
+    ):
+        with pytest.raises(ValueError):
+            parse_revisor_form(request)
+
+
 def test_parse_revisor_form_without_formulario_id(app):
     with app.test_request_context(
-        method="POST", data={"num_etapas": 1, "stage_name": ["Etapa 1"]}
+        method="POST",
+        data={"nome": "Proc", "status": "Aberto", "num_etapas": 1, "stage_name": ["Etapa 1"]},
     ):
         dados = parse_revisor_form(request)
     assert dados["formulario_id"] is None
@@ -96,6 +111,8 @@ def test_update_and_recreate_stages(app):
         with app.test_request_context(
             method="POST",
             data={
+                "nome": "Proc",
+                "status": "Aberto",
                 "formulario_id": form.id,
                 "num_etapas": 2,
                 "stage_name": ["E1", "E2"],
@@ -112,6 +129,8 @@ def test_update_and_recreate_stages(app):
         with app.test_request_context(
             method="POST",
             data={
+                "nome": "Proc",
+                "status": "Aberto",
                 "formulario_id": form.id,
                 "num_etapas": 1,
                 "stage_name": ["Novo"],

--- a/utils/revisor_helpers.py
+++ b/utils/revisor_helpers.py
@@ -24,6 +24,17 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
         formulario_id = int(raw_form_id) if raw_form_id else None
     except (TypeError, ValueError):
         formulario_id = None
+
+    nome = req.form.get("nome", "").strip()
+    if not nome:
+        raise ValueError("Nome do processo é obrigatório")
+
+    descricao = req.form.get("descricao", "").strip() or None
+
+    status = req.form.get("status", "").strip()
+    if status not in {"Aberto", "Encerrado", "Pendente"}:
+        raise ValueError("Status inválido")
+
     num_etapas = req.form.get("num_etapas", type=int, default=1)
     stage_names: List[str] = [s.strip() for s in req.form.getlist("stage_name")]
     if len(stage_names) < num_etapas or any(
@@ -54,6 +65,9 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
 
     return {
         "formulario_id": formulario_id,
+        "nome": nome,
+        "descricao": descricao,
+        "status": status,
         "num_etapas": num_etapas,
         "stage_names": stage_names,
         "availability_start": _parse_dt(start_raw),
@@ -67,6 +81,9 @@ def parse_revisor_form(req: Request) -> Dict[str, Any]:
 def update_revisor_process(processo: RevisorProcess, dados: Dict[str, Any]) -> None:
     """Updates a reviewer process with parsed data."""
     processo.formulario_id = dados.get("formulario_id")
+    processo.nome = dados.get("nome")
+    processo.descricao = dados.get("descricao")
+    processo.status = dados.get("status")
     processo.num_etapas = dados.get("num_etapas")
     processo.availability_start = dados.get("availability_start")
     processo.availability_end = dados.get("availability_end")


### PR DESCRIPTION
## Summary
- allow reviewer processes to store `nome`, `descricao` and `status`
- parse and validate new fields and pre-fill them in configuration form
- surface process details on participant listings and detail views

## Testing
- `pip install -r requirements-dev.txt`
- `pip install --break-system-packages -r requirements.txt` *(fails: Cannot uninstall urllib3 2.0.7, RECORD file not found)*
- `pytest -q system` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*
- `pip install --break-system-packages --no-deps Flask-SQLAlchemy`
- `pip install --break-system-packages --no-deps Flask SQLAlchemy`
- `pip install --break-system-packages --no-deps Werkzeug`
- `pip install --break-system-packages --no-deps Jinja2`
- `pip install --break-system-packages --no-deps Flask-Login`
- `pip install --break-system-packages --no-deps Flask-Migrate`
- `pip install --break-system-packages --no-deps alembic`
- `pip install --break-system-packages --no-deps Mako`
- `pip install --break-system-packages --no-deps Flask-Mail`
- `pip install --break-system-packages --no-deps Flask-SocketIO`
- `pip install --break-system-packages --no-deps python-socketio`
- `pip install --break-system-packages --no-deps python-engineio`
- `pip install --break-system-packages --no-deps bidict`
- `pip install --break-system-packages --no-deps Flask-WTF`
- `pip install --break-system-packages --no-deps WTForms`
- `pytest -q system` *(fails: 79 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b7868edc7883249ec3b04834353889