### PR TITLE
Fix duplicate fields in RevisorProcess model

### DIFF
--- a/models/review.py
+++ b/models/review.py
@@ -370,21 +370,13 @@ class RevisorProcess(db.Model):
     evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=True)
     nome = db.Column(db.String(255), nullable=False)
     descricao = db.Column(db.Text, nullable=True)
-    status = db.Column(db.String(50), nullable=False)
+    status = db.Column(db.String(50), nullable=False, default="ativo")
     num_etapas = db.Column(db.Integer, default=1)
-
-
-    # Informações básicas
-
-    nome = db.Column(db.String(255), nullable=True)
-    descricao = db.Column(db.Text, nullable=True)
-    status = db.Column(db.String(50), nullable=True)
 
     # Controle de disponibilidade do processo
     availability_start = db.Column(db.DateTime, nullable=True)
     availability_end = db.Column(db.DateTime, nullable=True)
     exibir_para_participantes = db.Column(db.Boolean, default=False)
-    status = db.Column(db.String(50), default="ativo")
 
     cliente = db.relationship(
         "Cliente", backref=db.backref("revisor_processes", lazy=True)


### PR DESCRIPTION
## Summary
- remove duplicate `nome`, `descricao`, and `status` columns from `RevisorProcess`
- ensure `status` defaults to `"ativo"`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b4f7b6c08324bc1ebfefccaac7f2