### PR TITLE
Allow monitors to view client polos

### DIFF
--- a/static/js/monitor_materiais.js
+++ b/static/js/monitor_materiais.js
@@ -38,24 +38,16 @@ async function carregarDadosIniciais() {
         const polosJson = await polosResponse.json();
         if (!polosJson.success) {
             mostrarAlerta(
-                polosJson.message || 'Nenhum polo atribuído ao monitor',
-                'info'
+                polosJson.message || 'Erro ao carregar polos',
+                'error'
             );
-            polosData = [];
-            materiaisData = [];
-            atualizarCardsPolos();
-            atualizarTabelaMateriais();
             return;
         }
 
         polosData = polosJson.polos || [];
 
         if (polosData.length === 0) {
-            mostrarAlerta('Nenhum polo atribuído ao monitor', 'info');
-            materiaisData = [];
-            atualizarCardsPolos();
-            atualizarTabelaMateriais();
-            return;
+            mostrarAlerta('Nenhum polo cadastrado', 'info');
         }
 
         const materiaisResponse = await fetch('/api/materiais');


### PR DESCRIPTION
## Summary
- remove monitor-to-polo assignments from monitor endpoints
- load all client polos on monitor dashboard and API
- update monitor material dashboard JS to handle full polo list

## Testing
- `pytest` *(fails: unexpected indent / missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b50589ec83248699b16e61e6618c