### PR TITLE
Add edit pages for polos and materiais

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -1003,3 +1003,73 @@ def novo_material():
         return redirect(url_for('main.index'))
     
     return render_template('material/novo_material.html')
+
+
+@material_routes.route('/editar-polo/<int:polo_id>', methods=['GET', 'POST'])
+@login_required
+def editar_polo(polo_id):
+    """Página para editar um polo existente."""
+    if not verificar_acesso_cliente():
+        flash('Acesso negado', 'error')
+        return redirect(url_for('main.index'))
+
+    polo = Polo.query.filter_by(
+        id=polo_id, cliente_id=current_user.id, ativo=True
+    ).first()
+    if not polo:
+        flash('Polo não encontrado', 'error')
+        return redirect(url_for('material_routes.gerenciar_materiais'))
+
+    if request.method == 'POST':
+        polo.nome = request.form.get('nome', polo.nome)
+        polo.descricao = request.form.get('descricao', polo.descricao)
+        polo.endereco = request.form.get('endereco', polo.endereco)
+        polo.responsavel = request.form.get('responsavel', polo.responsavel)
+        polo.telefone = request.form.get('telefone', polo.telefone)
+        polo.email = request.form.get('email', polo.email)
+        polo.updated_at = datetime.utcnow()
+        db.session.commit()
+        flash('Polo atualizado com sucesso', 'success')
+        return redirect(url_for('material_routes.gerenciar_materiais'))
+
+    return render_template('material/editar_polo.html', polo=polo)
+
+
+@material_routes.route('/editar-material/<int:material_id>', methods=['GET', 'POST'])
+@login_required
+def editar_material(material_id):
+    """Página para editar um material existente."""
+    if not verificar_acesso_cliente():
+        flash('Acesso negado', 'error')
+        return redirect(url_for('main.index'))
+
+    material = Material.query.filter_by(
+        id=material_id, cliente_id=current_user.id, ativo=True
+    ).first()
+    if not material:
+        flash('Material não encontrado', 'error')
+        return redirect(url_for('material_routes.gerenciar_materiais'))
+
+    polos = Polo.query.filter_by(cliente_id=current_user.id, ativo=True).all()
+
+    if request.method == 'POST':
+        material.polo_id = int(request.form.get('polo_id') or material.polo_id)
+        material.nome = request.form.get('nome', material.nome)
+        material.descricao = request.form.get('descricao', material.descricao)
+        material.unidade = request.form.get('unidade', material.unidade)
+        material.categoria = request.form.get('categoria', material.categoria)
+        material.quantidade_minima = int(
+            request.form.get('quantidade_minima') or material.quantidade_minima
+        )
+        preco = request.form.get('preco_unitario')
+        material.preco_unitario = float(preco) if preco else None
+        material.fornecedor = request.form.get('fornecedor', material.fornecedor)
+        material.updated_at = datetime.utcnow()
+        db.session.commit()
+        flash('Material atualizado com sucesso', 'success')
+        return redirect(url_for('material_routes.gerenciar_materiais'))
+
+    return render_template(
+        'material/editar_material.html', material=material, polos=polos
+    )
+

--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -255,7 +255,7 @@ function criarLinhaTabela(material) {
                 <button class="btn btn-outline-primary" onclick="abrirMovimentacao(${material.id})" title="Movimentar">
                     <i class="fas fa-exchange-alt"></i>
                 </button>
-                <button class="btn btn-outline-secondary" onclick="editarMaterial(${material.id})" title="Editar">
+                <button class="btn btn-outline-secondary" onclick="window.location.href='/editar-material/${material.id}'" title="Editar">
                     <i class="fas fa-edit"></i>
                 </button>
                 <button class="btn btn-outline-danger" onclick="excluirMaterial(${material.id})" title="Excluir">
@@ -412,29 +412,6 @@ async function salvarMaterial(event) {
     }
 }
 
-// Editar material
-function editarMaterial(materialId) {
-    const material = materiaisData.find(m => m.id === materialId);
-    if (!material) return;
-    
-    // Preencher formulário com dados do material
-    document.getElementById('material-polo').value = material.polo_id;
-    document.getElementById('material-nome').value = material.nome;
-    document.getElementById('material-descricao').value = material.descricao || '';
-    document.getElementById('material-unidade').value = material.unidade;
-    document.getElementById('material-categoria').value = material.categoria || '';
-    document.getElementById('material-quantidade-inicial').value = material.quantidade_atual;
-    document.getElementById('material-quantidade-minima').value = material.quantidade_minima;
-    document.getElementById('material-preco').value = material.preco_unitario || '';
-    document.getElementById('material-fornecedor').value = material.fornecedor || '';
-    
-    // Alterar título e ação do modal
-    document.querySelector('#modalMaterial .modal-title').textContent = 'Editar Material';
-    document.getElementById('form-material').setAttribute('data-edit-id', materialId);
-    
-    const modal = new bootstrap.Modal(document.getElementById('modalMaterial'));
-    modal.show();
-}
 
 // Excluir material
 async function excluirMaterial(materialId) {
@@ -473,26 +450,6 @@ function verMateriaisPolo(poloId) {
     document.getElementById('tabela-materiais').scrollIntoView({ behavior: 'smooth' });
 }
 
-// Editar polo
-function editarPolo(poloId) {
-    const polo = polosData.find(p => p.id === poloId);
-    if (!polo) return;
-    
-    // Preencher formulário com dados do polo
-    document.getElementById('polo-nome').value = polo.nome;
-    document.getElementById('polo-descricao').value = polo.descricao || '';
-    document.getElementById('polo-endereco').value = polo.endereco || '';
-    document.getElementById('polo-responsavel').value = polo.responsavel || '';
-    document.getElementById('polo-telefone').value = polo.telefone || '';
-    document.getElementById('polo-email').value = polo.email || '';
-    
-    // Alterar título e ação do modal
-    document.querySelector('#modalPolo .modal-title').textContent = 'Editar Polo';
-    document.getElementById('form-polo').setAttribute('data-edit-id', poloId);
-    
-    const modal = new bootstrap.Modal(document.getElementById('modalPolo'));
-    modal.show();
-}
 
 // Atualizar lista
 function atualizarLista() {

--- a/templates/material/editar_material.html
+++ b/templates/material/editar_material.html
@@ -1,0 +1,125 @@
+{% extends "base.html" %}
+
+{% block title %}Editar Material{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <!-- Header -->
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center">
+                <div>
+                    <h2 class="mb-0">📦 Editar Material</h2>
+                    <p class="text-muted mb-0">Atualize as informações do material selecionado</p>
+                </div>
+                <div>
+                    <a href="{{ url_for('material_routes.gerenciar_materiais') }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left"></i> Voltar
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Formulário -->
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Informações do Material</h5>
+                </div>
+                <div class="card-body">
+                    <form method="post">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="material-polo" class="form-label">Polo *</label>
+                                    <select class="form-select" id="material-polo" name="polo_id" required>
+                                        {% for polo in polos %}
+                                        <option value="{{ polo.id }}" {% if polo.id == material.polo_id %}selected{% endif %}>{{ polo.nome }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="material-categoria" class="form-label">Categoria</label>
+                                    <select class="form-select" id="material-categoria" name="categoria">
+                                        <option value="">Selecione uma categoria</option>
+                                        {% set categorias = ['Papelaria','Limpeza','Informática','Móveis','Equipamentos','Consumíveis','Outros'] %}
+                                        {% for cat in categorias %}
+                                        <option value="{{ cat }}" {% if cat == material.categoria %}selected{% endif %}>{{ cat }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="material-nome" class="form-label">Nome do Material *</label>
+                            <input type="text" class="form-control" id="material-nome" name="nome" value="{{ material.nome }}" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="material-descricao" class="form-label">Descrição</label>
+                            <textarea class="form-control" id="material-descricao" name="descricao" rows="3">{{ material.descricao }}</textarea>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-4">
+                                <div class="mb-3">
+                                    <label for="material-unidade" class="form-label">Unidade *</label>
+                                    <select class="form-select" id="material-unidade" name="unidade" required>
+                                        {% set unidades = ['un','cx','pct','kg','l','m','m²','resma','dz'] %}
+                                        {% for un in unidades %}
+                                        <option value="{{ un }}" {% if un == material.unidade %}selected{% endif %}>{{ un }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <div class="mb-3">
+                                    <label for="material-quantidade-atual" class="form-label">Quantidade Atual</label>
+                                    <input type="number" class="form-control" id="material-quantidade-atual" value="{{ material.quantidade_atual }}" disabled>
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <div class="mb-3">
+                                    <label for="material-quantidade-minima" class="form-label">Estoque Mínimo</label>
+                                    <input type="number" class="form-control" id="material-quantidade-minima" name="quantidade_minima" value="{{ material.quantidade_minima }}" min="0">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="material-preco" class="form-label">Preço Unitário (R$)</label>
+                                    <input type="number" class="form-control" id="material-preco" name="preco_unitario" step="0.01" min="0" value="{{ material.preco_unitario or '' }}">
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="material-fornecedor" class="form-label">Fornecedor</label>
+                                    <input type="text" class="form-control" id="material-fornecedor" name="fornecedor" value="{{ material.fornecedor }}">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="d-flex justify-content-end gap-2">
+                            <a href="{{ url_for('material_routes.gerenciar_materiais') }}" class="btn btn-secondary">
+                                <i class="fas fa-times"></i> Cancelar
+                            </a>
+                            <button type="submit" class="btn btn-success">
+                                <i class="fas fa-save"></i> Salvar Material
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/material/editar_polo.html
+++ b/templates/material/editar_polo.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+
+{% block title %}Editar Polo{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <!-- Header -->
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center">
+                <div>
+                    <h2 class="mb-0">📍 Editar Polo Formativo</h2>
+                    <p class="text-muted mb-0">Atualize os dados do polo selecionado</p>
+                </div>
+                <div>
+                    <a href="{{ url_for('material_routes.gerenciar_materiais') }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left"></i> Voltar
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Formulário -->
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Informações do Polo</h5>
+                </div>
+                <div class="card-body">
+                    <form method="post">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="mb-3">
+                                    <label for="polo-nome" class="form-label">Nome do Polo *</label>
+                                    <input type="text" class="form-control" id="polo-nome"
+                                           name="nome" value="{{ polo.nome }}" required>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="polo-descricao" class="form-label">Descrição</label>
+                            <textarea class="form-control" id="polo-descricao" name="descricao" rows="3">{{ polo.descricao }}</textarea>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="polo-endereco" class="form-label">Endereço</label>
+                            <input type="text" class="form-control" id="polo-endereco"
+                                           name="endereco" value="{{ polo.endereco }}">
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="polo-responsavel" class="form-label">Responsável</label>
+                                    <input type="text" class="form-control" id="polo-responsavel"
+                                           name="responsavel" value="{{ polo.responsavel }}">
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="polo-telefone" class="form-label">Telefone</label>
+                                    <input type="text" class="form-control" id="polo-telefone"
+                                           name="telefone" value="{{ polo.telefone }}">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="polo-email" class="form-label">E-mail</label>
+                            <input type="email" class="form-control" id="polo-email"
+                                           name="email" value="{{ polo.email }}">
+                        </div>
+
+                        <div class="d-flex justify-content-end gap-2">
+                            <a href="{{ url_for('material_routes.gerenciar_materiais') }}" class="btn btn-secondary">
+                                <i class="fas fa-times"></i> Cancelar
+                            </a>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> Salvar Polo
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/material/gerenciar_materiais.html
+++ b/templates/material/gerenciar_materiais.html
@@ -208,9 +208,10 @@
                                         <button class="btn btn-sm btn-outline-primary" onclick="verMateriaisPolo({{ stat.polo.id }})">
                                             <i class="fas fa-eye"></i> Ver Materiais
                                         </button>
-                                        <button class="btn btn-sm btn-outline-secondary" onclick="editarPolo({{ stat.polo.id }})">
+                                        <a class="btn btn-sm btn-outline-secondary"
+                                           href="{{ url_for('material_routes.editar_polo', polo_id=stat.polo.id) }}">
                                             <i class="fas fa-edit"></i> Editar
-                                        </button>
+                                        </a>
                                     </div>
                                 </div>
                             </div>
@@ -261,108 +262,6 @@
 </div>
 
 
-
-<!-- Modal Material -->
-<div class="modal fade" id="modalMaterial" tabindex="-1">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Editar Material</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <form id="form-material">
-                <div class="modal-body">
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label for="material-polo" class="form-label">Polo *</label>
-                                <select id="material-polo" class="form-select" required>
-                                    <option value="">Selecione um polo</option>
-                                    {% for polo in polos %}
-                                    <option value="{{ polo.id }}">{{ polo.nome }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label for="material-categoria" class="form-label">Categoria</label>
-                                <select id="material-categoria" class="form-select">
-                                    <option value="">Selecione uma categoria</option>
-                                    <option value="Papelaria">Papelaria</option>
-                                    <option value="Limpeza">Limpeza</option>
-                                    <option value="Informática">Informática</option>
-                                    <option value="Móveis">Móveis</option>
-                                    <option value="Equipamentos">Equipamentos</option>
-                                    <option value="Consumíveis">Consumíveis</option>
-                                    <option value="Outros">Outros</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mb-3">
-                        <label for="material-nome" class="form-label">Nome do Material *</label>
-                        <input type="text" class="form-control" id="material-nome" required>
-                    </div>
-                    <div class="mb-3">
-                        <label for="material-descricao" class="form-label">Descrição</label>
-                        <textarea class="form-control" id="material-descricao" rows="3"></textarea>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-4">
-                            <div class="mb-3">
-                                <label for="material-unidade" class="form-label">Unidade *</label>
-                                <select id="material-unidade" class="form-select" required>
-                                    <option value="">Selecione</option>
-                                    <option value="un">Unidade</option>
-                                    <option value="cx">Caixa</option>
-                                    <option value="pct">Pacote</option>
-                                    <option value="kg">Quilograma</option>
-                                    <option value="l">Litro</option>
-                                    <option value="m">Metro</option>
-                                    <option value="m²">Metro²</option>
-                                    <option value="resma">Resma</option>
-                                    <option value="dz">Dúzia</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="mb-3">
-                                <label for="material-quantidade-inicial" class="form-label">Quantidade Atual</label>
-                                <input type="number" class="form-control" id="material-quantidade-inicial" min="0" disabled>
-                                <div class="form-text">Quantidade atual em estoque</div>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="mb-3">
-                                <label for="material-quantidade-minima" class="form-label">Estoque Mínimo</label>
-                                <input type="number" class="form-control" id="material-quantidade-minima" min="0">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label for="material-preco" class="form-label">Preço Unitário (R$)</label>
-                                <input type="number" class="form-control" id="material-preco" min="0" step="0.01">
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label for="material-fornecedor" class="form-label">Fornecedor</label>
-                                <input type="text" class="form-control" id="material-fornecedor">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-success">Salvar</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
 
 <!-- Modal Movimentação -->
 <div class="modal fade" id="modalMovimentacao" tabindex="-1">


### PR DESCRIPTION
## Summary
- add edit routes and templates for polos and materials
- switch edit actions in materials manager to new pages
- drop modal-based editors and redirect via JS

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b506ceac8324bbdfe9601d576d37