### PR TITLE
Add monitor material movement page

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -698,6 +698,113 @@ def monitor_materiais():
         return redirect(url_for('main.index'))
 
 
+@material_routes.route('/monitor/materiais/nova-movimentacao', methods=['GET', 'POST'])
+@login_required
+def nova_movimentacao_monitor():
+    """Exibe formulário e registra movimentações para monitores."""
+    if not verificar_acesso_monitor():
+        flash('Acesso negado', 'error')
+        return redirect(url_for('main.index'))
+
+    if request.method == 'POST':
+        material_id = request.form.get('material_id', type=int)
+        tipo = request.form.get('tipo')
+        quantidade = request.form.get('quantidade', type=int)
+        observacoes = request.form.get('observacoes', '')
+
+        material = Material.query.get(material_id)
+        if not material:
+            flash('Material não encontrado', 'error')
+            return redirect(url_for('material_routes.nova_movimentacao_monitor'))
+
+        acesso = MonitorPolo.query.filter_by(
+            monitor_id=current_user.id,
+            polo_id=material.polo_id,
+            ativo=True
+        ).first()
+        if not acesso:
+            flash('Acesso negado ao polo deste material', 'error')
+            return redirect(url_for('material_routes.nova_movimentacao_monitor'))
+
+        if tipo == 'entrada':
+            nova_quantidade = material.quantidade_atual + quantidade
+        elif tipo == 'saida':
+            nova_quantidade = material.quantidade_atual - quantidade
+            if nova_quantidade < 0:
+                flash('Quantidade insuficiente em estoque', 'error')
+                return redirect(
+                    url_for('material_routes.nova_movimentacao_monitor',
+                            polo_id=material.polo_id, material_id=material.id)
+                )
+        elif tipo == 'ajuste':
+            nova_quantidade = quantidade
+        else:
+            flash('Tipo de movimentação inválido', 'error')
+            return redirect(url_for('material_routes.nova_movimentacao_monitor'))
+
+        movimentacao = MovimentacaoMaterial(
+            material_id=material_id,
+            monitor_id=current_user.id,
+            tipo=tipo,
+            quantidade=quantidade,
+            observacao=observacoes
+        )
+
+        material.quantidade_atual = nova_quantidade
+        material.updated_at = datetime.utcnow()
+
+        try:
+            db.session.add(movimentacao)
+            db.session.commit()
+            flash('Movimentação registrada com sucesso', 'success')
+            return redirect(url_for('material_routes.monitor_materiais'))
+        except Exception as e:
+            db.session.rollback()
+            current_app.logger.error(
+                f"Erro ao registrar movimentação: {str(e)}"
+            )
+            flash('Erro ao registrar movimentação', 'error')
+            return redirect(
+                url_for('material_routes.nova_movimentacao_monitor',
+                        polo_id=material.polo_id, material_id=material.id)
+            )
+
+    polos = (
+        db.session.query(Polo)
+        .join(MonitorPolo)
+        .filter(
+            MonitorPolo.monitor_id == current_user.id,
+            MonitorPolo.ativo.is_(True),
+            Polo.ativo.is_(True)
+        )
+        .all()
+    )
+
+    polo_id = request.args.get('polo_id', type=int)
+    material_id = request.args.get('material_id', type=int)
+    materiais = []
+    if polo_id:
+        materiais = (
+            Material.query
+            .join(MonitorPolo, MonitorPolo.polo_id == Material.polo_id)
+            .filter(
+                Material.polo_id == polo_id,
+                MonitorPolo.monitor_id == current_user.id,
+                MonitorPolo.ativo.is_(True),
+                Material.ativo.is_(True)
+            )
+            .all()
+        )
+
+    return render_template(
+        'material/nova_movimentacao_monitor.html',
+        polos=polos,
+        materiais=materiais,
+        polo_id=polo_id,
+        material_id=material_id
+    )
+
+
 @material_routes.route('/api/materiais/<int:material_id>/movimentacao', methods=['POST'])
 @csrf.exempt
 @login_required

--- a/static/js/monitor_materiais.js
+++ b/static/js/monitor_materiais.js
@@ -14,12 +14,6 @@ function configurarEventListeners() {
     document.getElementById('filtro-status').addEventListener('change', filtrarMateriais);
     document.getElementById('buscar-material').addEventListener('input', filtrarMateriais);
     
-    // Form de movimentação
-    document.getElementById('formMovimentacao').addEventListener('submit', registrarMovimentacao);
-    
-    // Mudança de polo no modal de movimentação
-    document.getElementById('movimentacao-polo').addEventListener('change', carregarMateriaisPolo);
-    
     // Mudança de tipo no modal WhatsApp
     document.getElementById('whatsapp-tipo').addEventListener('change', gerarTextoWhatsApp);
     document.getElementById('whatsapp-polo').addEventListener('change', gerarTextoWhatsApp);
@@ -166,8 +160,9 @@ function atualizarTabelaMateriais(materiaisFiltrados = null) {
     materiais.forEach(material => {
         const polo = polosData.find(p => p.id === material.polo_id);
         const status = getStatusMaterial(material);
-        const ultimaMovimentacao = material.ultima_movimentacao ? 
+        const ultimaMovimentacao = material.ultima_movimentacao ?
             new Date(material.ultima_movimentacao).toLocaleDateString('pt-BR') : 'Nunca';
+        const urlMov = `/monitor/materiais/nova-movimentacao?material_id=${material.id}&polo_id=${material.polo_id}`;
         
         const row = `
             <tr>
@@ -191,9 +186,10 @@ function atualizarTabelaMateriais(materiaisFiltrados = null) {
                         <button class="btn btn-outline-primary" onclick="verHistorico(${material.id})" title="Histórico">
                             <i class="fas fa-history"></i>
                         </button>
-                        <button class="btn btn-outline-success" onclick="novaMovimentacao(${material.id}, ${material.polo_id})" title="Nova Movimentação">
+                        <a class="btn btn-outline-success" href="${urlMov}"
+                            title="Nova Movimentação">
                             <i class="fas fa-plus"></i>
-                        </button>
+                        </a>
                     </div>
                 </td>
             </tr>
@@ -267,72 +263,6 @@ function filtrarMateriais() {
 function filtrarPorPolo(poloId) {
     document.getElementById('filtro-polo').value = poloId;
     filtrarMateriais();
-}
-
-async function carregarMateriaisPolo() {
-    const poloId = document.getElementById('movimentacao-polo').value;
-    const selectMaterial = document.getElementById('movimentacao-material');
-    
-    selectMaterial.innerHTML = '<option value="">Selecione um material</option>';
-    
-    if (poloId) {
-        const materiaisPolo = materiaisData.filter(m => m.polo_id == poloId);
-        materiaisPolo.forEach(material => {
-            selectMaterial.innerHTML += `<option value="${material.id}">${material.nome}</option>`;
-        });
-    }
-}
-
-async function registrarMovimentacao(event) {
-    event.preventDefault();
-    
-    const formData = {
-        material_id: document.getElementById('movimentacao-material').value,
-        tipo: document.getElementById('movimentacao-tipo').value,
-        quantidade: parseInt(document.getElementById('movimentacao-quantidade').value),
-        observacoes: document.getElementById('movimentacao-observacoes').value
-    };
-    
-    try {
-        const response = await fetch('/api/movimentacoes', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': getCSRFToken()
-            },
-            body: JSON.stringify(formData)
-        });
-        
-        const result = await response.json();
-        
-        if (response.ok) {
-            mostrarAlerta('Movimentação registrada com sucesso!', 'success');
-            bootstrap.Modal.getInstance(document.getElementById('modalMovimentacao')).hide();
-            document.getElementById('formMovimentacao').reset();
-            carregarDadosIniciais(); // Recarregar dados
-        } else {
-            throw new Error(result.message || 'Erro ao registrar movimentação');
-        }
-    } catch (error) {
-        console.error('Erro:', error);
-        mostrarAlerta(error.message, 'error');
-    }
-}
-
-function novaMovimentacao(materialId = null, poloId = null) {
-    if (poloId) {
-        document.getElementById('movimentacao-polo').value = poloId;
-        carregarMateriaisPolo();
-    }
-    
-    if (materialId) {
-        setTimeout(() => {
-            document.getElementById('movimentacao-material').value = materialId;
-        }, 100);
-    }
-    
-    const modal = new bootstrap.Modal(document.getElementById('modalMovimentacao'));
-    modal.show();
 }
 
 async function verHistorico(materialId) {

--- a/templates/material/monitor_materiais.html
+++ b/templates/material/monitor_materiais.html
@@ -15,9 +15,10 @@
                     <a href="{{ url_for('monitor_routes.dashboard') }}" class="btn btn-outline-secondary me-2">
                         <i class="fas fa-arrow-left me-2"></i>Voltar ao Dashboard
                     </a>
-                    <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#modalMovimentacao">
+                    <a href="{{ url_for('material_routes.nova_movimentacao_monitor') }}"
+                        class="btn btn-success">
                         <i class="fas fa-plus me-2"></i>Nova Movimentação
-                    </button>
+                    </a>
                 </div>
             </div>
         </div>
@@ -103,59 +104,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
-</div>
-
-<!-- Modal Nova Movimentação -->
-<div class="modal fade" id="modalMovimentacao" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Nova Movimentação</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <form id="formMovimentacao">
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label">Polo</label>
-                        <select class="form-select" id="movimentacao-polo" required>
-                            <option value="">Selecione um polo</option>
-                            {% for polo in polos %}
-                            <option value="{{ polo.id }}">{{ polo.nome }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Material</label>
-                        <select class="form-select" id="movimentacao-material" required>
-                            <option value="">Selecione um material</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Tipo de Movimentação</label>
-                        <select class="form-select" id="movimentacao-tipo" required>
-                            <option value="entrada">Entrada (Recebimento)</option>
-                            <option value="saida">Saída (Consumo)</option>
-                            <option value="ajuste">Ajuste de Estoque</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Quantidade</label>
-                        <input type="number" class="form-control" id="movimentacao-quantidade" min="1" required>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Observações</label>
-                        <textarea class="form-control" id="movimentacao-observacoes" rows="3" placeholder="Observações sobre a movimentação..."></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-save me-2"></i>Registrar Movimentação
-                    </button>
-                </div>
-            </form>
         </div>
     </div>
 </div>

--- a/templates/material/nova_movimentacao_monitor.html
+++ b/templates/material/nova_movimentacao_monitor.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block title %}Nova Movimentação - Monitor - IAFAP{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <h2 class="mb-4">Nova Movimentação</h2>
+            <form method="post">
+                {{ csrf_token() }}
+                <div class="mb-3">
+                    <label class="form-label">Polo</label>
+                    <select name="polo_id" id="polo" class="form-select" required>
+                        <option value="">Selecione um polo</option>
+                        {% for polo in polos %}
+                        <option value="{{ polo.id }}"
+                            {% if polo.id == polo_id %}selected{% endif %}>
+                            {{ polo.nome }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Material</label>
+                    <select name="material_id" id="material" class="form-select" required>
+                        <option value="">Selecione um material</option>
+                        {% for material in materiais %}
+                        <option value="{{ material.id }}"
+                            {% if material.id == material_id %}selected{% endif %}>
+                            {{ material.nome }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Tipo de Movimentação</label>
+                    <select name="tipo" class="form-select" required>
+                        <option value="entrada">Entrada (Recebimento)</option>
+                        <option value="saida">Saída (Consumo)</option>
+                        <option value="ajuste">Ajuste de Estoque</option>
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Quantidade</label>
+                    <input type="number" name="quantidade" class="form-control" min="1" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Observações</label>
+                    <textarea name="observacoes" class="form-control" rows="3"></textarea>
+                </div>
+                <div class="d-flex justify-content-between">
+                    <a href="{{ url_for('material_routes.monitor_materiais') }}"
+                        class="btn btn-secondary">Cancelar</a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save me-2"></i>Registrar
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.getElementById('polo').addEventListener('change', async function () {
+        const poloId = this.value;
+        const materialSelect = document.getElementById('material');
+        materialSelect.innerHTML = '<option value="">Selecione um material</option>';
+        if (!poloId) {
+            return;
+        }
+        const resp = await fetch(`/api/materiais?polo_id=${poloId}`);
+        const data = await resp.json();
+        if (data.success) {
+            data.materiais.forEach(m => {
+                const opt = document.createElement('option');
+                opt.value = m.id;
+                opt.textContent = m.nome;
+                materialSelect.appendChild(opt);
+            });
+        }
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add server-rendered page for monitors to record material movements
- remove modal-based movement form from monitor materials view
- simplify monitor materials JS and link to new movement route

## Testing
- `pytest` *(fails: IndentationError, ModuleNotFoundError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b5098fd0832491786f0098b282f8