### PR TITLE
Separate auto and manual distribution logs

### DIFF
--- a/migrations/versions/add_auto_distribution_log_table.py
+++ b/migrations/versions/add_auto_distribution_log_table.py
@@ -1,0 +1,53 @@
+"""Add auto distribution log table
+
+Revision ID: add_auto_distribution_log_table
+Revises: fix_assignment_foreign_keys
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "add_auto_distribution_log_table"
+down_revision = "fix_assignment_foreign_keys"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "auto_distribution_log",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("evento_id", sa.Integer, nullable=False),
+        sa.Column("total_submissions", sa.Integer, nullable=False),
+        sa.Column("total_assignments", sa.Integer, nullable=False),
+        sa.Column("distribution_seed", sa.String(length=50), nullable=True),
+        sa.Column("conflicts_detected", sa.Integer, nullable=True),
+        sa.Column("fallback_assignments", sa.Integer, nullable=True),
+        sa.Column("failed_assignments", sa.Integer, nullable=True),
+        sa.Column("distribution_details", sa.JSON, nullable=True),
+        sa.Column("error_log", sa.JSON, nullable=True),
+        sa.Column("started_at", sa.DateTime, nullable=True),
+        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column("duration_seconds", sa.Integer, nullable=True),
+        sa.ForeignKeyConstraint([
+            "evento_id"
+        ], ["evento.id"], name="fk_auto_distribution_log_evento", ondelete="CASCADE"),
+    )
+    op.create_index(
+        "idx_auto_distribution_log_evento",
+        "auto_distribution_log",
+        ["evento_id"],
+    )
+    op.create_index(
+        "idx_auto_distribution_log_started_at",
+        "auto_distribution_log",
+        ["started_at"],
+    )
+
+
+def downgrade():
+    op.drop_index("idx_auto_distribution_log_started_at", table_name="auto_distribution_log")
+    op.drop_index("idx_auto_distribution_log_evento", table_name="auto_distribution_log")
+    op.drop_table("auto_distribution_log")

--- a/models/review.py
+++ b/models/review.py
@@ -381,8 +381,12 @@ class DistributionLog(db.Model):
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     # relationships
-    evento = db.relationship("Evento", backref=db.backref("distribution_logs", lazy=True))
-    distributor = db.relationship("Usuario", backref=db.backref("distribution_logs", lazy=True))
+    evento = db.relationship(
+        "Evento", backref=db.backref("manual_distribution_logs", lazy=True)
+    )
+    distributor = db.relationship(
+        "Usuario", backref=db.backref("manual_distribution_logs", lazy=True)
+    )
 
     def __repr__(self):
         return f"<DistributionLog {self.id} evento={self.evento_id} type={self.distribution_type}>"

--- a/models/submission_system.py
+++ b/models/submission_system.py
@@ -131,12 +131,12 @@ class DistributionConfig(db.Model):
         return f"<DistributionConfig evento={self.evento_id} mode={self.distribution_mode}>"
 
 
-class DistributionLog(db.Model):
+class AutoDistributionLog(db.Model):
     """Log de auditoria das distribuições automáticas."""
-    
-    __tablename__ = "distribution_log"
+
+    __tablename__ = "auto_distribution_log"
     __table_args__ = {"extend_existing": True}
-    
+
     id = db.Column(db.Integer, primary_key=True)
     evento_id = db.Column(db.Integer, db.ForeignKey("evento.id"), nullable=False)
     
@@ -160,10 +160,15 @@ class DistributionLog(db.Model):
     duration_seconds = db.Column(db.Integer, nullable=True)
     
     # Relacionamentos
-    evento = db.relationship("Evento", backref=db.backref("distribution_logs", lazy=True))
-    
+    evento = db.relationship(
+        "Evento", backref=db.backref("auto_distribution_logs", lazy=True)
+    )
+
     def __repr__(self):
-        return f"<DistributionLog evento={self.evento_id} submissions={self.total_submissions}>"
+        return (
+            f"<AutoDistributionLog evento={self.evento_id} "
+            f"submissions={self.total_submissions}>"
+        )
     
     def mark_completed(self):
         """Marca a distribuição como concluída e calcula a duração."""

--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -22,7 +22,6 @@ from extensions import db, csrf
 from models import (
     AuditLog,
     Assignment,
-    DistributionLog,
     Evento,
     Formulario,
     RespostaCampo,

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -8,8 +8,11 @@ import json
 
 from extensions import db
 from models.submission_system import (
-    DistributionLog, ReviewerProfile, DistributionConfig,
-    ImportedSubmission, SpreadsheetMapping
+    AutoDistributionLog,
+    ReviewerProfile,
+    DistributionConfig,
+    ImportedSubmission,
+    SpreadsheetMapping,
 )
 from models.review import Assignment, Submission, Review
 from models.user import Usuario
@@ -29,14 +32,14 @@ class AuditService:
         """Gera relatório completo de distribuições."""
         try:
             # Filtros de data
-            query = DistributionLog.query.filter_by(evento_id=self.evento_id)
+            query = AutoDistributionLog.query.filter_by(evento_id=self.evento_id)
             
             if start_date:
-                query = query.filter(DistributionLog.started_at >= start_date)
+                query = query.filter(AutoDistributionLog.started_at >= start_date)
             if end_date:
-                query = query.filter(DistributionLog.started_at <= end_date)
+                query = query.filter(AutoDistributionLog.started_at <= end_date)
             
-            distributions = query.order_by(desc(DistributionLog.started_at)).all()
+            distributions = query.order_by(desc(AutoDistributionLog.started_at)).all()
             
             # Estatísticas gerais
             total_distributions = len(distributions)
@@ -241,9 +244,9 @@ class AuditService:
         """Gera relatório de análise de conflitos."""
         try:
             # Buscar logs de distribuição com conflitos
-            distributions = DistributionLog.query.filter(
-                DistributionLog.evento_id == self.evento_id,
-                DistributionLog.conflicts_detected > 0
+            distributions = AutoDistributionLog.query.filter(
+                AutoDistributionLog.evento_id == self.evento_id,
+                AutoDistributionLog.conflicts_detected > 0
             ).all()
             
             conflict_analysis = []
@@ -307,7 +310,9 @@ class AuditService:
             logger.error(f"Erro ao exportar CSV: {str(e)}")
             raise
     
-    def _analyze_distribution_periods(self, distributions: List[DistributionLog]) -> Dict:
+    def _analyze_distribution_periods(
+        self, distributions: List[AutoDistributionLog]
+    ) -> Dict:
         """Analisa distribuições por período."""
         if not distributions:
             return {}
@@ -335,7 +340,9 @@ class AuditService:
             "peak_month": max(monthly_stats.values(), key=lambda x: x["submissions"])["month"] if monthly_stats else None
         }
     
-    def _calculate_efficiency_metrics(self, distributions: List[DistributionLog]) -> Dict:
+    def _calculate_efficiency_metrics(
+        self, distributions: List[AutoDistributionLog]
+    ) -> Dict:
         """Calcula métricas de eficiência."""
         if not distributions:
             return {}
@@ -402,7 +409,9 @@ class AuditService:
             logger.error(f"Erro ao analisar carga de trabalho: {str(e)}")
             return {}
     
-    def _calculate_distribution_success_rate(self, distribution: DistributionLog) -> float:
+    def _calculate_distribution_success_rate(
+        self, distribution: AutoDistributionLog
+    ) -> float:
         """Calcula taxa de sucesso de uma distribuição."""
         if distribution.total_submissions == 0:
             return 0.0
@@ -410,7 +419,9 @@ class AuditService:
         successful_assignments = distribution.total_assignments - distribution.fallback_assignments
         return round((successful_assignments / distribution.total_submissions) * 100, 2)
     
-    def _calculate_duration_minutes(self, distribution: DistributionLog) -> Optional[float]:
+    def _calculate_duration_minutes(
+        self, distribution: AutoDistributionLog
+    ) -> Optional[float]:
         """Calcula duração da distribuição em minutos."""
         if not distribution.completed_at:
             return None
@@ -447,7 +458,9 @@ class AuditService:
             logger.error(f"Erro ao calcular tempo médio de revisão: {str(e)}")
             return None
     
-    def _extract_conflict_details(self, distribution: DistributionLog) -> List[Dict]:
+    def _extract_conflict_details(
+        self, distribution: AutoDistributionLog
+    ) -> List[Dict]:
         """Extrai detalhes dos conflitos de uma distribuição."""
         # Por enquanto, retorna informações básicas
         # TODO: Implementar log detalhado de conflitos

--- a/services/distribution_service.py
+++ b/services/distribution_service.py
@@ -6,8 +6,11 @@ from collections import defaultdict
 
 from extensions import db
 from models.submission_system import (
-    ReviewerProfile, ReviewerPreference, DistributionConfig, 
-    DistributionLog, SubmissionCategory
+    ReviewerProfile,
+    ReviewerPreference,
+    DistributionConfig,
+    AutoDistributionLog,
+    SubmissionCategory,
 )
 from models.review import Submission, Assignment
 from models.user import Usuario
@@ -42,7 +45,7 @@ class DistributionService:
         """Distribui submissões para revisores automaticamente."""
         try:
             # Inicializar log
-            self.log_entry = DistributionLog(
+            self.log_entry = AutoDistributionLog(
                 evento_id=self.evento_id,
                 distribution_seed=seed or str(random.randint(1000, 9999))
             )

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -5,7 +5,9 @@ from jinja2 import Template
 
 from extensions import db
 from models.submission_system import (
-    ReviewerProfile, DistributionLog, DistributionConfig
+    ReviewerProfile,
+    AutoDistributionLog,
+    DistributionConfig,
 )
 from models.review import Assignment, Submission
 from models.user import Usuario
@@ -22,7 +24,9 @@ class NotificationService:
         self.evento_id = evento_id
         self.evento = Evento.query.get(evento_id)
     
-    def notify_distribution_completed(self, distribution_log: DistributionLog) -> Dict:
+    def notify_distribution_completed(
+        self, distribution_log: AutoDistributionLog
+    ) -> Dict:
         """Notifica sobre conclusão da distribuição automática."""
         try:
             # Obter administradores do evento
@@ -252,7 +256,9 @@ class NotificationService:
             html=html_content
         )
     
-    def _calculate_success_rate(self, distribution_log: DistributionLog) -> float:
+    def _calculate_success_rate(
+        self, distribution_log: AutoDistributionLog
+    ) -> float:
         """Calcula taxa de sucesso da distribuição."""
         if distribution_log.total_submissions == 0:
             return 0.0


### PR DESCRIPTION
## Summary
- Rename automatic distribution log model to `AutoDistributionLog` with unique table and backref
- Give manual distribution logs their own backrefs on `Evento` and `Usuario`
- Update services to use new model and add migration for `auto_distribution_log`

## Testing
- `pytest` *(fails: unexpected indent / missing modules etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bb350a488324939112f987e799cf