### PR TITLE
Link monitors to client

### DIFF
--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -677,7 +677,8 @@ def cadastrar_monitor():
             dias_disponibilidade=','.join(dias_disponibilidade),
             turnos_disponibilidade=','.join(turnos_disponibilidade),
             codigo_acesso=gerar_codigo_acesso(),
-            ativo=True
+            ativo=True,
+            cliente_id=current_user.id
         )
         
         db.session.add(monitor)
@@ -1057,7 +1058,8 @@ def processar_importacao():
                     dias_disponibilidade=str(dados['dias_disponibilidade']).strip(),
                     turnos_disponibilidade=str(dados['turnos_disponibilidade']).strip(),
                     codigo_acesso=gerar_codigo_acesso(),
-                    ativo=True
+                    ativo=True,
+                    cliente_id=current_user.id
                 )
                 
                 db.session.add(novo_monitor)
@@ -1198,7 +1200,8 @@ def processar_cadastro_multiplo():
                     dias_disponibilidade=dias_disponibilidade,
                     turnos_disponibilidade=turnos_disponibilidade,
                     codigo_acesso=gerar_codigo_acesso(),
-                    ativo=True
+                    ativo=True,
+                    cliente_id=current_user.id
                 )
                 
                 db.session.add(novo_monitor)

--- a/scripts/fix_monitor_cliente_id.py
+++ b/scripts/fix_monitor_cliente_id.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Atualiza monitores com ``cliente_id`` nulo usando agendamentos existentes."""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from app import create_app
+from extensions import db
+from models.user import Monitor
+from models.event import MonitorAgendamento, AgendamentoVisita
+
+
+def fix_monitor_cliente_id():
+    """Define o cliente para monitores que estão sem ``cliente_id``."""
+    app = create_app()
+    with app.app_context():
+        print("=== Atualizando monitores sem cliente_id ===")
+        monitores = Monitor.query.filter_by(cliente_id=None).all()
+        print(f"Monitores encontrados: {len(monitores)}")
+
+        atualizados = 0
+        for monitor in monitores:
+            ma = (
+                MonitorAgendamento.query.join(
+                    AgendamentoVisita,
+                    MonitorAgendamento.agendamento_id == AgendamentoVisita.id,
+                )
+                .filter(
+                    MonitorAgendamento.monitor_id == monitor.id,
+                    AgendamentoVisita.cliente_id.isnot(None),
+                )
+                .first()
+            )
+            if ma:
+                monitor.cliente_id = ma.agendamento.cliente_id
+                atualizados += 1
+                print(
+                    f"Monitor {monitor.id} atualizado para cliente "
+                    f"{monitor.cliente_id}"
+                )
+
+        if atualizados:
+            db.session.commit()
+            print(f"{atualizados} monitores atualizados.")
+        else:
+            print("Nenhum monitor atualizado.")
+
+
+if __name__ == "__main__":
+    fix_monitor_cliente_id()


### PR DESCRIPTION
## Summary
- associate monitors to the logged-in client when registering individually, via file import or multi-entry form
- add script to assign cliente_id for existing monitors using related agendamentos

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c4e528c8324a67734b047db5518