### PR TITLE
Ensure Material active flag and include legacy records

### DIFF
--- a/migrations/versions/e5c80c0b2a3c_set_material_ativo_not_null.py
+++ b/migrations/versions/e5c80c0b2a3c_set_material_ativo_not_null.py
@@ -1,0 +1,33 @@
+"""set material ativo not null
+
+Revision ID: e5c80c0b2a3c
+Revises: c0f0b9fa83c0
+Create Date: 2025-02-15 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e5c80c0b2a3c'
+down_revision = 'c0f0b9fa83c0'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.execute("UPDATE material SET ativo = true WHERE ativo IS NULL")
+    with op.batch_alter_table('material', schema=None) as batch_op:
+        batch_op.alter_column(
+            'ativo',
+            existing_type=sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        )
+
+def downgrade():
+    with op.batch_alter_table('material', schema=None) as batch_op:
+        batch_op.alter_column(
+            'ativo',
+            existing_type=sa.Boolean(),
+            nullable=True,
+            server_default=None,
+        )

--- a/models/material.py
+++ b/models/material.py
@@ -63,7 +63,7 @@ class Material(db.Model):
     quantidade_minima = db.Column(db.Integer, nullable=False, default=0)  # estoque mínimo
     
     # Controle
-    ativo = db.Column(db.Boolean, default=True)
+    ativo = db.Column(db.Boolean, default=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     

--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -46,18 +46,28 @@ def gerenciar_materiais():
         polos = Polo.query.filter_by(cliente_id=current_user.id, ativo=True).all()
         
         # Estatísticas gerais
-        total_materiais = Material.query.filter_by(cliente_id=current_user.id, ativo=True).count()
-        materiais_baixo_estoque = Material.query.filter_by(cliente_id=current_user.id, ativo=True).filter(
-            Material.quantidade_atual <= Material.quantidade_minima
+        total_materiais = Material.query.filter(
+            Material.cliente_id == current_user.id,
+            Material.ativo.isnot(False),
         ).count()
-        materiais_esgotados = Material.query.filter_by(cliente_id=current_user.id, ativo=True).filter(
-            Material.quantidade_atual <= 0
+        materiais_baixo_estoque = Material.query.filter(
+            Material.cliente_id == current_user.id,
+            Material.ativo.isnot(False),
+            Material.quantidade_atual <= Material.quantidade_minima,
+        ).count()
+        materiais_esgotados = Material.query.filter(
+            Material.cliente_id == current_user.id,
+            Material.ativo.isnot(False),
+            Material.quantidade_atual <= 0,
         ).count()
         
         # Estatísticas por polo
         estatisticas_polos = []
         for polo in polos:
-            materiais_polo = Material.query.filter_by(polo_id=polo.id, ativo=True).all()
+            materiais_polo = Material.query.filter(
+                Material.polo_id == polo.id,
+                Material.ativo.isnot(False),
+            ).all()
             total_polo = len(materiais_polo)
             baixo_estoque_polo = sum(1 for m in materiais_polo if m.quantidade_atual <= m.quantidade_minima)
             esgotados_polo = sum(1 for m in materiais_polo if m.quantidade_atual <= 0)
@@ -130,7 +140,10 @@ def estatisticas_polos():
         estatisticas = []
         
         for polo in polos:
-            materiais = Material.query.filter_by(polo_id=polo.id, ativo=True).all()
+            materiais = Material.query.filter(
+                Material.polo_id == polo.id,
+                Material.ativo.isnot(False),
+            ).all()
             
             total_materiais = len(materiais)
             em_estoque = len([m for m in materiais if m.quantidade_atual > m.quantidade_minima])
@@ -205,7 +218,10 @@ def gerar_relatorio_excel():
             cliente_id = polos_monitor[0].cliente_id
         
         # Construir query
-        query = Material.query.filter_by(cliente_id=cliente_id, ativo=True)
+        query = Material.query.filter(
+            Material.cliente_id == cliente_id,
+            Material.ativo.isnot(False),
+        )
         
         if polo_id:
             query = query.filter_by(polo_id=polo_id)
@@ -462,7 +478,10 @@ def deletar_polo(polo_id):
             return jsonify({'success': False, 'message': 'Polo não encontrado'}), 404
         
         # Verificar se há materiais ativos no polo
-        materiais_ativos = Material.query.filter_by(polo_id=polo_id, ativo=True).count()
+        materiais_ativos = Material.query.filter(
+            Material.polo_id == polo_id,
+            Material.ativo.isnot(False),
+        ).count()
         if materiais_ativos > 0:
             return jsonify({
                 'success': False, 
@@ -520,7 +539,7 @@ def listar_materiais():
                 MonitorPolo.monitor_id == current_user.id,
                 MonitorPolo.ativo.is_(True),
                 Material.cliente_id == cliente_id,
-                Material.ativo.is_(True)
+                Material.ativo.isnot(False)
             )
 
         if polo_id:
@@ -780,7 +799,7 @@ def nova_movimentacao_monitor():
                 Material.polo_id == polo_id,
                 MonitorPolo.monitor_id == current_user.id,
                 MonitorPolo.ativo.is_(True),
-                Material.ativo.is_(True)
+                Material.ativo.isnot(False)
             )
             .all()
         )
@@ -918,7 +937,10 @@ def gerar_relatorio():
         polo_id = request.args.get('polo_id')
         tipo_relatorio = request.args.get('tipo', 'geral')  # geral, baixo_estoque, compras
         
-        query = Material.query.filter_by(cliente_id=current_user.id, ativo=True)
+        query = Material.query.filter(
+            Material.cliente_id == current_user.id,
+            Material.ativo.isnot(False),
+        )
         
         if polo_id:
             query = query.filter_by(polo_id=polo_id)

--- a/tests/test_material_ativo_filter.py
+++ b/tests/test_material_ativo_filter.py
@@ -1,0 +1,94 @@
+import os
+
+import pytest
+
+from config import Config
+from app import create_app
+from extensions import db
+from models.user import Cliente
+from models.material import Polo, Material
+
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('DB_PASS', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options(
+        app.config['SQLALCHEMY_DATABASE_URI']
+    )
+    with app.app_context():
+        # Allow null "ativo" to simulate legacy data
+        Material.__table__.columns['ativo'].nullable = True
+        db.create_all()
+
+        cliente = Cliente(nome='Cliente', email='c@test', senha='x')
+        db.session.add(cliente)
+        db.session.commit()
+
+        polo = Polo(nome='Polo', cliente_id=cliente.id, ativo=True)
+        db.session.add(polo)
+        db.session.commit()
+
+    yield app
+
+
+@pytest.fixture
+def session(app):
+    with app.app_context():
+        yield db.session
+
+
+def test_filter_considers_null_as_active(session):
+    cliente = Cliente.query.first()
+    polo = Polo.query.first()
+
+    ativo = Material(
+        nome='Ativo',
+        polo_id=polo.id,
+        cliente_id=cliente.id,
+        quantidade_inicial=0,
+        quantidade_atual=0,
+        quantidade_consumida=0,
+        quantidade_minima=0,
+        ativo=True,
+    )
+    inativo = Material(
+        nome='Inativo',
+        polo_id=polo.id,
+        cliente_id=cliente.id,
+        quantidade_inicial=0,
+        quantidade_atual=0,
+        quantidade_consumida=0,
+        quantidade_minima=0,
+        ativo=False,
+    )
+    nulo = Material(
+        nome='Nulo',
+        polo_id=polo.id,
+        cliente_id=cliente.id,
+        quantidade_inicial=0,
+        quantidade_atual=0,
+        quantidade_consumida=0,
+        quantidade_minima=0,
+        ativo=None,
+    )
+    session.add_all([ativo, inativo, nulo])
+    session.commit()
+
+    materiais = Material.query.filter(Material.ativo.isnot(False)).all()
+    nomes = [m.nome for m in materiais]
+    assert 'Ativo' in nomes
+    assert 'Nulo' in nomes
+    assert 'Inativo' not in nomes


### PR DESCRIPTION
## Summary
- Make `Material.ativo` non-null with default True
- Update material queries to handle null `ativo` as active
- Cover filtering behavior for inactive and legacy materials

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: IndentationError and missing model imports during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d4643b483249c175de607ed0d93