### PR TITLE
Add monitor-polo assignment interface

### DIFF
--- a/static/js/monitores_polos.js
+++ b/static/js/monitores_polos.js
@@ -1,0 +1,90 @@
+// Gerenciamento de atribuição de monitores aos polos
+
+async function carregarAtribuicoes() {
+    try {
+        const resp = await fetch('/api/monitores/polos');
+        const data = await resp.json();
+        if (!data.success) {
+            console.error('Erro ao carregar atribuições');
+            return;
+        }
+        const mapa = {};
+        (data.atribuicoes || []).forEach(atr => {
+            if (!mapa[atr.monitor_id]) {
+                mapa[atr.monitor_id] = [];
+            }
+            mapa[atr.monitor_id].push(atr);
+        });
+        document.querySelectorAll('#tabela-monitores tbody tr').forEach(tr => {
+            const monitorId = tr.dataset.monitorId;
+            const lista = tr.querySelector('.polos-atribuidos');
+            lista.innerHTML = '';
+            (mapa[monitorId] || []).forEach(atr => {
+                const li = document.createElement('li');
+                li.dataset.poloId = atr.polo_id;
+                li.textContent = atr.polo_nome;
+                const btn = document.createElement('button');
+                btn.className = 'btn btn-sm btn-danger ms-2 remover-polo';
+                btn.dataset.poloId = atr.polo_id;
+                btn.innerHTML = '<i class="fas fa-times"></i>';
+                li.appendChild(btn);
+                lista.appendChild(li);
+            });
+        });
+    } catch (err) {
+        console.error('Falha ao carregar atribuições', err);
+    }
+}
+
+async function atribuirPolo(monitorId, poloId) {
+    const resp = await fetch('/api/monitores/atribuir-polo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ monitor_id: monitorId, polo_id: poloId })
+    });
+    const data = await resp.json();
+    if (data.success) {
+        await carregarAtribuicoes();
+    } else {
+        alert(data.message || 'Erro ao atribuir polo');
+    }
+}
+
+async function removerPolo(monitorId, poloId) {
+    const resp = await fetch('/api/monitores/remover-polo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ monitor_id: monitorId, polo_id: poloId })
+    });
+    const data = await resp.json();
+    if (data.success) {
+        await carregarAtribuicoes();
+    } else {
+        alert(data.message || 'Erro ao remover polo');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    carregarAtribuicoes();
+
+    document.querySelectorAll('.atribuir-polo').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            const monitorId = row.dataset.monitorId;
+            const select = row.querySelector('.select-polo');
+            const poloId = select.value;
+            if (!poloId) return;
+            atribuirPolo(monitorId, poloId);
+        });
+    });
+
+    document.querySelectorAll('.polos-atribuidos').forEach(lista => {
+        lista.addEventListener('click', e => {
+            const btn = e.target.closest('.remover-polo');
+            if (!btn) return;
+            const monitorId = btn.closest('tr').dataset.monitorId;
+            const poloId = btn.dataset.poloId;
+            removerPolo(monitorId, poloId);
+        });
+    });
+});

--- a/templates/material/gerenciar_materiais.html
+++ b/templates/material/gerenciar_materiais.html
@@ -16,6 +16,9 @@
                     <a href="{{ url_for('material_routes.novo_polo') }}" class="btn btn-primary me-2">
                         <i class="fas fa-plus"></i> Novo Polo
                     </a>
+                    <a href="{{ url_for('material_routes.gerenciar_monitores_polo') }}" class="btn btn-info me-2">
+                        <i class="fas fa-user-tag"></i> Atribuir Monitor
+                    </a>
                     <a href="{{ url_for('material_routes.novo_material') }}" class="btn btn-success">
                         <i class="fas fa-plus"></i> Novo Material
                     </a>

--- a/templates/material/monitores_polos.html
+++ b/templates/material/monitores_polos.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block title %}Atribuir Monitores{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col-12 d-flex justify-content-between align-items-center">
+            <h2 class="mb-0">👥 Atribuir Monitores aos Polos</h2>
+            <a href="{{ url_for('material_routes.gerenciar_materiais') }}" class="btn btn-outline-secondary">Voltar</a>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-12">
+            <table class="table table-striped" id="tabela-monitores">
+                <thead>
+                    <tr>
+                        <th>Monitor</th>
+                        <th>Polos Atribuídos</th>
+                        <th>Atribuir Polo</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for monitor in monitores %}
+                    <tr data-monitor-id="{{ monitor.id }}">
+                        <td>{{ monitor.nome_completo }}</td>
+                        <td>
+                            <ul class="list-unstyled mb-0 polos-atribuidos">
+                                {% for mp in monitor.polos_atribuidos if mp.ativo %}
+                                <li data-polo-id="{{ mp.polo.id }}">
+                                    {{ mp.polo.nome }}
+                                    <button class="btn btn-sm btn-danger ms-2 remover-polo" data-polo-id="{{ mp.polo.id }}">
+                                        <i class="fas fa-times"></i>
+                                    </button>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                        <td>
+                            <div class="input-group">
+                                <select class="form-select select-polo">
+                                    <option value="">Selecione um polo</option>
+                                    {% for polo in polos %}
+                                    <option value="{{ polo.id }}">{{ polo.nome }}</option>
+                                    {% endfor %}
+                                </select>
+                                <button class="btn btn-primary atribuir-polo">
+                                    <i class="fas fa-plus"></i>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<script src="{{ url_for('static', filename='js/monitores_polos.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add navigation button to monitor-polo assignment
- create route and template to manage monitor-polo assignments
- implement frontend script to assign and remove monitors from polos

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError: unexpected indent)*

------
https://chatgpt.com/codex/tasks/task_e_68b879c50e6c8324958ae39e7e6c23d6