### PR TITLE
Hide CSRF token field in monitor material form

### DIFF
--- a/templates/material/nova_movimentacao_monitor.html
+++ b/templates/material/nova_movimentacao_monitor.html
@@ -8,7 +8,7 @@
         <div class="col-md-6">
             <h2 class="mb-4">Nova Movimentação</h2>
             <form method="post">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="mb-3">
                     <label class="form-label">Polo</label>
                     <select name="polo_id" id="polo" class="form-select" required>


### PR DESCRIPTION
## Summary
- add hidden CSRF token input for monitor material movement form

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b87ce7fd9c8324bdff17b1b55e0733