### PR TITLE
Refactor main index redirects

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -40,7 +40,7 @@ def gerenciar_materiais():
     """Página principal de gerenciamento de materiais para clientes."""
     if not verificar_acesso_cliente():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     try:
         # Buscar polos do cliente
@@ -701,7 +701,7 @@ def monitor_materiais():
     """Dashboard de materiais para monitores."""
     if not verificar_acesso_monitor():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     try:
         # Buscar todos os polos do cliente do monitor
@@ -716,7 +716,7 @@ def monitor_materiais():
     except Exception as e:
         current_app.logger.error(f"Erro ao carregar dashboard do monitor: {str(e)}")
         flash('Erro ao carregar dados', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
 
 
 @material_routes.route('/monitor/materiais/nova-movimentacao', methods=['GET', 'POST'])
@@ -725,7 +725,7 @@ def nova_movimentacao_monitor():
     """Exibe formulário e registra movimentações para monitores."""
     if not verificar_acesso_monitor():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
 
     if request.method == 'POST':
         material_id = request.form.get('material_id', type=int)
@@ -1004,7 +1004,7 @@ def gerenciar_monitores_polo():
     """Página para atribuir monitores a polos."""
     if not verificar_acesso_cliente():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
 
     try:
         monitores = (
@@ -1144,7 +1144,7 @@ def novo_polo():
     """Página para cadastro de novo polo."""
     if not verificar_acesso_cliente():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     return render_template('material/novo_polo.html')
 
@@ -1155,7 +1155,7 @@ def novo_material():
     """Página para cadastro de novo material."""
     if not verificar_acesso_cliente():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     return render_template('material/novo_material.html')
 
@@ -1166,7 +1166,7 @@ def editar_polo(polo_id):
     """Página para editar um polo existente."""
     if not verificar_acesso_cliente():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
 
     polo = Polo.query.filter_by(
         id=polo_id, cliente_id=current_user.id, ativo=True
@@ -1196,7 +1196,7 @@ def editar_material(material_id):
     """Página para editar um material existente."""
     if not verificar_acesso_cliente():
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
 
     material = Material.query.filter_by(
         id=material_id, cliente_id=current_user.id, ativo=True

--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -842,7 +842,7 @@ def distribuicao_manual():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     try:
         # Buscar agendamentos sem monitor atribuído
@@ -983,7 +983,7 @@ def importacao_massa():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     return render_template('importacao_massa.html')
 
@@ -1096,7 +1096,7 @@ def download_template():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     try:
         import pandas as pd
@@ -1139,7 +1139,7 @@ def cadastro_multiplo():
     # Verificar se o usuário é admin ou cliente
     if not hasattr(current_user, 'tipo') or current_user.tipo not in ['admin', 'cliente']:
         flash('Acesso negado', 'error')
-        return redirect(url_for('main.index'))
+        return redirect(url_for('evento_routes.home'))
     
     return render_template('cadastro_multiplo.html')
 

--- a/templates/validacao/buscar_certificados.html
+++ b/templates/validacao/buscar_certificados.html
@@ -74,7 +74,7 @@
             </div>
             
             <div class="text-center mt-3">
-                <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">
+                <a href="{{ url_for('evento_routes.home') }}" class="btn btn-outline-secondary">
                     <i class="fas fa-home"></i> Página Inicial
                 </a>
             </div>

--- a/templates/validacao/certificado_invalido.html
+++ b/templates/validacao/certificado_invalido.html
@@ -43,7 +43,7 @@
                     <a href="{{ url_for('validacao.buscar_certificados') }}" class="btn btn-primary">
                         <i class="fas fa-search"></i> Buscar Certificados
                     </a>
-                    <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary ml-2">
+                    <a href="{{ url_for('evento_routes.home') }}" class="btn btn-outline-secondary ml-2">
                         <i class="fas fa-home"></i> Página Inicial
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- Replace `url_for('main.index')` with `url_for('evento_routes.home')` in material and monitor routes
- Update certificate validation templates to link to `evento_routes.home`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; IndentationError and ImportError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b887670fb883248920d67a6732cca8