### PR TITLE
Add material shopping list with export options

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -93,6 +93,17 @@ def gerenciar_materiais():
         return redirect(url_for(endpoints.DASHBOARD_CLIENTE))
 
 
+@material_routes.route('/materiais/lista-compras')
+@login_required
+def listar_compras():
+    """Página para geração da lista de compras de materiais."""
+    if not verificar_acesso_cliente():
+        flash('Acesso negado', 'error')
+        return redirect(url_for('evento_routes.home'))
+
+    return render_template('material/lista_compras.html')
+
+
 @material_routes.route('/api/polos', methods=['GET'])
 @csrf.exempt
 @login_required

--- a/static/js/lista_compras.js
+++ b/static/js/lista_compras.js
@@ -1,0 +1,105 @@
+let materiais = [];
+let polos = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+    carregarDados();
+    document.getElementById('incluir-baixa').addEventListener('change', renderTabela);
+    document.getElementById('incluir-esgotados').addEventListener('change', renderTabela);
+    document.getElementById('btn-whatsapp').addEventListener('click', exportarWhatsApp);
+    document.getElementById('btn-pdf').addEventListener('click', exportarPDF);
+    document.getElementById('btn-xlsx').addEventListener('click', exportarXLSX);
+});
+
+async function carregarDados() {
+    try {
+        const [resPolos, resMateriais] = await Promise.all([
+            fetch('/api/polos'),
+            fetch('/api/materiais')
+        ]);
+
+        const polosJson = await resPolos.json();
+        polos = polosJson.polos || [];
+
+        const matJson = await resMateriais.json();
+        materiais = (matJson.materiais || []).map(m => ({
+            ...m,
+            polo: polos.find(p => p.id === m.polo_id)
+        }));
+        renderTabela();
+    } catch (err) {
+        console.error('Erro ao carregar dados:', err);
+    }
+}
+
+function filtrarMateriais() {
+    const incluirBaixa = document.getElementById('incluir-baixa').checked;
+    const incluirEsgotados = document.getElementById('incluir-esgotados').checked;
+
+    return materiais.filter(m => {
+        if (m.quantidade_atual < m.quantidade_minima) {
+            if (m.quantidade_atual === 0 && !incluirEsgotados) {
+                return false;
+            }
+            if (m.quantidade_atual > 0 && !incluirBaixa) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    });
+}
+
+function renderTabela() {
+    const tbody = document.querySelector('#tabela-lista-compras tbody');
+    if (!tbody) return;
+    const dados = filtrarMateriais();
+    tbody.innerHTML = '';
+    dados.forEach(mat => {
+        const comprar = Math.ceil(mat.quantidade_minima - mat.quantidade_atual + mat.quantidade_minima * 0.5);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${mat.nome}</td><td>${mat.polo ? mat.polo.nome : ''}</td><td>${mat.quantidade_atual}</td><td>${mat.quantidade_minima}</td><td>${comprar}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+function gerarTexto() {
+    return filtrarMateriais().map(m => {
+        const comprar = Math.ceil(m.quantidade_minima - m.quantidade_atual + m.quantidade_minima * 0.5);
+        return `${m.nome} - Comprar ${comprar} ${m.unidade}`;
+    }).join('\n');
+}
+
+function exportarWhatsApp() {
+    const texto = gerarTexto();
+    navigator.clipboard.writeText(texto);
+}
+
+function exportarPDF() {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    let y = 10;
+    filtrarMateriais().forEach((m, idx) => {
+        const comprar = Math.ceil(m.quantidade_minima - m.quantidade_atual + m.quantidade_minima * 0.5);
+        doc.text(`${idx + 1}. ${m.nome} - ${comprar} ${m.unidade}`, 10, y);
+        y += 10;
+    });
+    doc.save('lista_compras.pdf');
+}
+
+function exportarXLSX() {
+    const dados = filtrarMateriais().map(m => {
+        const comprar = Math.ceil(m.quantidade_minima - m.quantidade_atual + m.quantidade_minima * 0.5);
+        return {
+            Material: m.nome,
+            Polo: m.polo ? m.polo.nome : '',
+            QuantidadeAtual: m.quantidade_atual,
+            QuantidadeMinima: m.quantidade_minima,
+            Comprar: comprar,
+            Unidade: m.unidade
+        };
+    });
+    const ws = XLSX.utils.json_to_sheet(dados);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Lista');
+    XLSX.writeFile(wb, 'lista_compras.xlsx');
+}

--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -475,7 +475,7 @@ function gerarRelatorioGeral() {
 
 // Gerar lista de compras
 function gerarListaCompras() {
-    window.open('/relatorios/materiais/excel?tipo=compras', '_blank');
+    window.location.href = '/materiais/lista-compras';
 }
 
 // Função para baixar relatório em Excel

--- a/templates/material/lista_compras.html
+++ b/templates/material/lista_compras.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block title %}Lista de Compras{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="mb-0">🛒 Lista de Compras</h2>
+        <div>
+            <button id="btn-whatsapp" class="btn btn-success me-2">
+                <i class="fab fa-whatsapp"></i> WhatsApp
+            </button>
+            <button id="btn-pdf" class="btn btn-danger me-2">
+                <i class="fas fa-file-pdf"></i> PDF
+            </button>
+            <button id="btn-xlsx" class="btn btn-primary">
+                <i class="fas fa-file-excel"></i> XLSX
+            </button>
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="incluir-baixa" checked>
+                <label class="form-check-label" for="incluir-baixa">
+                    Incluir materiais em baixa
+                </label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="incluir-esgotados" checked>
+                <label class="form-check-label" for="incluir-esgotados">
+                    Incluir esgotados
+                </label>
+            </div>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-striped" id="tabela-lista-compras">
+            <thead>
+                <tr>
+                    <th>Material</th>
+                    <th>Polo</th>
+                    <th>Qtd Atual</th>
+                    <th>Qtd Mínima</th>
+                    <th>Comprar</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+<script src="{{ url_for('static', filename='js/lista_compras.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `listar_compras` route and template for material shopping list
- Redirect material manager to new shopping list page
- Implement clipboard, PDF, and XLSX exports for shopping list

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4', ImportError: cannot import name 'Submissao', IndentationError in tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af95c7d483248239ac8ba928d63c