### PR TITLE
Add standalone page for material movement

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -1228,3 +1228,21 @@ def editar_material(material_id):
         'material/editar_material.html', material=material, polos=polos
     )
 
+
+@material_routes.route('/materiais/<int:material_id>/movimentar')
+@login_required
+def movimentar_material(material_id):
+    """Página para registrar movimentação de um material."""
+    if not verificar_acesso_cliente():
+        flash('Acesso negado', 'error')
+        return redirect(url_for('evento_routes.home'))
+
+    material = Material.query.filter_by(
+        id=material_id, cliente_id=current_user.id, ativo=True
+    ).first()
+    if not material:
+        flash('Material não encontrado', 'error')
+        return redirect(url_for('material_routes.gerenciar_materiais'))
+
+    return render_template('material/movimentar_material.html', material=material)
+

--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -320,17 +320,9 @@ function filtrarMateriais() {
 
 // Funções de salvar polo e material removidas - agora usando páginas separadas
 
-// Abrir modal de movimentação
+// Abrir página de movimentação
 function abrirMovimentacao(materialId) {
-    const material = materiaisData.find(m => m.id === materialId);
-    if (!material) return;
-    
-    document.getElementById('movimentacao-material-id').value = materialId;
-    document.getElementById('movimentacao-material-nome').textContent = material.nome;
-    document.getElementById('estoque-atual').textContent = `${material.quantidade_atual} ${material.unidade}`;
-    
-    const modal = new bootstrap.Modal(document.getElementById('modalMovimentacao'));
-    modal.show();
+    window.location.href = `/materiais/${materialId}/movimentar`;
 }
 
 // Salvar movimentação

--- a/templates/material/gerenciar_materiais.html
+++ b/templates/material/gerenciar_materiais.html
@@ -266,48 +266,6 @@
 
 
 
-<!-- Modal Movimentação -->
-<div class="modal fade" id="modalMovimentacao" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Registrar Movimentação</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <form id="form-movimentacao">
-                <div class="modal-body">
-                    <input type="hidden" id="movimentacao-material-id">
-                    <div class="mb-3">
-                        <label class="form-label">Material:</label>
-                        <p class="form-control-plaintext" id="movimentacao-material-nome"></p>
-                    </div>
-                    <div class="mb-3">
-                        <label for="movimentacao-tipo" class="form-label">Tipo de Movimentação *</label>
-                        <select class="form-select" id="movimentacao-tipo" required>
-                            <option value="entrada">Entrada (Compra/Recebimento)</option>
-                            <option value="saida">Saída (Consumo/Uso)</option>
-                            <option value="ajuste">Ajuste de Estoque</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="movimentacao-quantidade" class="form-label">Quantidade *</label>
-                        <input type="number" class="form-control" id="movimentacao-quantidade" min="1" required>
-                        <div class="form-text">Estoque atual: <span id="estoque-atual"></span></div>
-                    </div>
-                    <div class="mb-3">
-                        <label for="movimentacao-observacao" class="form-label">Observação</label>
-                        <textarea class="form-control" id="movimentacao-observacao" rows="3" placeholder="Descreva o motivo da movimentação..."></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-primary">Registrar</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
-
 <!-- Modal WhatsApp -->
 <div class="modal fade" id="modalWhatsApp" tabindex="-1">
     <div class="modal-dialog modal-lg">

--- a/templates/material/movimentar_material.html
+++ b/templates/material/movimentar_material.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Movimentar Material{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2 class="mb-4">Movimentar Material</h2>
+    <form id="movimentacao-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" id="material-id" value="{{ material.id }}">
+        <div class="mb-3">
+            <label class="form-label">Material:</label>
+            <p class="form-control-plaintext">{{ material.nome }}</p>
+        </div>
+        <div class="mb-3">
+            <label for="tipo" class="form-label">Tipo de Movimentação *</label>
+            <select id="tipo" class="form-select" required>
+                <option value="entrada">Entrada (Compra/Recebimento)</option>
+                <option value="saida">Saída (Consumo/Uso)</option>
+                <option value="ajuste">Ajuste de Estoque</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="quantidade" class="form-label">Quantidade *</label>
+            <input type="number" id="quantidade" class="form-control" min="1" required>
+            <div class="form-text">Estoque atual: {{ material.quantidade_atual }} {{ material.unidade }}</div>
+        </div>
+        <div class="mb-3">
+            <label for="observacao" class="form-label">Observação</label>
+            <textarea id="observacao" class="form-control" rows="3" placeholder="Descreva o motivo da movimentação..."></textarea>
+        </div>
+        <div class="d-flex justify-content-between">
+            <a href="{{ url_for('material_routes.gerenciar_materiais') }}" class="btn btn-secondary">Cancelar</a>
+            <button type="submit" class="btn btn-primary">Registrar</button>
+        </div>
+    </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function getCSRFToken() {
+    return document.querySelector('meta[name=csrf-token]').getAttribute('content');
+}
+
+document.getElementById('movimentacao-form').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const materialId = document.getElementById('material-id').value;
+    const data = {
+        tipo: document.getElementById('tipo').value,
+        quantidade: parseInt(document.getElementById('quantidade').value),
+        observacao: document.getElementById('observacao').value
+    };
+    const resp = await fetch(`/api/materiais/${materialId}/movimentacao`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': getCSRFToken()
+        },
+        body: JSON.stringify(data)
+    });
+    const result = await resp.json();
+    if (resp.ok && result.success) {
+        window.location.href = "{{ url_for('material_routes.gerenciar_materiais') }}";
+    } else {
+        alert(result.message || 'Erro ao registrar movimentação');
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Redirect movement action to dedicated page instead of modal
- Serve new movement page via `/materiais/<id>/movimentar` route
- Post movement data to existing API and return to materials overview

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: unexpected indent and missing module bs4)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af9fe5208324b5b96d37924131a1