### PR TITLE
Add declaration request route and participant view handling

### DIFF
--- a/routes/certificado_routes.py
+++ b/routes/certificado_routes.py
@@ -1652,6 +1652,77 @@ def excluir_regra_certificado(regra_id):
         return {'success': False, 'message': 'Erro ao excluir regra'}, 500
 
 
+@certificado_routes.route('/solicitar_declaracao', methods=['POST'])
+@login_required
+def solicitar_declaracao():
+    """Solicitar declaração de participação."""
+    try:
+        data = request.get_json(silent=True) or request.form
+
+        solicitacao_existente = SolicitacaoCertificado.query.filter_by(
+            usuario_id=current_user.id,
+            evento_id=data['evento_id'],
+            tipo_certificado='declaracao',
+            status='pendente'
+        ).first()
+
+        if solicitacao_existente:
+            mensagem = (
+                'Já existe uma solicitação pendente para esta declaração'
+            )
+            if request.is_json:
+                return {'success': False, 'message': mensagem}, 400
+            flash(mensagem, 'warning')
+            return redirect(
+                request.referrer
+                or url_for(
+                    'dashboard_participante_routes.dashboard_participante'
+                )
+            )
+
+        dados_participacao = calcular_atividades_participadas(
+            current_user.id, data['evento_id']
+        )
+
+        solicitacao = SolicitacaoCertificado(
+            usuario_id=current_user.id,
+            evento_id=data['evento_id'],
+            tipo_certificado='declaracao',
+            justificativa=data.get('justificativa', ''),
+            dados_participacao=dados_participacao
+        )
+
+        db.session.add(solicitacao)
+        db.session.commit()
+
+        criar_notificacao_solicitacao(solicitacao)
+
+        mensagem = 'Solicitação enviada com sucesso'
+        if request.is_json:
+            return {
+                'success': True,
+                'message': mensagem,
+                'solicitacao_id': solicitacao.id,
+            }
+        flash(mensagem, 'success')
+        return redirect(
+            request.referrer
+            or url_for('dashboard_participante_routes.dashboard_participante')
+        )
+
+    except Exception as e:  # noqa: BLE001
+        db.session.rollback()
+        logger.error(f"Erro ao solicitar declaração: {str(e)}")
+        mensagem = 'Erro ao enviar solicitação'
+        if request.is_json:
+            return {'success': False, 'message': mensagem}, 500
+        flash(mensagem, 'danger')
+        return redirect(
+            request.referrer
+            or url_for('dashboard_participante_routes.dashboard_participante')
+        )
+
+
 @certificado_routes.route('/solicitar_certificado', methods=['POST'])
 @login_required
 def solicitar_certificado():

--- a/templates/participante/certificados_participante.html
+++ b/templates/participante/certificados_participante.html
@@ -434,25 +434,29 @@
         }
         
         function solicitarDeclaracao(tipo) {
-            // Implementar modal ou redirecionamento para solicitação de declaração
-            const form = document.createElement('form');
-            form.method = 'POST';
-            form.action = '{{ url_for("certificado_routes.solicitar_declaracao") }}';
-            
-            const tipoInput = document.createElement('input');
-            tipoInput.type = 'hidden';
-            tipoInput.name = 'tipo';
-            tipoInput.value = tipo;
-            form.appendChild(tipoInput);
-            
-            const eventoInput = document.createElement('input');
-            eventoInput.type = 'hidden';
-            eventoInput.name = 'evento_id';
-            eventoInput.value = '{{ evento.id if evento else "" }}';
-            form.appendChild(eventoInput);
-            
-            document.body.appendChild(form);
-            form.submit();
+            const payload = {
+                tipo: tipo,
+                evento_id: '{{ evento.id if evento else "" }}'
+            };
+
+            fetch('{{ url_for("certificado_routes.solicitar_declaracao") }}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert('Solicitação enviada com sucesso!');
+                    location.reload();
+                } else {
+                    alert('Erro: ' + data.message);
+                }
+            })
+            .catch(error => {
+                alert('Erro ao enviar solicitação');
+                console.error(error);
+            });
         }
     </script>
 </body>

--- a/templates/participante/minha_participacao.html
+++ b/templates/participante/minha_participacao.html
@@ -373,24 +373,29 @@
         }
         
         function solicitarDeclaracao(tipo) {
-            const form = document.createElement('form');
-            form.method = 'POST';
-            form.action = '{{ url_for("certificado_routes.solicitar_declaracao") }}';
-            
-            const tipoInput = document.createElement('input');
-            tipoInput.type = 'hidden';
-            tipoInput.name = 'tipo';
-            tipoInput.value = tipo;
-            form.appendChild(tipoInput);
-            
-            const eventoInput = document.createElement('input');
-            eventoInput.type = 'hidden';
-            eventoInput.name = 'evento_id';
-            eventoInput.value = '{{ evento.id if evento else "" }}';
-            form.appendChild(eventoInput);
-            
-            document.body.appendChild(form);
-            form.submit();
+            const payload = {
+                tipo: tipo,
+                evento_id: '{{ evento.id if evento else "" }}'
+            };
+
+            fetch('{{ url_for("certificado_routes.solicitar_declaracao") }}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert('Solicitação enviada com sucesso!');
+                    location.reload();
+                } else {
+                    alert('Erro: ' + data.message);
+                }
+            })
+            .catch(error => {
+                alert('Erro ao enviar solicitação');
+                console.error(error);
+            });
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add `/solicitar_declaracao` endpoint to register declaration requests
- handle success and error responses when participants request declarations

## Testing
- `pytest` *(fails: IndentationError and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9012356d083249766023267cdc2be