### PR TITLE
Return declaration template JSON for editing

### DIFF
--- a/routes/certificado_routes.py
+++ b/routes/certificado_routes.py
@@ -2043,19 +2043,27 @@ def editar_declaracao_template(template_id):
         id=template_id, cliente_id=current_user.id
     ).first_or_404()
     
-    if request.method == 'POST':
-        data = request.get_json()
-        
-        template.nome = data['nome']
-        template.conteudo = data['conteudo']
-        template.tipo = data.get('tipo', template.tipo)
-        template.ativo = data.get('ativo', template.ativo)
-        
-        db.session.commit()
-        
-        return {'success': True, 'message': 'Template atualizado com sucesso'}
-    
-    return render_template('certificado/editar_declaracao.html', template=template)
+    if request.method == 'GET':
+        return {
+            'template': {
+                'id': template.id,
+                'nome': template.nome,
+                'conteudo': template.conteudo,
+                'tipo': template.tipo,
+                'ativo': template.ativo,
+            }
+        }
+
+    data = request.get_json()
+
+    template.nome = data['nome']
+    template.conteudo = data['conteudo']
+    template.tipo = data.get('tipo', template.tipo)
+    template.ativo = data.get('ativo', template.ativo)
+
+    db.session.commit()
+
+    return {'success': True, 'message': 'Template atualizado com sucesso'}
 
 
 @certificado_routes.route('/declaracoes/deletar/<int:template_id>', methods=['DELETE'])


### PR DESCRIPTION
## Summary
- Serve declaration template data as JSON for GET requests
- Preserve existing update logic for POST and keep frontend $.get population flow

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py and 9 others)*

------
https://chatgpt.com/codex/tasks/task_e_68b901347fb88324800dd69e5aadcc06