### PR TITLE
Add endpoint and JS preview for declaration participants

### DIFF
--- a/templates/certificado/emissao_declaracoes.html
+++ b/templates/certificado/emissao_declaracoes.html
@@ -553,13 +553,32 @@ function previewDeclaracaoIndividual() {
 
 function previewLoteDeclaracoes() {
     const eventoId = $('#eventoLote').val();
-    
+
     if (!eventoId) {
         alert('Por favor, selecione um evento.');
         return;
     }
-    
-    // Implementar preview da lista de participantes
-    alert('Preview da lista de participantes em desenvolvimento');
+
+    $.get(`/certificado/declaracoes/preview-participantes/${eventoId}`, function(data) {
+        const participantes = data.participantes || [];
+        let html = '';
+
+        if (participantes.length) {
+            html += '<table class="table table-striped">';
+            html += '<thead><tr><th>#</th><th>Nome</th></tr></thead><tbody>';
+            participantes.forEach((p, idx) => {
+                html += `<tr><td>${idx + 1}</td><td>${p.nome}</td></tr>`;
+            });
+            html += '</tbody></table>';
+        } else {
+            html = '<p>Nenhum participante encontrado.</p>';
+        }
+
+        $('#previewTitle').text('Participantes do Evento');
+        $('#previewContent').html(html);
+        $('#modalPreview').modal('show');
+    }).fail(function() {
+        alert('Erro ao carregar participantes.');
+    });
 }
 </script>


### PR DESCRIPTION
## Summary
- add `preview-participantes` endpoint to fetch event participant summaries
- load participants via AJAX in declaração emission page and show in modal

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b90140bd8083249a51be7b4d4b7555