### PR TITLE
Show visitor count in single badge

### DIFF
--- a/templates/monitor/distribuicao_manual.html
+++ b/templates/monitor/distribuicao_manual.html
@@ -105,11 +105,13 @@
                                             </small>
                                         </td>
                                         <td>
-
-                                            <span class="badge bg-primary">{{ agendamento.alunos|length }} visitantes</span>
-
-                                            <span class="badge bg-primary">{{ agendamento.quantidade_alunos }} visitantes</span>
-
+                                            <span class="badge bg-primary">
+                                                {% if agendamento.alunos is not none %}
+                                                    {{ agendamento.alunos|length }} visitantes
+                                                {% else %}
+                                                    {{ agendamento.quantidade_alunos }} visitantes
+                                                {% endif %}
+                                            </span>
                                         </td>
                                         <td>
                                             <button class="btn btn-sm btn-success" 


### PR DESCRIPTION
## Summary
- Display visitor count in a single badge on manual monitor distribution page, using either `agendamento.alunos|length` or `agendamento.quantidade_alunos`

## Testing
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b9022d24988324a547fbb4db6afea3