### PR TITLE
Add WhatsApp export for automatic distribution results

### DIFF
--- a/templates/monitor/distribuicao_automatica.html
+++ b/templates/monitor/distribuicao_automatica.html
@@ -155,6 +155,7 @@ function executarDistribuicaoAutomatica(modo = 'somente_sem_monitor') {
         resultadoDiv.style.display = 'block';
         
         if (data.success) {
+            window.lastDistribuicaoData = data;
             let html = `
                 <div class="alert alert-success">
                     <h6>Distribuição realizada com sucesso!</h6>
@@ -206,7 +207,12 @@ function executarDistribuicaoAutomatica(modo = 'somente_sem_monitor') {
             }
             conteudoDiv.innerHTML = html + `
                 <div class="mt-3 text-end">
-                  <button class="btn btn-outline-secondary btn-sm" onclick="window.location.reload()">
+                  <button class="btn btn-outline-success btn-sm me-2"
+                    onclick="exportarParaWhatsApp()">
+                    <i class="fab fa-whatsapp"></i> Exportar para WhatsApp
+                  </button>
+                  <button class="btn btn-outline-secondary btn-sm"
+                    onclick="window.location.reload()">
                     <i class="fas fa-rotate"></i> Atualizar página
                   </button>
                 </div>
@@ -235,6 +241,44 @@ function executarDistribuicaoAutomatica(modo = 'somente_sem_monitor') {
                 <p>Não foi possível executar a distribuição automática. Tente novamente.</p>
             </div>
         `;
+    });
+}
+
+function exportarParaWhatsApp() {
+    const data = window.lastDistribuicaoData;
+    if (!data) {
+        alert('Nenhuma distribuição para exportar.');
+        return;
+    }
+
+    let mensagem = 'Distribuição de monitores:\n';
+    if (data.atribuicoes_detalhes && data.atribuicoes_detalhes.length) {
+        mensagem += '\nAgendamentos com monitor:\n';
+        data.atribuicoes_detalhes.forEach(a => {
+            mensagem += `• ${a.data || ''} ${a.hora || ''} - ${a.escola || ''} ` +
+                `(ID ${a.agendamento_id}) => ${a.monitor_nome || a.monitor_id}\n`;
+        });
+    }
+    if (data.pendentes && data.pendentes.length) {
+        mensagem += '\nAgendamentos sem monitor:\n';
+        data.pendentes.forEach(p => {
+            mensagem += `• ${p.data || ''} ${p.hora || ''} - ${p.escola || ''} ` +
+                `(ID ${p.agendamento_id}) - ${p.motivo || ''}\n`;
+        });
+    }
+
+    const url = 'https://api.whatsapp.com/send?text=' +
+        encodeURIComponent(mensagem);
+    navigator.clipboard.writeText(mensagem).then(() => {
+        const win = window.open(url, '_blank');
+        if (win) {
+            win.focus();
+            alert('Mensagem copiada e WhatsApp aberto.');
+        } else {
+            alert('Mensagem copiada, mas não foi possível abrir o WhatsApp.');
+        }
+    }).catch(() => {
+        alert('Não foi possível copiar a mensagem.');
     });
 }
 </script>


### PR DESCRIPTION
## Summary
- allow exporting distribution results to WhatsApp with a dedicated button
- add JS to copy formatted message to clipboard and open WhatsApp link with feedback

## Testing
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b907c105748324979d1e3f608eff9c