### PR TITLE
Ensure unique declaration template names

### DIFF
--- a/migrations/versions/03b7e3c050f6_add_unique_constraint_declaracao_template.py
+++ b/migrations/versions/03b7e3c050f6_add_unique_constraint_declaracao_template.py
@@ -1,0 +1,31 @@
+"""Add unique constraint to declaracao_template
+
+Revision ID: 03b7e3c050f6
+Revises: 42ad97f8ce32
+Create Date: 2025-09-05 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "03b7e3c050f6"
+down_revision = "42ad97f8ce32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        op.f("uq_declaracao_template_cliente_nome"),
+        "declaracao_template",
+        ["cliente_id", "nome"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("uq_declaracao_template_cliente_nome"),
+        "declaracao_template",
+        type_="unique",
+    )

--- a/models/certificado.py
+++ b/models/certificado.py
@@ -197,6 +197,14 @@ class CertificadoTemplateAvancado(db.Model):
 class DeclaracaoTemplate(db.Model):
     """Templates para declarações de comparecimento."""
     __tablename__ = "declaracao_template"
+    __table_args__ = (
+        db.UniqueConstraint(
+            "cliente_id",
+            "nome",
+            name="uq_declaracao_template_cliente_nome",
+        ),
+        {"extend_existing": True},
+    )
     
     id = db.Column(db.Integer, primary_key=True)
     cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)

--- a/routes/certificado_routes.py
+++ b/routes/certificado_routes.py
@@ -2104,7 +2104,15 @@ def criar_declaracao_template():
     """Criar novo template de declaração de comparecimento."""
     if request.method == 'POST':
         data = request.get_json()
-        
+        existente = DeclaracaoTemplate.query.filter_by(
+            cliente_id=current_user.id, nome=data.get('nome')
+        ).first()
+        if existente:
+            return {
+                'success': False,
+                'message': 'Template com este nome já existe'
+            }, 400
+
         template = DeclaracaoTemplate(
             nome=data['nome'],
             conteudo=data['conteudo'],
@@ -2112,10 +2120,10 @@ def criar_declaracao_template():
             ativo=data.get('ativo', True),
             cliente_id=current_user.id
         )
-        
+
         db.session.add(template)
         db.session.commit()
-        
+
         return {'success': True, 'message': 'Template de declaração criado com sucesso'}
     
     return render_template('certificado/criar_declaracao.html')
@@ -2143,6 +2151,19 @@ def editar_declaracao_template(template_id):
         }
 
     data = request.get_json()
+
+    existente = (
+        DeclaracaoTemplate.query.filter_by(
+            cliente_id=current_user.id, nome=data.get('nome')
+        )
+        .filter(DeclaracaoTemplate.id != template.id)
+        .first()
+    )
+    if existente:
+        return {
+            'success': False,
+            'message': 'Template com este nome já existe'
+        }, 400
 
     template.nome = data['nome']
     template.conteudo = data['conteudo']

--- a/routes/declaracao_routes.py
+++ b/routes/declaracao_routes.py
@@ -129,9 +129,16 @@ def criar_template():
             nome = request.form.get('nome')
             tipo = request.form.get('tipo')
             conteudo = request.form.get('conteudo')
-            
+
             if not all([nome, tipo, conteudo]):
                 flash('Todos os campos são obrigatórios.', 'error')
+                return render_template('declaracao/criar_template.html')
+
+            existente_nome = DeclaracaoTemplate.query.filter_by(
+                cliente_id=current_user.id, nome=nome
+            ).first()
+            if existente_nome:
+                flash('Já existe um template com este nome.', 'error')
                 return render_template('declaracao/criar_template.html')
                 
             # Verificar se já existe template ativo do mesmo tipo
@@ -186,9 +193,23 @@ def editar_template(template_id):
             return render_template('declaracao/editar_template.html', template=template)
             
         elif request.method == 'POST':
-            template.nome = request.form.get('nome')
-            template.conteudo = request.form.get('conteudo')
-            
+            novo_nome = request.form.get('nome')
+            novo_conteudo = request.form.get('conteudo')
+
+            existente_nome = (
+                DeclaracaoTemplate.query.filter_by(
+                    cliente_id=current_user.id, nome=novo_nome
+                )
+                .filter(DeclaracaoTemplate.id != template.id)
+                .first()
+            )
+            if existente_nome:
+                flash('Já existe um template com este nome.', 'error')
+                return render_template('declaracao/editar_template.html', template=template)
+
+            template.nome = novo_nome
+            template.conteudo = novo_conteudo
+
             # Gerenciar status ativo
             if request.form.get('definir_ativo'):
                 # Desativar outros templates do mesmo tipo


### PR DESCRIPTION
## Summary
- enforce uniqueness of declaration template names per client
- handle duplicate template names in creation and edit flows
- migrate database to add composite unique constraint

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ImportError, IndentationError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b90960006c8324a8176a1c5efdb66c