### PR TITLE
Handle Excel report errors and exempt CSRF GET

### DIFF
--- a/routes/material_routes.py
+++ b/routes/material_routes.py
@@ -214,6 +214,7 @@ def estatisticas_polos():
 
 
 @material_routes.route('/relatorios/materiais/excel', methods=['GET'])
+@csrf.exempt
 @login_required
 def gerar_relatorio_excel():
     """Gerar relatório de materiais em Excel."""

--- a/static/js/material_gerenciar.js
+++ b/static/js/material_gerenciar.js
@@ -482,11 +482,14 @@ function baixarRelatorioExcel(tipo = 'geral', poloId = null) {
             'X-CSRFToken': getCSRFToken()
         }
     })
-    .then(response => {
+    .then(async response => {
         if (response.ok) {
             return response.blob();
         }
-        throw new Error('Erro ao gerar relatório');
+        const data = await response.json().catch(() => ({}));
+        const message =
+            data.error?.message || data.message || 'Erro ao gerar relatório';
+        throw new Error(message);
     })
     .then(blob => {
         const url = window.URL.createObjectURL(blob);
@@ -502,7 +505,7 @@ function baixarRelatorioExcel(tipo = 'geral', poloId = null) {
     })
     .catch(error => {
         console.error('Erro:', error);
-        showAlert('Erro ao baixar relatório', 'danger');
+        showAlert(error.message || 'Erro ao baixar relatório', 'danger');
     })
     .finally(() => {
         hideLoading();


### PR DESCRIPTION
## Summary
- Improve Excel report download to show server error messages
- Exempt Excel report endpoint from CSRF when using GET

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bef3a2372083249cc5520df139a72c