### PR TITLE
Add monitor cadastro link migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ integração com o Mailjet, portanto não é necessário gerar tokens OAuth para
 Gmail.
 
 `APP_BASE_URL` define a URL base para gerar links externos, como o `notification_url` do Mercado Pago. Em desenvolvimento, aponte para um endereço público (ex.: URL do ngrok).
+Esse endereço também é utilizado para construir links de cadastro de monitores.
 
 `RECAPTCHA_PUBLIC_KEY` e `RECAPTCHA_PRIVATE_KEY` devem conter as chaves obtidas no [Google reCAPTCHA](https://www.google.com/recaptcha/admin). Sem valores válidos, o CAPTCHA não funcionará em produção.
 

--- a/migrations/versions/414d4628e3f4_add_monitor_cadastro_link_table.py
+++ b/migrations/versions/414d4628e3f4_add_monitor_cadastro_link_table.py
@@ -1,0 +1,30 @@
+"""add monitor cadastro link table
+
+Revision ID: 414d4628e3f4
+Revises: 3267ae82aadf
+Create Date: 2025-09-08 18:01:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "414d4628e3f4"
+down_revision = "3267ae82aadf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "monitor_cadastro_link",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token", sa.String(length=255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_monitor_cadastro_link")),
+        sa.UniqueConstraint("token", name=op.f("uq_monitor_cadastro_link_token")),
+    )
+
+
+def downgrade():
+    op.drop_table("monitor_cadastro_link")


### PR DESCRIPTION
## Summary
- create `monitor_cadastro_link` table with token and expiration
- document that `APP_BASE_URL` is also used for monitor signup links

## Testing
- `flask db upgrade heads` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `pytest` *(fails: IndentationError: unexpected indent)*

------
https://chatgpt.com/codex/tasks/task_e_68bf18f28b6c8324ac307cdd79aaa3ef