### PR TITLE
Add monitor invite link modal

### DIFF
--- a/static/js/gerenciar_monitores.js
+++ b/static/js/gerenciar_monitores.js
@@ -1,0 +1,54 @@
+// Funções para geração e cópia de links de inscrição de monitores
+let linkModal;
+
+document.addEventListener('DOMContentLoaded', () => {
+    const modalEl = document.getElementById('gerarLinkModal');
+    if (modalEl) {
+        linkModal = new bootstrap.Modal(modalEl);
+    }
+
+    const abrirModal = document.getElementById('gerar-link-btn');
+    if (abrirModal && linkModal) {
+        abrirModal.addEventListener('click', () => {
+            linkModal.show();
+        });
+    }
+});
+
+async function gerarLinkMonitor() {
+    const expiresInput = document.getElementById('expires-at');
+    const linkInput = document.getElementById('monitor-link');
+    const expiresAt = expiresInput?.value;
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+
+    try {
+        const response = await fetch('/monitor/gerar_link', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken
+            },
+            body: JSON.stringify({ expires_at: expiresAt })
+        });
+
+        if (!response.ok) {
+            throw new Error('Erro ao gerar link');
+        }
+
+        const data = await response.json();
+        linkInput.value = data.url || '';
+    } catch (err) {
+        alert(err.message);
+    }
+}
+
+function copiarLinkMonitor() {
+    const linkInput = document.getElementById('monitor-link');
+    const link = linkInput?.value;
+    if (!link) {
+        return;
+    }
+    navigator.clipboard.writeText(link).then(() => {
+        alert('Link copiado para a área de transferência');
+    });
+}

--- a/templates/monitor/gerenciar_monitores.html
+++ b/templates/monitor/gerenciar_monitores.html
@@ -29,14 +29,22 @@
                             <i class="fas fa-users-plus"></i>
                             <span class="d-none d-sm-inline ms-1">Cadastro Múltiplo</span>
                         </a>
-                        <a href="{{ url_for('monitor_routes.importacao_massa') }}" 
-                           class="btn btn-outline-primary" 
-                           data-bs-toggle="tooltip" 
-                           data-bs-placement="top" 
+                        <a href="{{ url_for('monitor_routes.importacao_massa') }}"
+                           class="btn btn-outline-primary"
+                           data-bs-toggle="tooltip"
+                           data-bs-placement="top"
                            title="Importar monitores via planilha">
                             <i class="fas fa-upload"></i>
                             <span class="d-none d-sm-inline ms-1">Importação</span>
                         </a>
+                        <button id="gerar-link-btn"
+                                class="btn btn-outline-primary"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="top"
+                                title="Gerar link de inscrição">
+                            <i class="fas fa-link"></i>
+                            <span class="d-none d-sm-inline ms-1">Gerar link</span>
+                        </button>
                     </div>
                     
                     <!-- Grupo 2: Distribuição -->
@@ -339,10 +347,37 @@
     </div>
 </div>
 
+<!-- Modal Gerar Link -->
+<div class="modal fade" id="gerarLinkModal" tabindex="-1" aria-labelledby="gerarLinkModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="gerarLinkModalLabel">Gerar link de inscrição</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label for="expires-at" class="form-label">Data de expiração</label>
+                    <input type="date" class="form-control" id="expires-at">
+                </div>
+                <div class="mb-3">
+                    <label for="monitor-link" class="form-label">Link gerado</label>
+                    <input type="text" class="form-control" id="monitor-link" readonly>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" onclick="gerarLinkMonitor()">Gerar</button>
+                <button type="button" class="btn btn-outline-secondary" onclick="copiarLinkMonitor()">Copiar link</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 
 {% endblock %}
 
 {% block scripts_extra %}
+<script src="{{ url_for('static', filename='js/gerenciar_monitores.js') }}"></script>
 <script>
 // Inicializar tooltips do Bootstrap
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- add "Gerar link" button and modal in monitor management page
- implement JavaScript to generate and copy invitation links
- register new script on monitor management template

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError: unexpected indent in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bf18f1a8e083249f3ad96718142249