### PR TITLE
Add monitor self-registration via tokenized links

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -15,6 +15,6 @@ from .material import *  # noqa: F401,F403
 
 # Importações explícitas para garantir disponibilidade
 from .event import ParticipanteEvento, MonitorAgendamento, PresencaAluno, MaterialApoio, NecessidadeEspecial
-from .user import Monitor
+from .user import Monitor, MonitorCadastroLink
 from .certificado import CertificadoConfig, CertificadoParticipante, NotificacaoCertificado, SolicitacaoCertificado, RegraCertificado, CertificadoTemplateAvancado, DeclaracaoTemplate
 

--- a/models/user.py
+++ b/models/user.py
@@ -193,6 +193,28 @@ class PasswordResetToken(db.Model):
         return f"<PasswordResetToken usuario_id={self.usuario_id} token={self.token}>"
 
 
+class MonitorCadastroLink(db.Model):
+    """Link para autoinscrição de monitores."""
+
+    __tablename__ = "monitor_cadastro_link"
+
+    id = db.Column(db.Integer, primary_key=True)
+    cliente_id = db.Column(db.Integer, db.ForeignKey("cliente.id"), nullable=False)
+    token = db.Column(
+        db.String(36), unique=True, nullable=False, default=lambda: str(uuid.uuid4())
+    )
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used = db.Column(db.Boolean, default=False)
+
+    cliente = db.relationship(
+        "Cliente", backref=db.backref("monitor_cadastro_links", lazy=True)
+    )
+
+    def is_valid(self):
+        """Retorna True se o link não foi usado e ainda não expirou."""
+        return (not self.used) and datetime.utcnow() < self.expires_at
+
+
 class Monitor(db.Model, UserMixin):
     __tablename__ = "monitor"
     id = db.Column(db.Integer, primary_key=True)

--- a/templates/monitor/auto_inscricao.html
+++ b/templates/monitor/auto_inscricao.html
@@ -1,0 +1,107 @@
+{% extends "base.html" %}
+
+{% block title %}Cadastro de Monitor{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Cadastro de Monitor</h2>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <label for="nome_completo" class="form-label">Nome Completo *</label>
+                <input type="text" class="form-control" id="nome_completo" name="nome_completo" required>
+            </div>
+            <div class="col-md-6 mb-3">
+                <label for="curso" class="form-label">Curso *</label>
+                <input type="text" class="form-control" id="curso" name="curso" required>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <label for="email" class="form-label">Email *</label>
+                <input type="email" class="form-control" id="email" name="email" required>
+            </div>
+            <div class="col-md-6 mb-3">
+                <label for="telefone_whatsapp" class="form-label">Telefone WhatsApp *</label>
+                <input type="text" class="form-control" id="telefone_whatsapp" name="telefone_whatsapp" required>
+            </div>
+        </div>
+        <div class="mb-3">
+            <label for="carga_horaria_disponibilidade" class="form-label">Carga Horária de Disponibilidade (horas/semana) *</label>
+            <input type="number" class="form-control" id="carga_horaria_disponibilidade" name="carga_horaria_disponibilidade" min="1" max="40" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Dias de Disponibilidade *</label>
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="segunda" name="dias_disponibilidade" value="segunda">
+                        <label class="form-check-label" for="segunda">Segunda-feira</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="terca" name="dias_disponibilidade" value="terca">
+                        <label class="form-check-label" for="terca">Terça-feira</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="quarta" name="dias_disponibilidade" value="quarta">
+                        <label class="form-check-label" for="quarta">Quarta-feira</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="quinta" name="dias_disponibilidade" value="quinta">
+                        <label class="form-check-label" for="quinta">Quinta-feira</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="sexta" name="dias_disponibilidade" value="sexta">
+                        <label class="form-check-label" for="sexta">Sexta-feira</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="sabado" name="dias_disponibilidade" value="sabado">
+                        <label class="form-check-label" for="sabado">Sábado</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="domingo" name="dias_disponibilidade" value="domingo">
+                        <label class="form-check-label" for="domingo">Domingo</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Turnos de Disponibilidade *</label>
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="manha" name="turnos_disponibilidade" value="manha">
+                        <label class="form-check-label" for="manha">Manhã</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="tarde" name="turnos_disponibilidade" value="tarde">
+                        <label class="form-check-label" for="tarde">Tarde</label>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="noite" name="turnos_disponibilidade" value="noite">
+                        <label class="form-check-label" for="noite">Noite</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">Registrar</button>
+    </form>
+</div>
+{% endblock %}

--- a/tests/test_monitor_link_registration.py
+++ b/tests/test_monitor_link_registration.py
@@ -1,0 +1,144 @@
+import os
+from datetime import datetime, timedelta
+
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('DB_PASS', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+
+import pytest
+from config import Config
+from app import create_app
+from extensions import db
+from models.user import Cliente, MonitorCadastroLink, Monitor
+import models  # noqa: F401
+
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options(
+        app.config['SQLALCHEMY_DATABASE_URI']
+    )
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='c@test', senha='x')
+        db.session.add(cliente)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_cliente(client, cliente_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(cliente_id)
+        sess['_fresh'] = True
+        sess['_id'] = 'test'
+        sess['user_type'] = 'cliente'
+
+
+def test_generate_link(client, app):
+    with app.app_context():
+        cliente = Cliente.query.first()
+    with client:
+        login_cliente(client, cliente.id)
+        expires_at = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+        resp = client.post('/monitor/gerar_link', json={'expires_at': expires_at})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success']
+        token = data['url'].rsplit('/', 1)[-1]
+        with app.app_context():
+            assert MonitorCadastroLink.query.filter_by(token=token).count() == 1
+
+
+def test_register_with_valid_token(client, app):
+    with app.app_context():
+        cliente = Cliente.query.first()
+        link = MonitorCadastroLink(
+            cliente_id=cliente.id,
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        db.session.add(link)
+        db.session.commit()
+        token = link.token
+
+    resp = client.post(
+        f'/monitor/inscricao/{token}',
+        data={
+            'nome_completo': 'Mon',
+            'curso': 'C',
+            'email': 'm@test',
+            'telefone_whatsapp': '1',
+            'carga_horaria_disponibilidade': '5',
+            'dias_disponibilidade': 'segunda',
+            'turnos_disponibilidade': 'manha',
+        },
+        follow_redirects=True,
+    )
+    assert resp.request.path == '/monitor/dashboard'
+    with app.app_context():
+        monitor = Monitor.query.filter_by(email='m@test').first()
+        assert monitor is not None
+        assert MonitorCadastroLink.query.filter_by(token=token, used=True).count() == 1
+    with client.session_transaction() as sess:
+        assert sess['user_type'] == 'monitor'
+
+
+def test_reject_expired_token(client, app):
+    with app.app_context():
+        cliente = Cliente.query.first()
+        link = MonitorCadastroLink(
+            cliente_id=cliente.id,
+            expires_at=datetime.utcnow() - timedelta(hours=1),
+        )
+        db.session.add(link)
+        db.session.commit()
+        token = link.token
+
+    resp = client.get(f'/monitor/inscricao/{token}')
+    assert resp.status_code == 400
+
+
+def test_reject_reused_token(client, app):
+    with app.app_context():
+        cliente = Cliente.query.first()
+        link = MonitorCadastroLink(
+            cliente_id=cliente.id,
+            expires_at=datetime.utcnow() + timedelta(hours=1),
+        )
+        db.session.add(link)
+        db.session.commit()
+        token = link.token
+
+    client.post(
+        f'/monitor/inscricao/{token}',
+        data={
+            'nome_completo': 'Mon',
+            'curso': 'C',
+            'email': 'unique@test',
+            'telefone_whatsapp': '1',
+            'carga_horaria_disponibilidade': '5',
+            'dias_disponibilidade': 'segunda',
+            'turnos_disponibilidade': 'manha',
+        },
+        follow_redirects=True,
+    )
+    with client.session_transaction() as sess:
+        sess.clear()
+    resp = client.get(f'/monitor/inscricao/{token}')
+    assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- Introduce `MonitorCadastroLink` model to manage time-limited signup tokens
- Allow clients/admins to generate signup links and public self-registration for monitors
- Provide automated tests for link generation and validation

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*
- `pytest tests/test_monitor_link_registration.py` *(fails: sqlite3.OperationalError: no such table: formularios)*

------
https://chatgpt.com/codex/tasks/task_e_68bf18ee8c50832486de86c4900eec99