### PR TITLE
Refactor atividade participation to service

### DIFF
--- a/routes/certificado_routes.py
+++ b/routes/certificado_routes.py
@@ -36,6 +36,7 @@ from models.certificado import (
 )
 from models.event import ConfiguracaoCertificadoAvancada
 from services.pdf_service import gerar_certificado_personalizado  # ajuste conforme a localização
+from services import certificado_service
 from utils.auth import login_required, require_permission, require_resource_access, role_required, cliente_required
 
 
@@ -987,7 +988,9 @@ def gerar_certificado_geral_evento(evento_id):
         
         if ok:
             # Calcular atividades participadas
-            atividades_participadas = calcular_atividades_participadas(usuario_id, evento_id, config)
+            atividades_participadas = certificado_service.calcular_atividades_participadas(
+                usuario_id, evento_id, config
+            )
             
             if atividades_participadas['total_horas'] >= (config.carga_horaria_minima or 0):
                 # Gerar certificado
@@ -1133,63 +1136,6 @@ def historico_emissoes():
         'success': True,
         'html': historico_html
     }
-
-
-def calcular_atividades_participadas(usuario_id, evento_id, config=None):
-    """Calcula todas as atividades que o usuário participou no evento."""
-    from models import Checkin
-    
-    # Oficinas com inscrição
-    oficinas_participadas = db.session.query(
-        Oficina.id, Oficina.titulo, Oficina.carga_horaria
-    ).join(
-        Checkin, Checkin.oficina_id == Oficina.id
-    ).filter(
-        Checkin.usuario_id == usuario_id,
-        Oficina.evento_id == evento_id
-    ).all()
-    
-    atividades = {
-        'oficinas': [],
-        'atividades_sem_inscricao': [],
-        'total_horas': 0,
-        'total_atividades': 0
-    }
-    
-    # Processar oficinas com inscrição
-    for oficina in oficinas_participadas:
-        atividades['oficinas'].append({
-            'id': oficina.id,
-            'titulo': oficina.titulo,
-            'carga_horaria': int(oficina.carga_horaria),
-            'tipo': 'oficina'
-        })
-        atividades['total_horas'] += int(oficina.carga_horaria)
-    
-    # Se configurado, incluir atividades sem inscrição
-    if config and config.incluir_atividades_sem_inscricao:
-        # Buscar check-ins em atividades sem inscrição formal
-        checkins_extras = db.session.query(
-            Checkin
-        ).filter(
-            Checkin.usuario_id == usuario_id,
-            Checkin.evento_id == evento_id,
-            Checkin.oficina_id.is_(None)  # Check-ins gerais do evento
-        ).all()
-        
-        for checkin in checkins_extras:
-            if checkin.palavra_chave and 'ATIVIDADE' in checkin.palavra_chave:
-                # Extrair informações da atividade do check-in
-                atividades['atividades_sem_inscricao'].append({
-                    'titulo': checkin.palavra_chave.replace('ATIVIDADE-', ''),
-                    'carga_horaria': 2,  # Valor padrão
-                    'tipo': 'atividade_extra'
-                })
-                atividades['total_horas'] += 2
-    
-    atividades['total_atividades'] = len(atividades['oficinas']) + len(atividades['atividades_sem_inscricao'])
-    
-    return atividades
 
 
 def gerar_certificado_geral_personalizado(usuario, evento, atividades, template, cliente):
@@ -1725,7 +1671,7 @@ def solicitar_declaracao():
                 )
             )
 
-        dados_participacao = calcular_atividades_participadas(
+        dados_participacao = certificado_service.calcular_atividades_participadas(
             current_user.id, data['evento_id']
         )
 
@@ -1791,7 +1737,7 @@ def solicitar_certificado():
             }
         
         # Coletar dados de participação
-        dados_participacao = calcular_atividades_participadas(
+        dados_participacao = certificado_service.calcular_atividades_participadas(
             current_user.id, data['evento_id']
         )
         
@@ -1952,7 +1898,9 @@ def avaliar_regras_certificado(usuario_id, evento_id, tipo_certificado='geral'):
         evento_id=evento_id, ativo=True
     ).order_by(RegraCertificado.prioridade.asc()).all()
     
-    dados_participacao = calcular_atividades_participadas(usuario_id, evento_id)
+    dados_participacao = certificado_service.calcular_atividades_participadas(
+        usuario_id, evento_id
+    )
     
     for regra in regras:
         if avaliar_condicoes_regra(regra, dados_participacao):
@@ -2055,7 +2003,7 @@ def gerar_certificado_aprovado(solicitacao):
     try:
         if solicitacao.tipo_certificado == 'geral':
             # Gerar certificado geral
-            atividades = calcular_atividades_participadas(
+            atividades = certificado_service.calcular_atividades_participadas(
                 solicitacao.usuario_id, solicitacao.evento_id
             )
             


### PR DESCRIPTION
## Summary
- move activity participation calculation logic into `certificado_service`
- update routes to use `certificado_service.calcular_atividades_participadas`
- adjust participant routes to consume service

## Testing
- `pytest` *(fails: unexpected indent and missing modules; 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8c73f6ec8324a0f7fa7e8b07e882