### PR TITLE
Use process step data in candidate form

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -607,17 +607,22 @@ def submit_application(process_id: int):
 
     # Create a basic form instance for CSRF protection
     form = FlaskForm()
-    
+    stage_names = [e.nome for e in sorted(processo.etapas, key=lambda e: e.numero)]
+
     # Check if process has multiple steps
     if processo.num_etapas > 1:
         return render_template(
-            "revisor/candidatura_form_steps.html", 
-            formulario=formulario, 
+            "revisor/candidatura_form_steps.html",
+            formulario=formulario,
             processo=processo,
-            form=form
+            num_etapas=processo.num_etapas,
+            stage_names=stage_names,
+            form=form,
         )
     else:
-        return render_template("revisor/candidatura_form.html", formulario=formulario, form=form)
+        return render_template(
+            "revisor/candidatura_form.html", formulario=formulario, form=form
+        )
 
 
 @revisor_routes.route("/revisor/progress/<codigo>")

--- a/templates/revisor/candidatura_form_steps.html
+++ b/templates/revisor/candidatura_form_steps.html
@@ -218,6 +218,8 @@
 </div>
 
 <script>
+const totalProcessSteps = {{ num_etapas }};
+const stageNames = {{ stage_names | tojson }};
 let currentStep = 1;
 let totalSteps = 1;
 let stepData = {};
@@ -253,7 +255,12 @@ function loadFormStructure() {
 // Organize fields by steps
 function organizeFieldsBySteps() {
     stepData = {};
-    
+
+    // Initialize all steps to ensure empty stages are represented
+    for (let i = 1; i <= totalProcessSteps; i++) {
+        stepData[i] = [];
+    }
+
     formFields.forEach(campo => {
         const etapa = campo.etapa || 1;
         if (!stepData[etapa]) {
@@ -261,8 +268,8 @@ function organizeFieldsBySteps() {
         }
         stepData[etapa].push(campo);
     });
-    
-    totalSteps = Math.max(...Object.keys(stepData).map(Number)) + 1; // +1 for summary
+
+    totalSteps = totalProcessSteps + 1; // +1 for summary
 }
 
 // Render step progress and content
@@ -278,10 +285,11 @@ function renderStepProgress() {
     
     // Regular steps
     for (let i = 1; i <= totalSteps - 1; i++) {
+        const label = stageNames[i - 1] || `Etapa ${i}`;
         progressHTML += `
             <div class="step-item" id="step-item-${i}">
                 <div class="step-circle">${i}</div>
-                <div class="step-label">Etapa ${i}</div>
+                <div class="step-label">${label}</div>
             </div>
         `;
     }
@@ -304,12 +312,13 @@ function renderStepContents() {
     
     Object.keys(stepData).forEach(stepNum => {
         const fields = stepData[stepNum];
+        const label = stageNames[stepNum - 1] || `Etapa ${stepNum}`;
         contentsHTML += `
             <div class="step-content" id="step-${stepNum}">
                 <div class="card">
                     <div class="card-header">
                         <h5 class="mb-0">
-                            <i class="fas fa-edit me-2"></i>Etapa ${stepNum}
+                            <i class="fas fa-edit me-2"></i>${label}
                         </h5>
                     </div>
                     <div class="card-body">


### PR DESCRIPTION
## Summary
- pass reviewer process step count and names to multi-step candidate form
- show empty stages and summary by using process-defined total steps
- display step progress labels using provided stage names

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c0639640788324844c86d171b864fb