### PR TITLE
Expose step names in reviewer application steps view

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -624,6 +624,7 @@ def submit_application(process_id: int):
 
             num_etapas=processo.num_etapas,
             stage_names=stage_names,
+            step_names=step_names,
             form=form,
 
         )


### PR DESCRIPTION
## Summary
- include `step_names` in `candidatura_form_steps` rendering to expose step labels

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py, causing 10 collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c068adba608324a1f34ef907417e99