### PR TITLE
Handle missing step names in template

### DIFF
--- a/templates/revisor/candidatura_form_steps.html
+++ b/templates/revisor/candidatura_form_steps.html
@@ -224,7 +224,7 @@ let currentStep = 1;
 let totalSteps = 1;
 let stepData = {};
 let formFields = [];
-const stepNames = {{ step_names | tojson }};
+const stepNames = {{ step_names | default([]) | tojson }};
 
 // Initialize form when page loads
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- default missing `step_names` to empty list in candidatura form steps template

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c068aebe5c8324abcf7ed4c1cf8b3e