### PR TITLE
Use notification service in monitor routes

### DIFF
--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -1057,8 +1057,8 @@ def atribuir_monitor():
         db.session.commit()
         
         # Notificar monitor sobre alunos PCD/Neurodivergentes se houver
-        from routes.agendamento_routes import NotificacaoAgendamento
-        NotificacaoAgendamento.notificar_monitor_alunos_pcd(agendamento)
+        from routes.agendamento_routes import NotificacaoAgendamentoService
+        NotificacaoAgendamentoService.notificar_monitor_alunos_pcd(agendamento)
         
         return jsonify({
             'success': True, 
@@ -1634,8 +1634,8 @@ def distribuir_automaticamente():
                     pass
                 
                 # Notificar monitor sobre alunos PCD/Neurodivergentes se houver
-                from routes.agendamento_routes import NotificacaoAgendamento
-                NotificacaoAgendamento.notificar_monitor_alunos_pcd(agendamento)
+                from routes.agendamento_routes import NotificacaoAgendamentoService
+                NotificacaoAgendamentoService.notificar_monitor_alunos_pcd(agendamento)
             else:
                 current_app.logger.warning(
                     "Nenhum monitor disponível para o agendamento %s",


### PR DESCRIPTION
## Summary
- update monitor assignment routes to import NotificacaoAgendamentoService instead of the model
- invoke the notification service when alerting monitors about alunos PCD/neurodivergentes

## Testing
- pytest tests/test_monitor_assignment_client_scope.py *(fails: ModuleNotFoundError: No module named 'routes.editor_routes')*

------
https://chatgpt.com/codex/tasks/task_e_68cd635346ac8324b59aefc06f0df73e