### PR TITLE
Add email and WhatsApp details to agendamento view

### DIFF
--- a/templates/professor/detalhes_agendamento.html
+++ b/templates/professor/detalhes_agendamento.html
@@ -63,7 +63,28 @@
       <p><strong>Turma:</strong> {{ agendamento.turma }}</p>
       <p><strong>Nível de Ensino:</strong> {{ agendamento.nivel_ensino }}</p>
       <p><strong>Status do Agendamento:</strong> {{ agendamento.status }}</p>
-      
+
+      {% set email = agendamento.professor.email if agendamento.professor and agendamento.professor.email else agendamento.responsavel_email %}
+      {% if email %}
+        <p><strong>E-mail:</strong> {{ email }}</p>
+      {% endif %}
+
+      {% if agendamento.responsavel_whatsapp %}
+        {% set whatsapp_display = agendamento.responsavel_whatsapp %}
+        {% set whatsapp_number = agendamento.responsavel_whatsapp
+          |replace('(', '')
+          |replace(')', '')
+          |replace('-', '')
+          |replace(' ', '')
+          |replace('+', '') %}
+        <p>
+          <strong>WhatsApp:</strong>
+          <a href="https://api.whatsapp.com/send?phone={{ whatsapp_number }}" target="_blank" rel="noopener">
+            {{ whatsapp_display }}
+          </a>
+        </p>
+      {% endif %}
+
       {% if agendamento.salas_selecionadas %}
         <p><strong>Salas Selecionadas:</strong> {{ agendamento.salas_selecionadas }}</p>
       {% endif %}


### PR DESCRIPTION
## Summary
- display contact email with fallback to responsible email on agendamento details page
- add WhatsApp link with sanitized phone number and original formatting
- hide contact information fields when corresponding data is unavailable

## Testing
- pytest *(fails: missing SECRET_KEY env var, missing dependencies, and syntax issues in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cda0bf31f48324ad1c2cff267417e0