### PR TITLE
Add usage_count to monitor link tracking

### DIFF
--- a/migrations/versions/c9a2d4f2b6d1_add_usage_count_to_monitor_cadastro_link.py
+++ b/migrations/versions/c9a2d4f2b6d1_add_usage_count_to_monitor_cadastro_link.py
@@ -1,0 +1,72 @@
+"""Add usage_count column and drop used from monitor_cadastro_link"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c9a2d4f2b6d1"
+down_revision = "5b9348f021f4"
+branch_labels = None
+depends_on = None
+
+
+def _insp():
+    return sa.inspect(op.get_bind())
+
+
+def _get_columns(table_name: str) -> dict[str, dict]:
+    insp = _insp()
+    columns: dict[str, dict] = {}
+    for column in insp.get_columns(table_name):
+        columns[column["name"]] = column
+    return columns
+
+
+def upgrade():
+    table = "monitor_cadastro_link"
+    columns = _get_columns(table)
+
+    if "usage_count" not in columns:
+        op.add_column(
+            table,
+            sa.Column(
+                "usage_count",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+        )
+        op.execute(sa.text(f"UPDATE {table} SET usage_count = 0 WHERE usage_count IS NULL"))
+        op.alter_column(table, "usage_count", server_default=None)
+
+    columns = _get_columns(table)
+    if "used" in columns:
+        op.drop_column(table, "used")
+
+
+def downgrade():
+    table = "monitor_cadastro_link"
+    columns = _get_columns(table)
+
+    if "used" not in columns:
+        op.add_column(
+            table,
+            sa.Column(
+                "used",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+        # Recalcula estado de uso com base na contagem
+        op.execute(
+            sa.text(
+                f"UPDATE {table} SET used = 1 WHERE usage_count IS NOT NULL AND usage_count > 0"
+            )
+        )
+        op.alter_column(table, "used", server_default=None)
+
+    columns = _get_columns(table)
+    if "usage_count" in columns:
+        op.drop_column(table, "usage_count")

--- a/models/user.py
+++ b/models/user.py
@@ -207,15 +207,15 @@ class MonitorCadastroLink(db.Model):
         db.String(36), unique=True, nullable=False, default=lambda: str(uuid.uuid4())
     )
     expires_at = db.Column(db.DateTime, nullable=False)
-    used = db.Column(db.Boolean, default=False)
+    usage_count = db.Column(db.Integer, nullable=False, default=0)
 
     cliente = db.relationship(
         "Cliente", backref=db.backref("monitor_cadastro_links", lazy=True)
     )
 
     def is_valid(self):
-        """Retorna True se o link não foi usado e ainda não expirou."""
-        return (not self.used) and datetime.utcnow() < self.expires_at
+        """Retorna True se o link ainda não expirou."""
+        return datetime.utcnow() < self.expires_at
 
 
 class Monitor(db.Model, UserMixin):

--- a/routes/monitor_routes.py
+++ b/routes/monitor_routes.py
@@ -128,7 +128,7 @@ def monitor_inscricao_submit(token):
         cliente_id=link.cliente_id,
     )
     db.session.add(monitor)
-    link.used = True
+    link.usage_count = (link.usage_count or 0) + 1
     db.session.commit()
 
     login_user(monitor)


### PR DESCRIPTION
## Summary
- add an Alembic migration that introduces usage_count on monitor_cadastro_link and drops the legacy used flag
- expose the new field in the MonitorCadastroLink model, update validity checks, and count each successful registration
- refresh the monitor link registration tests to use usage_count semantics and allow re-use until expiration

## Testing
- pytest tests/test_monitor_link_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68cda0c7b84083249a06d6d7cbd850e5